### PR TITLE
Rename MIDI upload tool and unify styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ extending-move/
 │   ├── restore.html             # File upload with options
 │   ├── drum_rack_inspector.html # Grid layout with actions
 │   ├── synth_preset_inspector.html # Synth macro management interface
-│   └── set_management.html      # MIDI file upload and set generation interface
+│   └── midi_upload.html         # MIDI file upload and set generation interface
 ├── templates_jinja/       # Jinja templates used by the Flask app
 ├── examples/              # Example files for testing and development
 │   ├── Track Presets/          # Sample presets organized by instrument type
@@ -412,7 +412,7 @@ To handle multiple forms in a single tab, update the `attachFormHandler` functio
 ```js
 // See static/main.js for the full implementation
 function attachFormHandler(tabName) {
-  if (tabName === 'SetManagement') {
+  if (tabName === 'MidiUpload') {
     const container = document.getElementById(tabName);
     container.querySelectorAll('form').forEach(form => {
       form.addEventListener('submit', async event => {

--- a/MIDI_PATTERN_GUIDE.md
+++ b/MIDI_PATTERN_GUIDE.md
@@ -100,7 +100,7 @@ pattern = create_rhythm_pattern(
 
 You can also generate sets from MIDI files through the web interface:
 
-1. Navigate to the Set Management page
+1. Navigate to the MIDI Upload page
 2. Upload a .mid or .midi file
 3. Specify a set name and optional tempo
 4. Select a pad and color for the device

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tools for extending the Ableton Move. This project provides a companion webserve
 
 ## Features
 
-- **Move Set Management**
+- **MIDI Upload**
   - Upload and restore Move Sets (.ablbundle)
   - Choose target pad and color
 

--- a/flask_app.py
+++ b/flask_app.py
@@ -131,8 +131,8 @@ def slice_tool():
     )
 
 
-@app.route("/set-management", methods=["GET", "POST"])
-def set_management():
+@app.route("/midi-upload", methods=["GET", "POST"])
+def midi_upload():
     message = None
     success = False
     message_type = None
@@ -154,13 +154,13 @@ def set_management():
         message_type = context.get("message_type")
         success = message_type != "error" if message_type else False
     return render_template(
-        "set_management.html",
+        "midi_upload.html",
         message=message,
         success=success,
         message_type=message_type,
         pad_options=pad_options,
         pad_color_options=pad_color_options,
-        active_tab="set-management",
+        active_tab="midi-upload",
     )
 
 

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -14,7 +14,7 @@ import json
 class SetManagementHandler(BaseHandler):
     def handle_get(self):
         """
-        Return context for rendering the Set Management page.
+        Return context for rendering the MIDI Upload page.
         """
         # Get available pads
         _, ids = list_msets(return_free_ids=True)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -227,14 +227,14 @@ class MyServer(BaseHTTPRequestHandler):
     file_placer_handler = FilePlacerHandler()
     synth_preset_inspector_handler = SynthPresetInspectorHandler()
     set_management_handler = SetManagementHandler()
-    @route_handler.get("/set-management", "set_management.html")
+    @route_handler.get("/midi-upload", "midi_upload.html")
     def handle_set_management_get(self):
-        """Handle GET request for Set Management page."""
-        print("DEBUG: /set-management GET called")
+        """Handle GET request for MIDI Upload page."""
+        print("DEBUG: /midi-upload GET called")
         import sys; sys.stdout.flush()
         return self.set_management_handler.handle_get()
 
-    @route_handler.post("/set-management")
+    @route_handler.post("/midi-upload")
     def handle_set_management_post(self, form):
         """Handle POST request to create a new set."""
         return self.set_management_handler.handle_post(form)
@@ -481,7 +481,7 @@ class MyServer(BaseHTTPRequestHandler):
         Handle all POST requests.
         Processes form data and delegates to appropriate handler.
         """
-        if self.path not in ["/slice", "/refresh", "/reverse", "/drum-rack-inspector", "/restore", "/chord", "/place-files", "/synth-preset-inspector", "/detect-transients", "/set-management"]:
+        if self.path not in ["/slice", "/refresh", "/reverse", "/drum-rack-inspector", "/restore", "/chord", "/place-files", "/synth-preset-inspector", "/detect-transients", "/midi-upload"]:
             self.send_error(404)
             return
 

--- a/static/main.js
+++ b/static/main.js
@@ -115,11 +115,11 @@ async function handleRestoreSubmit(form) {
 
 function attachFormHandler(tabName) {
     console.log("Attaching form handlers for tab:", tabName);
-    // Special case: intercept both Create and Generate forms in Set Management tab
-    if (tabName === 'SetManagement') {
+    // Special case: intercept both Create and Generate forms in MIDI Upload tab
+    if (tabName === 'MidiUpload') {
       const container = document.getElementById(tabName);
       if (container) {
-        // Attach to all forms in the SetManagement container
+        // Attach to all forms in the MidiUpload container
         container.querySelectorAll('form').forEach(form => {
           form.addEventListener('submit', async function(event) {
             event.preventDefault();
@@ -318,9 +318,9 @@ async function submitForm(form, tabName) {
             a.remove();
             window.URL.revokeObjectURL(urlBlob);
         } else {
-            // Handle JSON responses for SetManagement
+            // Handle JSON responses for MidiUpload
             const contentType = response.headers.get('Content-Type') || '';
-            if (tabName === 'SetManagement' && contentType.includes('application/json')) {
+            if (tabName === 'MidiUpload' && contentType.includes('application/json')) {
                 const data = await response.json();
                 const container = document.getElementById(tabName);
                 const msgDiv = container.querySelector('#result-message');

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
             <button class="tablinks" onclick="openTab(event, 'Chord')">Chords</button>
             <button class="tablinks" onclick="openTab(event, 'SynthPresetInspector')">Macros</button>
             <button class="tablinks" onclick="openTab(event, 'Reverse')">Reverse</button>
-            <button class="tablinks" onclick="openTab(event, 'SetManagement')">MIDI</button>
+            <button class="tablinks" onclick="openTab(event, 'MidiUpload')">MIDI Upload</button>
         </div>
 
         <div id="Restore" class="tabcontent">
@@ -44,8 +44,8 @@
             <!-- The Reverse WAV form content will be loaded here dynamically -->
         </div>
 
-        <div id="SetManagement" class="tabcontent">
-            <!-- The Set Management form content will be loaded here dynamically -->
+        <div id="MidiUpload" class="tabcontent">
+            <!-- The MIDI Upload form content will be loaded here dynamically -->
         </div>
 
 <small id="footer">More information on <a href="http://github.com/charlesvestal/extending-move">GitHub</a>. <a href="mailto:charles@charles.pizza">Feedback welcome!</a></small>

--- a/templates/midi_upload.html
+++ b/templates/midi_upload.html
@@ -1,12 +1,12 @@
 <h2>MIDI Upload</h2>
 <div id="result-message">{message_html}</div>
 
-<div class="set-management-container">
-    <div class="midi-upload-section">
+<div  >
+    <div  >
         <h3>Upload MIDI File</h3>
         <p>Upload a MIDI file to generate an Ableton Live set with the notes from the file.</p>
         
-        <form method="post" action="/set-management" enctype="multipart/form-data">
+        <form method="post" action="/midi-upload" enctype="multipart/form-data">
             <input type="hidden" name="action" value="upload_midi" />
             
             <div class="form-group">
@@ -48,101 +48,8 @@
                 </select>
             </div>
             
-            <button type="submit" class="generate-button">Generate Set from MIDI</button>
+            <button type="submit" >Generate Set from MIDI</button>
         </form>
     </div>
 </div>
 
-<style>
-.set-management-container {
-    max-width: 600px;
-    margin: 0 auto;
-}
-
-.midi-upload-section {
-    padding: 30px;
-    background: #f9f9f9;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-}
-
-.midi-upload-section h3 {
-    margin-top: 0;
-    color: #333;
-}
-
-.midi-upload-section p {
-    color: #666;
-    margin-bottom: 25px;
-}
-
-.form-group {
-    margin-bottom: 20px;
-}
-
-.form-group label {
-    display: block;
-    margin-bottom: 5px;
-    font-weight: bold;
-    color: #333;
-}
-
-.form-group input[type="text"],
-.form-group input[type="number"],
-.form-group input[type="file"],
-.form-group select {
-    width: 100%;
-    padding: 8px 12px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 14px;
-}
-
-.form-group input[type="file"] {
-    padding: 6px;
-    background: white;
-}
-
-.form-group small {
-    display: block;
-    margin-top: 5px;
-    color: #666;
-    font-size: 12px;
-}
-
-.generate-button {
-    width: 100%;
-    padding: 12px 30px;
-    background: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    font-size: 16px;
-    cursor: pointer;
-    transition: background 0.3s;
-}
-
-.generate-button:hover {
-    background: #218838;
-}
-
-#result-message {
-    margin-bottom: 20px;
-}
-
-.success {
-    padding: 15px;
-    background: #d4edda;
-    border: 1px solid #c3e6cb;
-    border-radius: 4px;
-    color: #155724;
-}
-
-.error {
-    padding: 15px;
-    background: #f8d7da;
-    border: 1px solid #f5c6cb;
-    border-radius: 4px;
-    color: #721c24;
-}
-</style>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -13,7 +13,7 @@
         <a href="/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chord Kit</a>
         <a href="/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Synth Macros</a>
         <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse WAV</a>
-        <a href="/set-management" class="{% if active_tab == 'set-management' %}active{% endif %}">MIDI Upload</a>
+        <a href="/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI Upload</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -4,11 +4,11 @@
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
-<div class="set-management-container">
-    <div class="midi-upload-section">
+<div  >
+    <div  >
         <h3>Upload MIDI File</h3>
         <p>Upload a MIDI file to generate an Ableton Live set with the notes from the file.</p>
-        <form method="post" action="/set-management" enctype="multipart/form-data">
+        <form method="post" action="/midi-upload" enctype="multipart/form-data">
             <input type="hidden" name="action" value="upload_midi" />
             <div class="form-group">
                 <label for="midi_type">MIDI Type:</label>
@@ -43,71 +43,8 @@
                     {{ pad_color_options | safe }}
                 </select>
             </div>
-            <button type="submit" class="generate-button">Generate Set from MIDI</button>
+            <button type="submit" >Generate Set from MIDI</button>
         </form>
     </div>
 </div>
-<style>
-.set-management-container {
-    max-width: 600px;
-    margin: 0 auto;
-}
-.midi-upload-section {
-    padding: 30px;
-    background: #f9f9f9;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-}
-.midi-upload-section h3 {
-    margin-top: 0;
-    color: #333;
-}
-.midi-upload-section p {
-    color: #666;
-    margin-bottom: 25px;
-}
-.form-group {
-    margin-bottom: 20px;
-}
-.form-group label {
-    display: block;
-    margin-bottom: 5px;
-    font-weight: bold;
-    color: #333;
-}
-.form-group input[type="text"],
-.form-group input[type="number"],
-.form-group input[type="file"],
-.form-group select {
-    width: 100%;
-    padding: 8px 12px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 14px;
-}
-.form-group input[type="file"] {
-    padding: 6px;
-    background: white;
-}
-.form-group small {
-    display: block;
-    margin-top: 5px;
-    color: #666;
-    font-size: 12px;
-}
-.generate-button {
-    width: 100%;
-    padding: 12px 30px;
-    background: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    font-size: 16px;
-    cursor: pointer;
-    transition: background 0.3s;
-}
-.generate-button:hover {
-    background: #218838;
-}
-</style>
 {% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -104,19 +104,19 @@ def test_detect_transients(client, monkeypatch):
     assert resp.json['success'] is True
 
 
-def test_set_management_get(client, monkeypatch):
+def test_midi_upload_get(client, monkeypatch):
     def fake_get():
         return {
             'pad_options': '<option value="1">1</option>',
             'pad_color_options': '<option value="1">1</option>'
         }
     monkeypatch.setattr(flask_app.set_management_handler, 'handle_get', fake_get)
-    resp = client.get('/set-management')
+    resp = client.get('/midi-upload')
     assert resp.status_code == 200
     assert b'<option value="1">1</option>' in resp.data
 
 
-def test_set_management_post(client, monkeypatch):
+def test_midi_upload_post(client, monkeypatch):
     def fake_post(form):
         return {
             'message': 'ok',
@@ -134,7 +134,7 @@ def test_set_management_post(client, monkeypatch):
         'pad_color': '1',
         'midi_file': f
     }
-    resp = client.post('/set-management', data=data, content_type='multipart/form-data')
+    resp = client.post('/midi-upload', data=data, content_type='multipart/form-data')
     assert resp.status_code == 200
     assert b'ok' in resp.data
 


### PR DESCRIPTION
## Summary
- rename set_management templates to midi_upload
- use new /midi-upload route in Flask and legacy servers
- update JavaScript and navigation for MidiUpload tab
- drop inline styles from MIDI upload pages
- update docs and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for mido and flask)*

------
https://chatgpt.com/codex/tasks/task_e_68400a30fd688325a99811415d9735dc