### PR TITLE
Reorder tabs and default to Restore

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -5,7 +5,7 @@ This example shows how parts of ``move-webserver.py`` can be served
 via Flask.  Only the reverse, restore, and slice tools are
 implemented to demonstrate the approach.
 """
-from flask import Flask, render_template, request, send_file, jsonify
+from flask import Flask, render_template, request, send_file, jsonify, redirect
 import os
 from handlers.reverse_handler_class import ReverseHandler
 from handlers.restore_handler_class import RestoreHandler
@@ -47,7 +47,7 @@ dash_app.layout = html.Div([html.H1("Move Dash"), html.P("Placeholder")])
 
 @app.route("/")
 def index():
-    return render_template("index.html", active_tab="home")
+    return redirect("/restore")
 
 @app.route("/reverse", methods=["GET", "POST"])
 def reverse():

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,20 +19,21 @@
             <button class="tablinks" onclick="openTab(event, 'Restore')" id="defaultOpen">Restore Set</button>
             <button class="tablinks" onclick="openTab(event, 'Slice')">Slice Kit</button>
             <button class="tablinks" onclick="openTab(event, 'Chord')">Chord Kit</button>
-            <button class="tablinks" onclick="openTab(event, 'DrumRackInspector')">Drum Rack Inspector</button>
             <button class="tablinks" onclick="openTab(event, 'SynthPresetInspector')">Synth Macros</button>
             <button class="tablinks" onclick="openTab(event, 'Reverse')">Reverse WAV</button>
-            <!-- <button class="tablinks" onclick="openTab(event, 'Refresh')">Refresh Library</button> -->
             <button class="tablinks" onclick="openTab(event, 'SetManagement')">MIDI Upload</button>
+        </div>
+
+        <div id="Restore" class="tabcontent">
+            <!-- The Restore Set form content will be loaded here dynamically -->
         </div>
 
         <div id="Slice" class="tabcontent">
             <!-- The Slice Kit form content will be loaded here dynamically -->
         </div>
 
-        
-        <div id="DrumRackInspector" class="tabcontent">
-            <!-- The Drum Rack Inspector form content will be loaded here dynamically -->
+        <div id="Chord" class="tabcontent">
+            <!-- The Chord Kit form content will be loaded here dynamically -->
         </div>
 
         <div id="SynthPresetInspector" class="tabcontent">
@@ -41,14 +42,6 @@
 
         <div id="Reverse" class="tabcontent">
             <!-- The Reverse WAV form content will be loaded here dynamically -->
-        </div>        
-        
-        <div id="Restore" class="tabcontent">
-            <!-- The Restore Set form content will be loaded here dynamically -->
-        </div>
-        
-        <div id="Chord" class="tabcontent">
-            <!-- The Chord Kit form content will be loaded here dynamically -->
         </div>
 
         <div id="SetManagement" class="tabcontent">

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,12 +16,12 @@
     <body>
         <h1 id="header">Move - Extended</h1>
         <div class="tab">
-            <button class="tablinks" onclick="openTab(event, 'Restore')" id="defaultOpen">Restore Set</button>
-            <button class="tablinks" onclick="openTab(event, 'Slice')">Slice Kit</button>
-            <button class="tablinks" onclick="openTab(event, 'Chord')">Chord Kit</button>
-            <button class="tablinks" onclick="openTab(event, 'SynthPresetInspector')">Synth Macros</button>
-            <button class="tablinks" onclick="openTab(event, 'Reverse')">Reverse WAV</button>
-            <button class="tablinks" onclick="openTab(event, 'SetManagement')">MIDI Upload</button>
+            <button class="tablinks" onclick="openTab(event, 'Restore')" id="defaultOpen">Restore</button>
+            <button class="tablinks" onclick="openTab(event, 'Slice')">Slice</button>
+            <button class="tablinks" onclick="openTab(event, 'Chord')">Chords</button>
+            <button class="tablinks" onclick="openTab(event, 'SynthPresetInspector')">Macros</button>
+            <button class="tablinks" onclick="openTab(event, 'Reverse')">Reverse</button>
+            <button class="tablinks" onclick="openTab(event, 'SetManagement')">MIDI</button>
         </div>
 
         <div id="Restore" class="tabcontent">

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -8,12 +8,12 @@
 <body>
     <h1 id="header">Move - Extended</h1>
     <nav class="tab">
-        <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
+        <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore Set</a>
         <a href="/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice Kit</a>
         <a href="/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chord Kit</a>
-        <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore Set</a>
-        <a href="/set-management" class="{% if active_tab == 'set-management' %}active{% endif %}">MIDI Upload</a>
         <a href="/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Synth Macros</a>
+        <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
+        <a href="/set-management" class="{% if active_tab == 'set-management' %}active{% endif %}">MIDI Upload</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- reorder navigation tabs per spec
- remove Drum Rack Inspector button
- redirect root URL to `/restore`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840025467848325b62704a1db493eec