### PR TITLE
Add Synth Macros support in Flask app

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -10,6 +10,7 @@ import os
 from handlers.reverse_handler_class import ReverseHandler
 from handlers.restore_handler_class import RestoreHandler
 from handlers.slice_handler_class import SliceHandler
+from handlers.synth_preset_inspector_handler_class import SynthPresetInspectorHandler
 from dash import Dash, html
 from core.reverse_handler import get_wav_files
 import cgi
@@ -33,6 +34,7 @@ app = Flask(__name__, template_folder="templates_jinja")
 reverse_handler = ReverseHandler()
 restore_handler = RestoreHandler()
 slice_handler = SliceHandler()
+synth_handler = SynthPresetInspectorHandler()
 dash_app = Dash(__name__, server=app, routes_pathname_prefix="/dash/")
 dash_app.layout = html.Div([html.H1("Move Dash"), html.P("Placeholder")])
 
@@ -108,6 +110,31 @@ def slice_tool():
         message=message,
         success=success,
         active_tab="slice",
+    )
+
+
+@app.route("/synth-macros", methods=["GET", "POST"])
+def synth_macros():
+    message = None
+    success = False
+    options_html = ""
+    macros_html = ""
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = synth_handler.handle_post(form)
+    else:
+        result = synth_handler.handle_get()
+    message = result.get("message")
+    success = result.get("message_type") != "error"
+    options_html = result.get("options", "")
+    macros_html = result.get("macros_html", "")
+    return render_template(
+        "synth_macros.html",
+        message=message,
+        success=success,
+        options_html=options_html,
+        macros_html=macros_html,
+        active_tab="synth-macros",
     )
 
 

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -11,6 +11,7 @@
         <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
         <a href="/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice Kit</a>
         <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore Set</a>
+        <a href="/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Synth Macros</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -1,0 +1,186 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Synth Macros (Drift)</h2>
+<p><em>Note: Deleting and adding macro assignments will immediately alter your preset files and can result in broken presets. Back them up! Ranges are optional, and not all parameters take them (i.e. Voice1_Filter1_Type). Experiement!</em></p>
+
+{% if message %}
+  <p style="color: {{ 'green' if success else 'red' }};">{{ message }}</p>
+{% endif %}
+
+<form method="post" action="/synth-macros" id="preset-form">
+    <input type="hidden" name="action" id="action-input" value="select_preset">
+    <input type="hidden" name="param_path" id="param-path-input" value="">
+    <input type="hidden" name="param_name" id="param-name-input" value="">
+    <input type="hidden" name="macro_index" id="macro-index-input" value="">
+    <div class="preset-selection">
+        <select name="preset_select" id="preset_select">
+            {{ options_html | safe }}
+        </select>
+    </div>
+    
+    <div class="macro-display">
+        {{ macros_html | safe }}
+    </div>
+</form>
+
+<!-- The dropdown change event is handled by main.js using AJAX -->
+
+<style>
+    .preset-selection {
+        margin-bottom: 20px;
+        padding: 15px;
+        background-color: #f5f5f5;
+        border-radius: 5px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    
+    .preset-selection select {
+        flex-grow: 1;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+    
+    .macros-container {
+        margin-top: 20px;
+    }
+    
+    .macro-item {
+        margin-bottom: 20px;
+        padding: 15px;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        background-color: #f9f9f9;
+    }
+    
+    .macro-header {
+        margin-top: 0;
+        color: #333;
+        font-size: 1.17em;
+        font-weight: bold;
+        margin-bottom: 15px;
+        display: flex;
+        align-items: center;
+    }
+    
+    .macro-name-input {
+        padding: 5px;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        font-size: 1em;
+        width: 60%;
+        margin-left: 10px;
+    }
+    
+    .parameter-mapping {
+        margin: 15px 0;
+        padding: 10px;
+        background-color: #f0f0f0;
+        border-radius: 4px;
+    }
+    
+    .parameter-mapping select {
+        display: block;
+        width: 100%;
+        padding: 8px;
+        margin: 8px 0 15px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+    
+    .parameter-controls {
+        display: flex;
+        align-items: center;
+        gap: 15px;
+        margin-bottom: 10px;
+    }
+    
+    .range-inputs-inline {
+        display: flex;
+        gap: 10px;
+    }
+    
+    .range-inputs-inline label {
+        display: flex;
+        align-items: center;
+        font-size: 0.9em;
+        color: #555;
+    }
+    
+    .range-inputs-inline input {
+        padding: 6px;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        width: 80px;
+        margin-left: 5px;
+    }
+    
+    .current-mappings {
+        margin-top: 15px;
+        padding-top: 10px;
+        border-top: 1px dashed #ccc;
+    }
+    
+    .current-mappings h4 {
+        margin-top: 0;
+        font-size: 1em;
+        color: #555;
+    }
+    
+    .parameters-list {
+        margin-top: 10px;
+        padding-left: 20px;
+    }
+    
+    .parameters-list li {
+        margin-bottom: 5px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    
+    .parameter-info {
+        flex-grow: 1;
+    }
+    
+    .delete-mapping-btn {
+        background-color: #f44336;
+        color: white;
+        border: none;
+        border-radius: 3px;
+        padding: 3px 8px;
+        font-size: 0.8em;
+        cursor: pointer;
+        margin-left: 10px;
+    }
+    
+    .delete-mapping-btn:hover {
+        background-color: #d32f2f;
+    }
+    
+    .add-mapping-btn {
+        background-color: #4CAF50;
+        color: white;
+        border: none;
+        border-radius: 3px;
+        padding: 5px 10px;
+        font-size: 0.9em;
+        cursor: pointer;
+        margin-left: 10px;
+    }
+    
+    .add-mapping-btn:hover {
+        background-color: #45a049;
+    }
+    
+    .save-name-btn {
+        margin-left: 10px;
+    }
+    
+    .save-name-btn:hover {
+        background-color: #0b7dda;
+    }
+</style>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -57,6 +57,32 @@ def test_slice_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'sliced' in resp.data
 
+def test_synth_macros_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'message': 'choose',
+            'message_type': 'info',
+            'options': '<option value="p">p</option>',
+            'macros_html': ''
+        }
+    monkeypatch.setattr(flask_app.synth_handler, 'handle_get', fake_get)
+    resp = client.get('/synth-macros')
+    assert resp.status_code == 200
+    assert b'choose' in resp.data
+
+def test_synth_macros_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'message': 'saved',
+            'message_type': 'success',
+            'options': '',
+            'macros_html': '<p>done</p>'
+        }
+    monkeypatch.setattr(flask_app.synth_handler, 'handle_post', fake_post)
+    resp = client.post('/synth-macros', data={'action': 'select_preset'})
+    assert resp.status_code == 200
+    assert b'saved' in resp.data
+
 def test_detect_transients(client, monkeypatch):
     def fake_detect(form):
         return {'content': '{"success": true}', 'status': 200, 'headers': [('Content-Type', 'application/json')]}


### PR DESCRIPTION
## Summary
- add SynthPresetInspectorHandler to `flask_app.py`
- create Flask route `/synth-macros` with synth macro management
- add navigation link for Synth Macros
- provide Jinja template `synth_macros.html`
- test new route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff0d525488325a0a9ef4e3f1e16a4