### PR TITLE
Add experimental Dash interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tools for extending the Ableton Move. This project provides a companion webserver that runs alongside the official Move server, accessible at move.local:909.
 
 All tools are also accessible via a unified Dash interface at `move.local:909/dash`.
-The Reverse and Restore pages now use native Dash forms.
+Every tool now uses native Dash forms instead of embedded iframes.
 
 ![CleanShot 2025-05-11 at 10 56 02](https://github.com/user-attachments/assets/be64a1d8-992a-4a84-bbbf-15095479d11d)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Tools for extending the Ableton Move. This project provides a companion webserver that runs alongside the official Move server, accessible at move.local:909.
 
+An experimental Dash interface is available at `move.local:909/dash` for a more interactive UI.
+
 ![CleanShot 2025-05-11 at 10 56 02](https://github.com/user-attachments/assets/be64a1d8-992a-4a84-bbbf-15095479d11d)
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Tools for extending the Ableton Move. This project provides a companion webserver that runs alongside the official Move server, accessible at move.local:909.
 
 All tools are also accessible via a unified Dash interface at `move.local:909/dash`.
+The Reverse and Restore pages now use native Dash forms.
 
 ![CleanShot 2025-05-11 at 10 56 02](https://github.com/user-attachments/assets/be64a1d8-992a-4a84-bbbf-15095479d11d)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tools for extending the Ableton Move. This project provides a companion webserver that runs alongside the official Move server, accessible at move.local:909.
 
-An experimental Dash interface is available at `move.local:909/dash` for a more interactive UI.
+All tools are also accessible via a unified Dash interface at `move.local:909/dash`.
 
 ![CleanShot 2025-05-11 at 10 56 02](https://github.com/user-attachments/assets/be64a1d8-992a-4a84-bbbf-15095479d11d)
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -191,7 +191,13 @@ def dash_layout():
             html.H1("Move Dash"),
             html.Nav(
                 [
+                    dcc.Link("Restore", href="/dash/restore", style={"margin-right": "10px"}),
                     dcc.Link("Reverse", href="/dash/reverse", style={"margin-right": "10px"}),
+                    dcc.Link("Slice", href="/dash/slice", style={"margin-right": "10px"}),
+                    dcc.Link("MIDI Upload", href="/dash/midi-upload", style={"margin-right": "10px"}),
+                    dcc.Link("Synth Macros", href="/dash/synth-macros", style={"margin-right": "10px"}),
+                    dcc.Link("Drum Rack", href="/dash/drum-rack-inspector", style={"margin-right": "10px"}),
+                    dcc.Link("Refresh", href="/dash/refresh", style={"margin-right": "10px"}),
                 ]
             ),
             html.Div(id="dash-page-content"),
@@ -226,6 +232,18 @@ def reverse_page_layout():
 def render_page(pathname):
     if pathname == "/dash/reverse":
         return reverse_page_layout()
+    if pathname == "/dash/restore":
+        return html.Iframe(src="/restore", style={"width": "100%", "height": "800px", "border": "none"})
+    if pathname == "/dash/slice":
+        return html.Iframe(src="/slice", style={"width": "100%", "height": "800px", "border": "none"})
+    if pathname == "/dash/midi-upload":
+        return html.Iframe(src="/midi-upload", style={"width": "100%", "height": "800px", "border": "none"})
+    if pathname == "/dash/synth-macros":
+        return html.Iframe(src="/synth-macros", style={"width": "100%", "height": "800px", "border": "none"})
+    if pathname == "/dash/drum-rack-inspector":
+        return html.Iframe(src="/drum-rack-inspector", style={"width": "100%", "height": "800px", "border": "none"})
+    if pathname == "/dash/refresh":
+        return html.Iframe(src="/refresh", style={"width": "100%", "height": "200px", "border": "none"})
     return html.Div("Select a tool from the navigation.")
 
 


### PR DESCRIPTION
## Summary
- integrate Dash with existing Flask server
- create basic Dash layout and dynamic page for reversing WAVs
- note new Dash app in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407f85a2508325a624e6bd4fdd349c