### PR TITLE
Port drum rack inspector to Flask

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -12,6 +12,7 @@ from handlers.restore_handler_class import RestoreHandler
 from handlers.slice_handler_class import SliceHandler
 from handlers.set_management_handler_class import SetManagementHandler
 from handlers.synth_preset_inspector_handler_class import SynthPresetInspectorHandler
+from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
 from dash import Dash, html
@@ -41,6 +42,7 @@ set_management_handler = SetManagementHandler()
 synth_handler = SynthPresetInspectorHandler()
 file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
+drum_rack_handler = DrumRackInspectorHandler()
 dash_app = Dash(__name__, server=app, routes_pathname_prefix="/dash/")
 dash_app.layout = html.Div([html.H1("Move Dash"), html.P("Placeholder")])
 
@@ -199,6 +201,34 @@ def synth_macros():
 @app.route("/chord", methods=["GET"])
 def chord():
     return render_template("chord.html", active_tab="chord")
+
+
+@app.route("/drum-rack-inspector", methods=["GET", "POST"])
+def drum_rack_inspector():
+    message = None
+    success = False
+    message_type = None
+    options_html = ""
+    samples_html = ""
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = drum_rack_handler.handle_post(form)
+    else:
+        result = drum_rack_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    options_html = result.get("options") or result.get("options_html", "")
+    samples_html = result.get("samples_html", "")
+    return render_template(
+        "drum_rack_inspector.html",
+        message=message,
+        success=success,
+        message_type=message_type,
+        options_html=options_html,
+        samples_html=samples_html,
+        active_tab="drum-rack-inspector",
+    )
 
 
 @app.route("/place-files", methods=["POST"])

--- a/flask_app.py
+++ b/flask_app.py
@@ -5,13 +5,22 @@ This example shows how parts of ``move-webserver.py`` can be served
 via Flask.  Only the reverse, restore, and slice tools are
 implemented to demonstrate the approach.
 """
-from flask import Flask, render_template, request, send_file, jsonify, redirect
+from flask import (
+    Flask,
+    render_template,
+    request,
+    send_file,
+    jsonify,
+    redirect,
+)
 import os
 from handlers.reverse_handler_class import ReverseHandler
 from handlers.restore_handler_class import RestoreHandler
 from handlers.slice_handler_class import SliceHandler
 from handlers.set_management_handler_class import SetManagementHandler
-from handlers.synth_preset_inspector_handler_class import SynthPresetInspectorHandler
+from handlers.synth_preset_inspector_handler_class import (
+    SynthPresetInspectorHandler,
+)
 from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
@@ -34,6 +43,7 @@ class FileField(cgi.FieldStorage):
         self.filename = fs.filename
         self.file = fs.stream
 
+
 app = Flask(__name__, template_folder="templates_jinja")
 reverse_handler = ReverseHandler()
 restore_handler = RestoreHandler()
@@ -50,6 +60,7 @@ dash_app.layout = html.Div([html.H1("Move Dash"), html.P("Placeholder")])
 @app.route("/")
 def index():
     return redirect("/restore")
+
 
 @app.route("/reverse", methods=["GET", "POST"])
 def reverse():
@@ -75,6 +86,7 @@ def reverse():
         active_tab="reverse",
     )
 
+
 @app.route("/restore", methods=["GET", "POST"])
 def restore():
     message = None
@@ -83,8 +95,8 @@ def restore():
     options_html = ""
     if request.method == "POST":
         form_data = request.form.to_dict()
-        if 'ablbundle' in request.files:
-            form_data['ablbundle'] = FileField(request.files['ablbundle'])
+        if "ablbundle" in request.files:
+            form_data["ablbundle"] = FileField(request.files["ablbundle"])
         form = SimpleForm(form_data)
         result = restore_handler.handle_post(form)
         message = result.get("message")
@@ -101,6 +113,7 @@ def restore():
         active_tab="restore",
     )
 
+
 @app.route("/slice", methods=["GET", "POST"])
 def slice_tool():
     message = None
@@ -108,8 +121,8 @@ def slice_tool():
     message_type = None
     if request.method == "POST":
         form_data = request.form.to_dict()
-        if 'file' in request.files:
-            form_data['file'] = FileField(request.files['file'])
+        if "file" in request.files:
+            form_data["file"] = FileField(request.files["file"])
         form = SimpleForm(form_data)
         result = slice_handler.handle_post(form)
         if result is not None:
@@ -198,9 +211,39 @@ def synth_macros():
         active_tab="synth-macros",
     )
 
+
 @app.route("/chord", methods=["GET"])
 def chord():
     return render_template("chord.html", active_tab="chord")
+
+
+@app.route("/samples/<path:sample_path>", methods=["GET", "OPTIONS"])
+def serve_sample(sample_path):
+    """Serve sample audio files with CORS headers."""
+    from urllib.parse import unquote
+
+    base_dir = "/data/UserData/UserLibrary/Samples/Preset Samples"
+    decoded_path = unquote(sample_path)
+    full_path = os.path.join(base_dir, decoded_path)
+
+    base_real = os.path.realpath(base_dir)
+    file_real = os.path.realpath(full_path)
+
+    if not file_real.startswith(base_real):
+        return ("Access denied", 403)
+
+    if not os.path.exists(file_real):
+        return ("File not found", 404)
+
+    if request.method == "OPTIONS":
+        resp = app.make_response("")
+    else:
+        resp = send_file(file_real)
+
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    return resp
 
 
 @app.route("/drum-rack-inspector", methods=["GET", "POST"])
@@ -234,8 +277,8 @@ def drum_rack_inspector():
 @app.route("/place-files", methods=["POST"])
 def place_files_route():
     form_data = request.form.to_dict()
-    if 'file' in request.files:
-        form_data['file'] = FileField(request.files['file'])
+    if "file" in request.files:
+        form_data["file"] = FileField(request.files["file"])
     form = SimpleForm(form_data)
     result = file_placer_handler.handle_post(form)
     return jsonify(result)
@@ -251,13 +294,16 @@ def refresh_route():
 @app.route("/detect-transients", methods=["POST"])
 def detect_transients_route():
     form_data = request.form.to_dict()
-    if 'file' in request.files:
-        form_data['file'] = FileField(request.files['file'])
+    if "file" in request.files:
+        form_data["file"] = FileField(request.files["file"])
     form = SimpleForm(form_data)
     resp = slice_handler.handle_detect_transients(form)
-    return resp["content"], resp.get("status", 200), resp.get(
-        "headers", [("Content-Type", "application/json")]
+    return (
+        resp["content"],
+        resp.get("status", 200),
+        resp.get("headers", [("Content-Type", "application/json")]),
     )
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=9090)

--- a/static/drum_rack.js
+++ b/static/drum_rack.js
@@ -1,0 +1,114 @@
+let drumRackWaveforms = [];
+
+function initializeDrumRackWaveforms() {
+    drumRackWaveforms.forEach(ws => {
+        try { ws.destroy(); } catch (e) { console.error('destroy error', e); }
+    });
+    drumRackWaveforms = [];
+
+    const containers = document.querySelectorAll('.waveform-container');
+    containers.forEach(container => {
+        const startPct = parseFloat(container.dataset.playbackStart) || 0;
+        const lengthPct = parseFloat(container.dataset.playbackLength) || 1;
+        const audioPath = container.dataset.audioPath;
+        if (!audioPath) return;
+
+        const ws = WaveSurfer.create({
+            container: container,
+            waveColor: 'violet',
+            progressColor: 'purple',
+            height: 64,
+            responsive: true,
+            normalize: true,
+            minPxPerSec: 50,
+            barWidth: 2,
+            interact: false,
+            hideScrollbar: true
+        });
+        container.wavesurfer = ws;
+        drumRackWaveforms.push(ws);
+
+        const audioContext = ws.backend.getAudioContext();
+        fetch(audioPath)
+            .then(res => res.arrayBuffer())
+            .then(data => audioContext.decodeAudioData(data))
+            .then(buffer => {
+                const duration = buffer.duration;
+                const sampleRate = buffer.sampleRate;
+                const startSample = Math.floor(startPct * duration * sampleRate);
+                const frameCount = Math.floor(lengthPct * duration * sampleRate);
+                const slicedBuffer = audioContext.createBuffer(buffer.numberOfChannels, frameCount, sampleRate);
+                for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+                    slicedBuffer.copyToChannel(
+                        buffer.getChannelData(ch).subarray(startSample, startSample + frameCount),
+                        ch,
+                        0
+                    );
+                }
+                ws.loadDecodedBuffer(slicedBuffer);
+            });
+        ws.on('finish', () => { ws.stop(); });
+        container.addEventListener('click', function(e) {
+            e.stopPropagation();
+            drumRackWaveforms.forEach(other => { if (other.isPlaying()) other.stop(); });
+            ws.stop();
+            ws.seekTo(0);
+            requestAnimationFrame(() => ws.play(0));
+        });
+    });
+}
+
+function initializeTimeStretchModal() {
+    const modal = document.getElementById('timeStretchModal');
+    if (!modal) return;
+    const closeBtn = modal.querySelector('.modal-close');
+    document.querySelectorAll('.time-stretch-button').forEach(btn => {
+        btn.addEventListener('click', function(e) {
+            e.preventDefault();
+            document.getElementById('ts_sample_path').value = btn.getAttribute('data-sample-path');
+            document.getElementById('ts_preset_path').value = btn.getAttribute('data-preset-path');
+            document.getElementById('ts_pad_number').value = btn.getAttribute('data-pad-number');
+            modal.classList.remove('hidden');
+        });
+    });
+    closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
+    window.addEventListener('click', e => { if (e.target === modal) modal.classList.add('hidden'); });
+    const preserveCheckbox = document.getElementById('ts_preserve_pitch');
+    const algoSelect = document.getElementById('ts_algorithm');
+    function updateAlgoState() { algoSelect.disabled = !preserveCheckbox.checked; }
+    preserveCheckbox.addEventListener('change', updateAlgoState);
+    updateAlgoState();
+}
+
+function submitTimeStretchForm() {
+    const form = document.getElementById('timeStretchForm');
+    const loading = document.getElementById('ts_loading');
+    const applyBtn = form.querySelector('button[type="submit"]');
+    applyBtn.disabled = true;
+    loading.classList.remove('hidden');
+
+    const url = form.getAttribute('action');
+    const formData = new FormData(form);
+    fetch(url, { method: form.method, body: formData })
+        .then(response => response.text())
+        .then(html => {
+            loading.classList.add('hidden');
+            applyBtn.disabled = false;
+            let container = form.closest('.tabcontent');
+            if (!container) container = document.querySelector('.tabcontent');
+            container.innerHTML = html;
+            initDrumRackTab();
+        })
+        .catch(err => {
+            console.error(err);
+            loading.classList.add('hidden');
+            applyBtn.disabled = false;
+        });
+}
+
+function initDrumRackTab() {
+    initializeDrumRackWaveforms();
+    initializeTimeStretchModal();
+}
+
+export { initDrumRackTab, submitTimeStretchForm };

--- a/static/drum_rack.js
+++ b/static/drum_rack.js
@@ -78,6 +78,12 @@ function initializeTimeStretchModal() {
     function updateAlgoState() { algoSelect.disabled = !preserveCheckbox.checked; }
     preserveCheckbox.addEventListener('change', updateAlgoState);
     updateAlgoState();
+
+    const tsForm = document.getElementById('timeStretchForm');
+    const loadingOverlay = document.getElementById('ts_loading');
+    tsForm.addEventListener('submit', () => {
+        if (loadingOverlay) loadingOverlay.classList.remove('hidden');
+    });
 }
 
 function initDrumRackTab() {

--- a/static/drum_rack.js
+++ b/static/drum_rack.js
@@ -80,35 +80,9 @@ function initializeTimeStretchModal() {
     updateAlgoState();
 }
 
-function submitTimeStretchForm() {
-    const form = document.getElementById('timeStretchForm');
-    const loading = document.getElementById('ts_loading');
-    const applyBtn = form.querySelector('button[type="submit"]');
-    applyBtn.disabled = true;
-    loading.classList.remove('hidden');
-
-    const url = form.getAttribute('action');
-    const formData = new FormData(form);
-    fetch(url, { method: form.method, body: formData })
-        .then(response => response.text())
-        .then(html => {
-            loading.classList.add('hidden');
-            applyBtn.disabled = false;
-            let container = form.closest('.tabcontent');
-            if (!container) container = document.querySelector('.tabcontent');
-            container.innerHTML = html;
-            initDrumRackTab();
-        })
-        .catch(err => {
-            console.error(err);
-            loading.classList.add('hidden');
-            applyBtn.disabled = false;
-        });
-}
-
 function initDrumRackTab() {
     initializeDrumRackWaveforms();
     initializeTimeStretchModal();
 }
 
-export { initDrumRackTab, submitTimeStretchForm };
+export { initDrumRackTab };

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -11,6 +11,7 @@
         <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore Set</a>
         <a href="/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice Kit</a>
         <a href="/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chord Kit</a>
+        <a href="/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drum Rack</a>
         <a href="/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Synth Macros</a>
         <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
         <a href="/set-management" class="{% if active_tab == 'set-management' %}active{% endif %}">MIDI Upload</a>

--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -58,7 +58,7 @@
   <div class="modal-content">
     <span class="modal-close">&times;</span>
     <div id="ts_loading" class="loading-overlay hidden">Time stretching…</div>
-    <form method="POST" action="/drum-rack-inspector" id="timeStretchForm" onsubmit="event.preventDefault(); submitTimeStretchForm();">
+    <form method="POST" action="/drum-rack-inspector" id="timeStretchForm">
       <input type="hidden" name="action" value="time_stretch_sample">
       <input type="hidden" name="sample_path" id="ts_sample_path">
       <input type="hidden" name="preset_path" id="ts_preset_path">

--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Drum Rack Inspector</h2>
+<p><em>Note: this inspects the samples from a drum rack, and shows an individual slice based on start and length information. Reversing or time stretching a sample will create a new copy of the raw sound file itself, and keep your sliced region.</em></p>
+{% if message %}
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+<form method="POST" action="/drum-rack-inspector">
+    <input type="hidden" name="action" value="select_preset">
+    <label for="preset_select">Select a Drum Rack:</label>
+    <select name="preset_select" id="preset_select">
+        {{ options_html | safe }}
+    </select>
+    <button type="submit">Load</button>
+</form>
+<div class="samples-container">
+    {{ samples_html | safe }}
+</div>
+<!-- Time Stretch Modal -->
+<style>
+  .modal .loading-overlay {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: rgba(255,255,255,0.8);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.25rem;
+    z-index: 10;
+  }
+  .modal .loading-overlay.hidden { display: none; }
+  .modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  .modal.hidden { display: none; }
+  .modal-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    position: relative;
+    z-index: 1001;
+  }
+  .modal-close { position: absolute; top: 10px; right: 10px; cursor: pointer; }
+  #timeStretchModal input[type="number"] {
+      width: auto;
+      max-width: none;
+  }
+</style>
+<div id="timeStretchModal" class="modal hidden">
+  <div class="modal-content">
+    <span class="modal-close">&times;</span>
+    <div id="ts_loading" class="loading-overlay hidden">Time stretching…</div>
+    <form method="POST" action="/drum-rack-inspector" id="timeStretchForm" onsubmit="event.preventDefault(); submitTimeStretchForm();">
+      <input type="hidden" name="action" value="time_stretch_sample">
+      <input type="hidden" name="sample_path" id="ts_sample_path">
+      <input type="hidden" name="preset_path" id="ts_preset_path">
+      <input type="hidden" name="pad_number" id="ts_pad_number">
+      <label for="ts_bpm">BPM:</label>
+      <input type="number" name="bpm" id="ts_bpm" step="any" required value="120">
+      <label for="ts_measures">Measures:</label>
+      <input type="number" name="measures" id="ts_measures" step="any" required value="1.0">
+      <label for="ts_preserve_pitch"><input type="checkbox" name="preserve_pitch" id="ts_preserve_pitch" checked> Preserve pitch</label>
+      <div id="ts_algorithm_container">
+        <label for="ts_algorithm">Algorithm:</label>
+        <select name="algorithm" id="ts_algorithm">
+          <option value="wsola" selected>WSOLA (best for drums)</option>
+          <option value="phase">Phase-Vocoder (best for melodic)</option>
+        </select>
+      </div>
+      <button type="submit" class="apply-time-stretch-button">Apply</button>
+    </form>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
+<script type="module" src="/static/drum_rack.js"></script>
+<script type="module">
+  import { initDrumRackTab } from '/static/drum_rack.js';
+  document.addEventListener('DOMContentLoaded', initDrumRackTab);
+</script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -88,6 +88,31 @@ def test_synth_macros_post(client, monkeypatch):
     assert b'id="preset_select"' in resp.data and b'disabled' in resp.data
     assert b'Choose Another Preset' in resp.data
 
+def test_drum_rack_inspector_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'options': '<option value="1">P</option>',
+            'message': '',
+            'samples_html': ''
+        }
+    monkeypatch.setattr(flask_app.drum_rack_handler, 'handle_get', fake_get)
+    resp = client.get('/drum-rack-inspector')
+    assert resp.status_code == 200
+    assert b'<option value="1">P</option>' in resp.data
+
+def test_drum_rack_inspector_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'message': 'ok',
+            'message_type': 'success',
+            'options': '<option value="1">P</option>',
+            'samples_html': '<div>grid</div>'
+        }
+    monkeypatch.setattr(flask_app.drum_rack_handler, 'handle_post', fake_post)
+    resp = client.post('/drum-rack-inspector', data={'action':'select_preset', 'preset_select':'x'})
+    assert resp.status_code == 200
+    assert b'grid' in resp.data
+
 def test_chord_get(client):
     resp = client.get('/chord')
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add drum rack inspector Flask route and handler wiring
- create Jinja template for drum rack inspector with Wavesurfer
- include drum rack tab in base navigation
- implement frontend logic in new `drum_rack.js`
- cover new route with unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400af772cc8325b61fc796604de7c0