### PR TITLE
Enable local development via example paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ Enable at boot with
 update-rc.d ableton-startup defaults
 ```
 
+## Local Development
+
+Running the webserver on a normal computer is handy for hacking on the tools
+without having a Move connected.  When the Move specific paths under
+``/data/UserData`` are unavailable, the server will automatically fall back to
+the `examples` directory in this repository.  You can also override any of the
+locations with environment variables:
+
+```
+MSETS_DIRECTORY   Path to store generated sets
+MSET_SAMPLE_PATH  Path containing audio samples
+TRACK_PRESET_DIR  Path for preset files
+```
+
+This makes it possible to run the sample generation scripts and web UI locally
+while still mimicking the expected directory layout.
+
 ## Documentation
 
 Check the [Wiki](https://github.com/charlesvestal/extending-move/wiki) for:

--- a/core/config.py
+++ b/core/config.py
@@ -1,8 +1,54 @@
 # config.py
 
-# Paths and 
-MSETS_DIRECTORY = "/data/UserData/UserLibrary/Sets"
-MSET_SAMPLE_PATH = "/data/UserData/UserLibrary/Samples"
+"""Configuration helpers for file paths.
+
+This module resolves the directories used by the webserver. When running on the
+Move hardware the paths under ``/data/UserData`` exist. For local development we
+fall back to the ``examples`` directory so the code can run without the device.
+
+Environment variables may override any of these locations:
+
+``MSETS_DIRECTORY``      Path to the Sets directory
+``MSET_SAMPLE_PATH``     Path to the Samples directory
+``TRACK_PRESET_DIR``     Path to the Track Presets directory
+"""
+
+import os
+
+
+EXAMPLES_DIR = os.path.join(os.path.dirname(__file__), "..", "examples")
+
+
+def _resolve_path(env_name: str, default_path: str, example_subdir: str) -> str:
+    """Return a usable path for Move data or the examples fallback."""
+
+    if env_name in os.environ:
+        return os.environ[env_name]
+    if os.path.exists(default_path):
+        return default_path
+    return os.path.join(EXAMPLES_DIR, example_subdir)
+
+
+MSETS_DIRECTORY = _resolve_path(
+    "MSETS_DIRECTORY",
+    "/data/UserData/UserLibrary/Sets",
+    "Sets",
+)
+
+MSET_SAMPLE_PATH = _resolve_path(
+    "MSET_SAMPLE_PATH",
+    "/data/UserData/UserLibrary/Samples",
+    "Samples",
+)
+
+TRACK_PRESET_DIR = _resolve_path(
+    "TRACK_PRESET_DIR",
+    "/data/UserData/UserLibrary/Track Presets",
+    "Track Presets",
+)
+
+SAMPLES_PRESET_DIR = os.path.join(MSET_SAMPLE_PATH, "Preset Samples")
+
 MSET_ABLETON_URI = "ableton:/user-library/Sets"
 
 # Allowed ranges for user inputs

--- a/core/drum_rack_inspector_handler.py
+++ b/core/drum_rack_inspector_handler.py
@@ -3,6 +3,8 @@ import os
 import json
 import urllib.parse
 
+from core.config import MSET_SAMPLE_PATH, TRACK_PRESET_DIR
+
 def update_drum_cell_sample(preset_path, pad_number, new_sample_path, new_playback_start=None, new_playback_length=None):
     """
     Update the sample URI for a specific drum cell in a preset.
@@ -29,9 +31,9 @@ def update_drum_cell_sample(preset_path, pad_number, new_sample_path, new_playba
                         # Convert system path to Ableton URI format
                         # Encode the new sample path
                         encoded_path = urllib.parse.quote(new_sample_path)
-                        
-                        if encoded_path.startswith('/data/UserData/UserLibrary/Samples/'):
-                            uri = encoded_path.replace('/data/UserData/UserLibrary/Samples/', 'ableton:/user-library/Samples/')
+
+                        if encoded_path.startswith(MSET_SAMPLE_PATH + '/'):
+                            uri = encoded_path.replace(MSET_SAMPLE_PATH + '/', 'ableton:/user-library/Samples/')
                         else:
                             uri = 'file://' + encoded_path
                             
@@ -103,8 +105,8 @@ def get_drum_cell_samples(preset_path):
                     if sample_uri:
                         # Handle Ableton URI format
                         if sample_uri.startswith('ableton:/user-library/Samples/'):
-                            # Convert ableton:/user-library/Samples/ to /data/UserData/UserLibrary/Samples/
-                            sample_path = sample_uri.replace('ableton:/user-library/Samples/', '/data/UserData/UserLibrary/Samples/')
+                            # Convert ableton:/user-library/Samples/ to local sample path
+                            sample_path = sample_uri.replace('ableton:/user-library/Samples/', MSET_SAMPLE_PATH + '/')
                         else:
                             # Fallback to original file:// handling
                             sample_path = sample_uri.split('file://')[-1]
@@ -170,7 +172,7 @@ def scan_for_drum_rack_presets():
             - presets: List of dicts with preset info (name and path)
     """
     try:
-        presets_dir = "/data/UserData/UserLibrary/Track Presets"
+        presets_dir = TRACK_PRESET_DIR
         drum_rack_presets = []
 
         # Check if directory exists

--- a/core/midi_pattern_generator.py
+++ b/core/midi_pattern_generator.py
@@ -83,7 +83,8 @@ def generate_pattern_set(
         song['tempo'] = tempo
         
         # Save the modified set
-        output_dir = "/data/UserData/UserLibrary/Sets"
+        from core.config import MSETS_DIRECTORY
+        output_dir = MSETS_DIRECTORY
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, set_name)
         if not output_path.endswith('.abl'):

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -4,11 +4,13 @@ import copy
 import mido
 from typing import Dict, List, Any, Optional
 
+from core.config import MSETS_DIRECTORY
+
 def create_set(set_name):
     """
     Create a blank set file in the UserLibrary/Sets directory.
     """
-    directory = "/data/UserData/UserLibrary/Sets"
+    directory = MSETS_DIRECTORY
     os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, set_name)
     try:
@@ -78,7 +80,7 @@ def generate_c_major_chord_example(set_name: str, tempo: float = 120.0) -> Dict[
         song['tempo'] = tempo
         
         # Save the modified set
-        output_dir = "/data/UserData/UserLibrary/Sets"
+        output_dir = MSETS_DIRECTORY
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, set_name)
         if not output_path.endswith('.abl'):
@@ -220,7 +222,7 @@ def generate_midi_set_from_file(set_name: str, midi_file_path: str, tempo: float
         song['tempo'] = tempo
         
         # Save the modified set
-        output_dir = "/data/UserData/UserLibrary/Sets"
+        output_dir = MSETS_DIRECTORY
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, set_name)
         if not output_path.endswith('.abl'):
@@ -337,7 +339,7 @@ def generate_drum_set_from_file(set_name: str, midi_file_path: str, tempo: float
 
         # Update tempo and save
         song['tempo'] = tempo
-        output_dir = "/data/UserData/UserLibrary/Sets"
+        output_dir = MSETS_DIRECTORY
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, set_name)
         if not output_path.endswith('.abl'):

--- a/core/slice_handler.py
+++ b/core/slice_handler.py
@@ -473,8 +473,9 @@ def process_kit(input_wav, preset_name=None, regions=None, num_slices=None, keep
 
         elif mode == "auto_place":
             # Set up paths for direct placement
-            samples_target_dir = "/data/UserData/UserLibrary/Samples/Preset Samples"
-            presets_target_dir = "/data/UserData/UserLibrary/Track Presets"
+            from core.config import SAMPLES_PRESET_DIR, TRACK_PRESET_DIR
+            samples_target_dir = SAMPLES_PRESET_DIR
+            presets_target_dir = TRACK_PRESET_DIR
             preset_output_file = os.path.join(presets_target_dir, f"{preset}.ablpreset")
 
             # Create sliced file via slice_wav (preserves extension)

--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -637,10 +637,8 @@ def scan_for_synth_presets():
             - presets: List of dicts with preset info (name, path, and type)
     """
     try:
-        presets_dir = "/data/UserData/UserLibrary/Track Presets"
-        # For local development, check if examples directory exists
-        if not os.path.exists(presets_dir) and os.path.exists("examples/Track Presets"):
-            presets_dir = "examples/Track Presets"
+        from core.config import TRACK_PRESET_DIR
+        presets_dir = TRACK_PRESET_DIR
             
         synth_presets = []
 

--- a/handlers/drum_rack_inspector_handler_class.py
+++ b/handlers/drum_rack_inspector_handler_class.py
@@ -3,10 +3,15 @@ import cgi
 import os
 import urllib.parse
 from handlers.base_handler import BaseHandler
-from core.drum_rack_inspector_handler import scan_for_drum_rack_presets, get_drum_cell_samples, update_drum_cell_sample
+from core.drum_rack_inspector_handler import (
+    scan_for_drum_rack_presets,
+    get_drum_cell_samples,
+    update_drum_cell_sample,
+)
 from core.reverse_handler import reverse_wav_file
 from core.refresh_handler import refresh_library
 from core.time_stretch_handler import time_stretch_wav
+from core.config import MSET_SAMPLE_PATH
 
 class DrumRackInspectorHandler(BaseHandler):
     def handle_get(self):
@@ -64,8 +69,13 @@ class DrumRackInspectorHandler(BaseHandler):
 
                     if sample:
                         print(f"\nSample: {sample}")  # Debug log
-                        if sample.get('path') and sample['path'].startswith('/data/UserData/UserLibrary/Samples/'):
-                            web_path = '/samples/' + sample['path'].replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
+                        sample_path = sample.get('path', '')
+                        if sample_path.startswith(MSET_SAMPLE_PATH + os.sep):
+                            web_path = '/samples/' + sample_path.replace(
+                                os.path.join(MSET_SAMPLE_PATH, 'Preset Samples') + os.sep,
+                                '',
+                                1,
+                            )
                             web_path = urllib.parse.quote(web_path)
                             waveform_id = f'waveform-{pad_num}'
                             # Add new data-playback-start and data-playback-length attributes
@@ -244,10 +254,15 @@ class DrumRackInspectorHandler(BaseHandler):
                 sample = grid_samples[idx]
                 cell_html = '<div class="drum-cell">'
 
-                if sample and sample.get('path', '').startswith('/data/UserData/UserLibrary/Samples/'):
-                    web_path = '/samples/' + sample['path'] \
-                                .replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
-                    web_path = urllib.parse.quote(web_path)
+                if sample:
+                    sample_path = sample.get('path', '')
+                    if sample_path.startswith(MSET_SAMPLE_PATH + os.sep):
+                        web_path = '/samples/' + sample_path.replace(
+                            os.path.join(MSET_SAMPLE_PATH, 'Preset Samples') + os.sep,
+                            '',
+                            1,
+                        )
+                        web_path = urllib.parse.quote(web_path)
                     wf_id = f'waveform-{num}'
                     cell_html += f'''
                         <div class="pad-info">
@@ -376,8 +391,13 @@ class DrumRackInspectorHandler(BaseHandler):
                     cell_html = '<div class="drum-cell">'
 
                     if sample:
-                        if sample.get('path') and sample['path'].startswith('/data/UserData/UserLibrary/Samples/'):
-                            web_path = '/samples/' + sample['path'].replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
+                        sample_path = sample.get('path', '')
+                        if sample_path.startswith(MSET_SAMPLE_PATH + os.sep):
+                            web_path = '/samples/' + sample_path.replace(
+                                os.path.join(MSET_SAMPLE_PATH, 'Preset Samples') + os.sep,
+                                '',
+                                1,
+                            )
                             web_path = urllib.parse.quote(web_path)
                             waveform_id = f'waveform-{pad_num}'
                             cell_html += f'''

--- a/handlers/reverse_handler_class.py
+++ b/handlers/reverse_handler_class.py
@@ -2,6 +2,7 @@
 import cgi
 from handlers.base_handler import BaseHandler
 from core.reverse_handler import get_wav_files, reverse_wav_file
+from core.config import MSET_SAMPLE_PATH
 
 class ReverseHandler(BaseHandler):
     def handle_post(self, form: cgi.FieldStorage):
@@ -19,7 +20,7 @@ class ReverseHandler(BaseHandler):
         try:
             success, message, new_path = reverse_wav_file(
                 filename=wav_file,
-                directory="/data/UserData/UserLibrary/Samples"
+                directory=MSET_SAMPLE_PATH
             )
             if not success:
                 return self.format_error_response(message)
@@ -33,5 +34,5 @@ class ReverseHandler(BaseHandler):
 
     def get_wav_options(self):
         """Get WAV file options for the template."""
-        wav_files = get_wav_files("/data/UserData/UserLibrary/Samples")
+        wav_files = get_wav_files(MSET_SAMPLE_PATH)
         return ''.join([f'<option value="{file}">{file}</option>' for file in wav_files])

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -16,6 +16,7 @@ from handlers.restore_handler_class import RestoreHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.synth_preset_inspector_handler_class import SynthPresetInspectorHandler
 from handlers.set_management_handler_class import SetManagementHandler
+from core.config import SAMPLES_PRESET_DIR
 
 # Define the PID file location
 PID_FILE = os.path.expanduser('~/extending-move/move-webserver.pid')
@@ -361,7 +362,7 @@ class MyServer(BaseHTTPRequestHandler):
             relative_path = unquote(relative_path)
             
             # Construct the full path to the samples directory
-            base_samples_dir = '/data/UserData/UserLibrary/Samples/Preset Samples'
+            base_samples_dir = SAMPLES_PRESET_DIR
             full_path = os.path.join(base_samples_dir, relative_path)
             
             # Security check: ensure the requested path is within the samples directory

--- a/static/chord.js
+++ b/static/chord.js
@@ -478,14 +478,17 @@ function initChordTab() {
     const samplesForm = new FormData();
     samplesForm.append("mode", "zip");
     samplesForm.append("file", samplesZipBlob);
-    samplesForm.append("destination", "/data/UserData/UserLibrary/Samples/Preset Samples");
+    const localDev = ["localhost", "127.0.0.1"].includes(location.hostname);
+    const samplesDest = localDev ? "examples/Samples/Preset Samples" : "/data/UserData/UserLibrary/Samples/Preset Samples";
+    samplesForm.append("destination", samplesDest);
     await fetch("/place-files", { method: "POST", body: samplesForm });
     
     // Place the preset file via the File Placer API (place mode)
     const presetForm = new FormData();
     presetForm.append("mode", "place");
     presetForm.append("file", new Blob([presetJson], { type: "application/json" }), presetName + ".ablpreset");
-    presetForm.append("destination", "/data/UserData/UserLibrary/Track Presets");
+    const presetDest = localDev ? "examples/Track Presets" : "/data/UserData/UserLibrary/Track Presets";
+    presetForm.append("destination", presetDest);
     await fetch("/place-files", { method: "POST", body: presetForm });
     
     // Refresh the library after placement.


### PR DESCRIPTION
## Summary
- add dynamic path resolution in `core.config`
- update handlers and core modules to use config paths
- allow sample serving from local examples
- adjust chord.js to place files in examples when running locally

## Testing
- `pytest -q`
- `python test_chord_example.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5c028a808325b56109dcc85a90b7