### PR TITLE
Improve message styling and inline notifications

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -53,16 +53,19 @@ def index():
 def reverse():
     message = None
     success = False
+    message_type = None
     if request.method == "POST":
         form = SimpleForm(request.form.to_dict())
         result = reverse_handler.handle_post(form)
         message = result.get("message")
-        success = result.get("message_type") != "error"
+        message_type = result.get("message_type")
+        success = message_type != "error"
     wav_list = get_wav_files("/data/UserData/UserLibrary/Samples")
     return render_template(
         "reverse.html",
         message=message,
         success=success,
+        message_type=message_type,
         wav_files=wav_list,
         active_tab="reverse",
     )
@@ -71,6 +74,7 @@ def reverse():
 def restore():
     message = None
     success = False
+    message_type = None
     options_html = ""
     if request.method == "POST":
         form_data = request.form.to_dict()
@@ -79,13 +83,15 @@ def restore():
         form = SimpleForm(form_data)
         result = restore_handler.handle_post(form)
         message = result.get("message")
-        success = result.get("message_type") != "error"
+        message_type = result.get("message_type")
+        success = message_type != "error"
     context = restore_handler.handle_get()
     options_html = context.get("options", "")
     return render_template(
         "restore.html",
         message=message,
         success=success,
+        message_type=message_type,
         options_html=options_html,
         active_tab="restore",
     )
@@ -94,6 +100,7 @@ def restore():
 def slice_tool():
     message = None
     success = False
+    message_type = None
     if request.method == "POST":
         form_data = request.form.to_dict()
         if 'file' in request.files:
@@ -110,11 +117,13 @@ def slice_tool():
                     pass
                 return resp
             message = result.get("message")
-            success = result.get("message_type") != "error"
+            message_type = result.get("message_type")
+            success = message_type != "error"
     return render_template(
         "slice.html",
         message=message,
         success=success,
+        message_type=message_type,
         active_tab="slice",
     )
 
@@ -123,6 +132,7 @@ def slice_tool():
 def set_management():
     message = None
     success = False
+    message_type = None
     context = set_management_handler.handle_get()
     pad_options = context.get("pad_options", "")
     pad_color_options = context.get("pad_color_options", "")
@@ -133,12 +143,14 @@ def set_management():
         form = SimpleForm(form_data)
         result = set_management_handler.handle_post(form)
         message = result.get("message")
-        success = result.get("message_type") != "error"
+        message_type = result.get("message_type")
+        success = message_type != "error"
         pad_options = result.get("pad_options", pad_options)
     return render_template(
         "set_management.html",
         message=message,
         success=success,
+        message_type=message_type,
         pad_options=pad_options,
         pad_color_options=pad_color_options,
         active_tab="set-management",
@@ -149,6 +161,7 @@ def set_management():
 def synth_macros():
     message = None
     success = False
+    message_type = None
     options_html = ""
     macros_html = ""
     selected_preset = None
@@ -158,7 +171,8 @@ def synth_macros():
     else:
         result = synth_handler.handle_get()
     message = result.get("message")
-    success = result.get("message_type") != "error"
+    message_type = result.get("message_type")
+    success = message_type != "error"
     options_html = result.get("options", "")
     macros_html = result.get("macros_html", "")
     selected_preset = result.get("selected_preset")
@@ -167,6 +181,7 @@ def synth_macros():
         "synth_macros.html",
         message=message,
         success=success,
+        message_type=message_type,
         options_html=options_html,
         macros_html=macros_html,
         preset_selected=preset_selected,

--- a/flask_app.py
+++ b/flask_app.py
@@ -60,6 +60,9 @@ def reverse():
         message = result.get("message")
         message_type = result.get("message_type")
         success = message_type != "error"
+    else:
+        message = "Select a WAV file to reverse"
+        message_type = "info"
     wav_list = get_wav_files("/data/UserData/UserLibrary/Samples")
     return render_template(
         "reverse.html",
@@ -146,6 +149,10 @@ def set_management():
         message_type = result.get("message_type")
         success = message_type != "error"
         pad_options = result.get("pad_options", pad_options)
+    else:
+        message = context.get("message")
+        message_type = context.get("message_type")
+        success = message_type != "error" if message_type else False
     return render_template(
         "set_management.html",
         message=message,

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -126,6 +126,15 @@ class BaseHandler:
         response.update(kwargs)
         return response
 
+    def format_info_response(self, message: str, **kwargs) -> Dict[str, Any]:
+        """Format an informational response."""
+        response = {
+            "message": message,
+            "message_type": "info"
+        }
+        response.update(kwargs)
+        return response
+
     def cleanup_upload(self, filepath: str):
         """
         Clean up an uploaded file.

--- a/handlers/reverse_handler_class.py
+++ b/handlers/reverse_handler_class.py
@@ -4,6 +4,15 @@ from handlers.base_handler import BaseHandler
 from core.reverse_handler import get_wav_files, reverse_wav_file
 
 class ReverseHandler(BaseHandler):
+    def handle_get(self):
+        """Provide options and an informational message for the reverse page."""
+        wav_files = get_wav_files("/data/UserData/UserLibrary/Samples")
+        return {
+            "wav_files": wav_files,
+            "message": "Select a WAV file to reverse",
+            "message_type": "info",
+        }
+
     def handle_post(self, form: cgi.FieldStorage):
         """Handle POST request for WAV file reversal."""
         # Validate action

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -25,7 +25,9 @@ class SetManagementHandler(BaseHandler):
         pad_color_options = ''.join(f'<option value="{i}">{i}</option>' for i in range(1,27))
         return {
             'pad_options': pad_options,
-            'pad_color_options': pad_color_options
+            'pad_color_options': pad_color_options,
+            'message': 'Upload a MIDI file to generate a set',
+            'message_type': 'info'
         }
 
     def handle_post(self, form):

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -86,10 +86,8 @@ class TemplateManager:
         message = kwargs.get("message", "")
         message_type = kwargs.get("message_type", "")
         if message:
-            if message_type == "success":
-                message_html = f'<p style="color: green;">{message}</p>'
-            elif message_type == "error":
-                message_html = f'<p style="color: red;">{message}</p>'
+            if message_type in ("success", "error", "info"):
+                message_html = f'<p class="{message_type}">{message}</p>'
             else:
                 message_html = f'<p>{message}</p>'
         else:

--- a/static/chord.js
+++ b/static/chord.js
@@ -361,6 +361,14 @@ async function processChordSample(buffer, intervals) {
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });
 }
 
+function showChordMessage(text, type = 'info') {
+  const msgEl = document.getElementById('chord-message');
+  if (msgEl) {
+    msgEl.textContent = text;
+    msgEl.className = type;
+  }
+}
+
 function initChordTab() {
   // Attach event listener for generatePreset
   const presetBtn = document.getElementById('generatePreset');
@@ -375,7 +383,7 @@ function initChordTab() {
     const fileInput = document.getElementById('wavFileInput');
     const presetNameInput = document.getElementById('presetName');
     if (!fileInput.files || fileInput.files.length === 0) {
-      alert("Please select a WAV file.");
+      showChordMessage('Please select a WAV file.', 'error');
       return;
     }
     const file = fileInput.files[0];
@@ -429,7 +437,7 @@ function initChordTab() {
     }).catch(function(err) {
       console.error('Error generating bundle', err);
       document.getElementById('loadingIndicator').style.display = 'none';
-      alert('Failed to generate bundle');
+      showChordMessage('Failed to generate bundle', 'error');
     });
     });
   }
@@ -442,7 +450,7 @@ function initChordTab() {
     const fileInput = document.getElementById('wavFileInput');
     const presetNameInput = document.getElementById('presetName');
     if (!fileInput.files || fileInput.files.length === 0) {
-      alert("Please select a WAV file.");
+      showChordMessage('Please select a WAV file.', 'error');
       return;
     }
     const file = fileInput.files[0];
@@ -486,7 +494,7 @@ function initChordTab() {
     } catch (err) {
       console.error('Error zipping samples', err);
       document.getElementById('loadingIndicator').style.display = 'none';
-      alert('Failed to package samples');
+      showChordMessage('Failed to package samples', 'error');
       return;
     }
 
@@ -514,13 +522,13 @@ function initChordTab() {
     } catch (err) {
       console.error('Error placing preset', err);
       document.getElementById('loadingIndicator').style.display = 'none';
-      alert('Failed to place preset');
+      showChordMessage('Failed to place preset', 'error');
       return;
     }
 
     document.getElementById('progressPercent').textContent = '100%';
     document.getElementById('loadingIndicator').style.display = 'none';
-    alert("Preset and samples placed successfully.");
+    showChordMessage('Preset and samples placed successfully.', 'success');
   });
 
   // Attach event listener for file input

--- a/static/main.js
+++ b/static/main.js
@@ -520,7 +520,11 @@ function initializeWaveform() {
     if (evenSlicesBtn) {
         evenSlicesBtn.addEventListener('click', function() {
             if (!audioReady || !wavesurfer) {
-                alert("Audio file must be loaded first.");
+                const msg = document.getElementById('slice-message');
+                if (msg) {
+                    msg.textContent = 'Audio file must be loaded first.';
+                    msg.className = 'error';
+                }
                 return;
             }
             wavesurfer.stop();

--- a/static/style.css
+++ b/static/style.css
@@ -298,6 +298,15 @@ input[type="submit"]:hover {
     margin-bottom: 1rem;
 }
 
+/* Informational messages */
+.info {
+    color: #155724;
+    padding: 0.75rem;
+    background-color: #e9f7fc;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
 /* Chord grid styling */
 .chord-list {
     margin-top: 2rem;

--- a/templates_jinja/chord.html
+++ b/templates_jinja/chord.html
@@ -10,6 +10,7 @@
 <div id="loadingIndicator" style="display:none; margin-top:10px;">
   Generating bundle... <span id="progressPercent">0%</span>
 </div>
+<p id="chord-message"></p>
 <div class="chord-list">
   <h3>Chords to be generated:</h3>
   <ul id="chordList"></ul>

--- a/templates_jinja/restore.html
+++ b/templates_jinja/restore.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Restore Move Set (.ablbundle)</h2>
 {% if message %}
-  <p style="color: {{ 'green' if success else 'red' }};">{{ message }}</p>
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 <form action="/restore" method="post" enctype="multipart/form-data">
     <label for="ablbundle">Select .ablbundle file:</label>

--- a/templates_jinja/reverse.html
+++ b/templates_jinja/reverse.html
@@ -3,7 +3,7 @@
 <h2>Reverse a WAV File</h2>
 <p><em>This will create a reversed version of any individual sample, keeping the original.</em></p>
 {% if message %}
-  <p style="color: {{ 'green' if success else 'red' }};">{{ message }}</p>
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 <form method="post">
     <input type="hidden" name="action" value="reverse_file">

--- a/templates_jinja/set_management.html
+++ b/templates_jinja/set_management.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>MIDI Upload</h2>
 {% if message %}
-<div class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</div>
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 <div class="set-management-container">
     <div class="midi-upload-section">
@@ -108,20 +108,6 @@
 }
 .generate-button:hover {
     background: #218838;
-}
-.success {
-    padding: 15px;
-    background: #d4edda;
-    border: 1px solid #c3e6cb;
-    border-radius: 4px;
-    color: #155724;
-}
-.error {
-    padding: 15px;
-    background: #f8d7da;
-    border: 1px solid #f5c6cb;
-    border-radius: 4px;
-    color: #721c24;
 }
 </style>
 {% endblock %}

--- a/templates_jinja/set_management.html
+++ b/templates_jinja/set_management.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>MIDI Upload</h2>
 {% if message %}
-<div class="{{ 'success' if success else 'error' }}">{{ message }}</div>
+<div class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</div>
 {% endif %}
 <div class="set-management-container">
     <div class="midi-upload-section">

--- a/templates_jinja/slice.html
+++ b/templates_jinja/slice.html
@@ -2,8 +2,9 @@
 {% block content %}
 <h2>Slice a WAV File into a Kit</h2>
 {% if message %}
-  <p style="color: {{ 'green' if success else 'red' }};">{{ message }}</p>
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
+<p id="slice-message"></p>
 <form id="slice-form" action="/slice" method="post" enctype="multipart/form-data">
   <input type="hidden" name="action" value="slice">
   <input type="hidden" name="regions" id="regions-input">

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -4,7 +4,7 @@
 <p><em>Note: Deleting and adding macro assignments will immediately alter your preset files and can result in broken presets. Back them up! Ranges are optional, and not all parameters take them (i.e. Voice1_Filter1_Type). Experiement!</em></p>
 
 {% if message %}
-  <p style="color: {{ 'green' if success else 'red' }};">{{ message }}</p>
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 
 <form method="post" action="/synth-macros" id="preset-form">


### PR DESCRIPTION
## Summary
- format informational responses in `BaseHandler`
- standardize message HTML rendering
- expose message type to Flask templates
- style success/error/info classes
- remove browser alerts and show inline messages instead

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400492d9fc8325b1937621e4ab6b7c