### PR TITLE
Add MIDI Upload feature to Flask app

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -10,6 +10,7 @@ import os
 from handlers.reverse_handler_class import ReverseHandler
 from handlers.restore_handler_class import RestoreHandler
 from handlers.slice_handler_class import SliceHandler
+from handlers.set_management_handler_class import SetManagementHandler
 from dash import Dash, html
 from core.reverse_handler import get_wav_files
 import cgi
@@ -33,6 +34,7 @@ app = Flask(__name__, template_folder="templates_jinja")
 reverse_handler = ReverseHandler()
 restore_handler = RestoreHandler()
 slice_handler = SliceHandler()
+set_management_handler = SetManagementHandler()
 dash_app = Dash(__name__, server=app, routes_pathname_prefix="/dash/")
 dash_app.layout = html.Div([html.H1("Move Dash"), html.P("Placeholder")])
 
@@ -108,6 +110,32 @@ def slice_tool():
         message=message,
         success=success,
         active_tab="slice",
+    )
+
+
+@app.route("/set-management", methods=["GET", "POST"])
+def set_management():
+    message = None
+    success = False
+    context = set_management_handler.handle_get()
+    pad_options = context.get("pad_options", "")
+    pad_color_options = context.get("pad_color_options", "")
+    if request.method == "POST":
+        form_data = request.form.to_dict()
+        if "midi_file" in request.files:
+            form_data["midi_file"] = FileField(request.files["midi_file"])
+        form = SimpleForm(form_data)
+        result = set_management_handler.handle_post(form)
+        message = result.get("message")
+        success = result.get("message_type") != "error"
+        pad_options = result.get("pad_options", pad_options)
+    return render_template(
+        "set_management.html",
+        message=message,
+        success=success,
+        pad_options=pad_options,
+        pad_color_options=pad_color_options,
+        active_tab="set-management",
     )
 
 

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -11,6 +11,7 @@
         <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
         <a href="/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice Kit</a>
         <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore Set</a>
+        <a href="/set-management" class="{% if active_tab == 'set-management' %}active{% endif %}">MIDI Upload</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/set_management.html
+++ b/templates_jinja/set_management.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>MIDI Upload</h2>
+{% if message %}
+<div class="{{ 'success' if success else 'error' }}">{{ message }}</div>
+{% endif %}
+<div class="set-management-container">
+    <div class="midi-upload-section">
+        <h3>Upload MIDI File</h3>
+        <p>Upload a MIDI file to generate an Ableton Live set with the notes from the file.</p>
+        <form method="post" action="/set-management" enctype="multipart/form-data">
+            <input type="hidden" name="action" value="upload_midi" />
+            <div class="form-group">
+                <label for="midi_type">MIDI Type:</label>
+                <select name="midi_type" id="midi_type" required>
+                    <option value="melodic" selected>Melodic MIDI</option>
+                    <option value="drum">Drum MIDI (808)</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="midi_file">MIDI File:</label>
+                <input type="file" name="midi_file" id="midi_file" accept=".mid,.midi" required />
+                <small>Supported formats: .mid, .midi</small>
+            </div>
+            <div class="form-group">
+                <label for="set_name">Set Name:</label>
+                <input type="text" name="set_name" id="set_name" placeholder="My MIDI Set" required />
+            </div>
+            <div class="form-group">
+                <label for="tempo">Tempo (BPM):</label>
+                <input type="number" name="tempo" id="tempo" min="20" max="300" placeholder="Auto-detect from MIDI" />
+                <small>Leave blank to use tempo from MIDI file (or default 120 BPM)</small>
+            </div>
+            <div class="form-group">
+                <label for="pad_index">Device Pad:</label>
+                <select name="pad_index" id="pad_index" required>
+                    {{ pad_options | safe }}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="pad_color">Pad Color:</label>
+                <select name="pad_color" id="pad_color" required>
+                    {{ pad_color_options | safe }}
+                </select>
+            </div>
+            <button type="submit" class="generate-button">Generate Set from MIDI</button>
+        </form>
+    </div>
+</div>
+<style>
+.set-management-container {
+    max-width: 600px;
+    margin: 0 auto;
+}
+.midi-upload-section {
+    padding: 30px;
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+}
+.midi-upload-section h3 {
+    margin-top: 0;
+    color: #333;
+}
+.midi-upload-section p {
+    color: #666;
+    margin-bottom: 25px;
+}
+.form-group {
+    margin-bottom: 20px;
+}
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: #333;
+}
+.form-group input[type="text"],
+.form-group input[type="number"],
+.form-group input[type="file"],
+.form-group select {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+}
+.form-group input[type="file"] {
+    padding: 6px;
+    background: white;
+}
+.form-group small {
+    display: block;
+    margin-top: 5px;
+    color: #666;
+    font-size: 12px;
+}
+.generate-button {
+    width: 100%;
+    padding: 12px 30px;
+    background: #28a745;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+.generate-button:hover {
+    background: #218838;
+}
+.success {
+    padding: 15px;
+    background: #d4edda;
+    border: 1px solid #c3e6cb;
+    border-radius: 4px;
+    color: #155724;
+}
+.error {
+    padding: 15px;
+    background: #f8d7da;
+    border: 1px solid #f5c6cb;
+    border-radius: 4px;
+    color: #721c24;
+}
+</style>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -65,3 +65,38 @@ def test_detect_transients(client, monkeypatch):
     resp = client.post('/detect-transients', data={'file': f}, content_type='multipart/form-data')
     assert resp.status_code == 200
     assert resp.json['success'] is True
+
+
+def test_set_management_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'pad_options': '<option value="1">1</option>',
+            'pad_color_options': '<option value="1">1</option>'
+        }
+    monkeypatch.setattr(flask_app.set_management_handler, 'handle_get', fake_get)
+    resp = client.get('/set-management')
+    assert resp.status_code == 200
+    assert b'<option value="1">1</option>' in resp.data
+
+
+def test_set_management_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'message': 'ok',
+            'message_type': 'success',
+            'pad_options': '<option value="2">2</option>',
+            'pad_color_options': '<option value="1">1</option>'
+        }
+    monkeypatch.setattr(flask_app.set_management_handler, 'handle_post', fake_post)
+    f = (io.BytesIO(b'data'), 'test.mid')
+    data = {
+        'action': 'upload_midi',
+        'midi_type': 'melodic',
+        'set_name': 'MySet',
+        'pad_index': '1',
+        'pad_color': '1',
+        'midi_file': f
+    }
+    resp = client.post('/set-management', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    assert b'ok' in resp.data


### PR DESCRIPTION
## Summary
- integrate MIDI Upload Set Management page with Flask
- add Jinja template for MIDI upload form
- expose new `/set-management` route in Flask app
- link MIDI Upload in the navigation bar
- test GET/POST of `/set-management`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff0dd11d88325b4b2ee426fc06580