### PR TITLE
Add Drum Rack Inspector to Flask example

### DIFF
--- a/static/drum_rack_page.js
+++ b/static/drum_rack_page.js
@@ -1,0 +1,50 @@
+let drumRackWaveforms = [];
+function initializeDrumRackWaveforms() {
+  drumRackWaveforms.forEach(ws => { try { ws.destroy(); } catch (e) {} });
+  drumRackWaveforms = [];
+  const containers = document.querySelectorAll('.waveform-container');
+  containers.forEach(container => {
+    const startPct = parseFloat(container.dataset.playbackStart) || 0;
+    const lengthPct = parseFloat(container.dataset.playbackLength) || 1;
+    const audioPath = container.dataset.audioPath;
+    if (!audioPath) return;
+    const ws = WaveSurfer.create({
+      container: container,
+      waveColor: 'violet',
+      progressColor: 'purple',
+      height: 64,
+      responsive: true,
+      normalize: true,
+      minPxPerSec: 50,
+      barWidth: 2,
+      interact: false,
+      hideScrollbar: true
+    });
+    container.wavesurfer = ws;
+    drumRackWaveforms.push(ws);
+    const ctx = ws.backend.getAudioContext();
+    fetch(audioPath)
+      .then(r => r.arrayBuffer())
+      .then(d => ctx.decodeAudioData(d))
+      .then(buffer => {
+        const dur = buffer.duration;
+        const sr = buffer.sampleRate;
+        const start = Math.floor(startPct * dur * sr);
+        const count = Math.floor(lengthPct * dur * sr);
+        const sliced = ctx.createBuffer(buffer.numberOfChannels, count, sr);
+        for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+          sliced.copyToChannel(buffer.getChannelData(ch).subarray(start, start + count), ch, 0);
+        }
+        ws.loadDecodedBuffer(sliced);
+      });
+    ws.on('finish', () => ws.stop());
+    container.addEventListener('click', e => {
+      e.stopPropagation();
+      drumRackWaveforms.forEach(other => { if (other.isPlaying()) { other.stop(); } });
+      ws.stop();
+      ws.seekTo(0);
+      requestAnimationFrame(() => ws.play(0));
+    });
+  });
+}
+document.addEventListener('DOMContentLoaded', initializeDrumRackWaveforms);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -11,6 +11,7 @@
         <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
         <a href="/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice Kit</a>
         <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore Set</a>
+        <a href="/drum-rack-inspector" class="{% if active_tab == 'drum_rack_inspector' %}active{% endif %}">Drum Rack Inspector</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Drum Rack Inspector</h2>
+<p><em>Note: this inspects the samples from a drum rack, and shows an individual slice based on start and length information. Reversing or time stretching a sample will create a new copy of the raw sound file itself, and keep your sliced region.</em></p>
+{% if message %}
+  <p style="color: {{ 'green' if success else 'red' }};">{{ message }}</p>
+{% endif %}
+<form method="post" action="/drum-rack-inspector">
+  <input type="hidden" name="action" value="select_preset">
+  <label for="preset_select">Select a Drum Rack:</label>
+  <select name="preset_select" id="preset_select">
+    {{ options_html | safe }}
+  </select>
+  <button type="submit">Load</button>
+</form>
+<div class="samples-container">
+  {{ samples_html | safe }}
+</div>
+<!-- Time Stretch Modal -->
+<style>
+.modal .loading-overlay {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(255,255,255,0.8);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.25rem;
+  z-index: 10;
+}
+.modal .loading-overlay.hidden { display: none; }
+.modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+.modal.hidden { display: none; }
+.modal-content { background: #fff; padding: 20px; border-radius: 4px; position: relative; z-index: 1001; }
+.modal-close { position: absolute; top: 10px; right: 10px; cursor: pointer; }
+#timeStretchModal input[type="number"] { width: auto; max-width: none; }
+</style>
+<div id="timeStretchModal" class="modal hidden">
+  <div class="modal-content">
+    <span class="modal-close" onclick="document.getElementById('timeStretchModal').classList.add('hidden')">&times;</span>
+    <div id="ts_loading" class="loading-overlay hidden">Time stretching…</div>
+    <form method="post" action="/drum-rack-inspector" id="timeStretchForm" onsubmit="event.preventDefault(); submitTimeStretchForm();">
+      <input type="hidden" name="action" value="time_stretch_sample">
+      <input type="hidden" name="sample_path" id="ts_sample_path">
+      <input type="hidden" name="preset_path" id="ts_preset_path">
+      <input type="hidden" name="pad_number" id="ts_pad_number">
+      <label for="ts_bpm">BPM:</label>
+      <input type="number" name="bpm" id="ts_bpm" step="any" required value="120">
+      <label for="ts_measures">Measures:</label>
+      <input type="number" name="measures" id="ts_measures" step="any" required value="1.0">
+      <label for="ts_preserve_pitch"><input type="checkbox" name="preserve_pitch" id="ts_preserve_pitch" checked> Preserve pitch</label>
+      <div id="ts_algorithm_container">
+        <label for="ts_algorithm">Algorithm:</label>
+        <select name="algorithm" id="ts_algorithm">
+          <option value="wsola" selected>WSOLA (best for drums)</option>
+          <option value="phase">Phase-Vocoder (best for melodic)</option>
+        </select>
+      </div>
+      <button type="submit" class="apply-time-stretch-button">Apply</button>
+    </form>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
+<script src="/static/drum_rack_page.js"></script>
+<script>
+function submitTimeStretchForm() {
+  const form = document.getElementById('timeStretchForm');
+  const loading = document.getElementById('ts_loading');
+  const btn = form.querySelector('button[type="submit"]');
+  btn.disabled = true;
+  loading.classList.remove('hidden');
+  const data = new FormData(form);
+  fetch(form.action, {method: 'POST', body: data})
+    .then(r => r.text())
+    .then(html => {
+      loading.classList.add('hidden');
+      btn.disabled = false;
+      document.querySelector('.tabcontent').innerHTML = html;
+    })
+    .catch(e => {
+      console.error(e);
+      loading.classList.add('hidden');
+      btn.disabled = false;
+    });
+}
+</script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -57,6 +57,23 @@ def test_slice_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'sliced' in resp.data
 
+def test_drum_rack_get(client, monkeypatch):
+    def fake_get():
+        return {'options': '<option>dr</option>', 'message': '', 'samples_html': ''}
+    monkeypatch.setattr(flask_app.drum_rack_handler, 'handle_get', fake_get)
+    resp = client.get('/drum-rack-inspector')
+    assert resp.status_code == 200
+    assert b'<option>dr</option>' in resp.data
+
+def test_drum_rack_post(client, monkeypatch):
+    def fake_post(form):
+        return {'message': 'done', 'message_type': 'success', 'options': '', 'samples_html': ''}
+    monkeypatch.setattr(flask_app.drum_rack_handler, 'handle_post', fake_post)
+    data = {'action': 'select_preset', 'preset_select': 'foo'}
+    resp = client.post('/drum-rack-inspector', data=data)
+    assert resp.status_code == 200
+    assert b'done' in resp.data
+
 def test_detect_transients(client, monkeypatch):
     def fake_detect(form):
         return {'content': '{"success": true}', 'status': 200, 'headers': [('Content-Type', 'application/json')]}


### PR DESCRIPTION
## Summary
- add Drum Rack Inspector route and sample file serving to `flask_app.py`
- create Jinja template for Drum Rack Inspector
- add dedicated JavaScript for waveform display
- update base navigation
- test new endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff0cd263883259ea342c8f67a2b21