### PR TITLE
Add Windows wrappers for utility scripts

### DIFF
--- a/utility-scripts/win/install-on-move.bat
+++ b/utility-scripts/win/install-on-move.bat
@@ -1,0 +1,7 @@
+@echo off
+REM Windows wrapper for install-on-move.sh
+set "SCRIPT_DIR=%~dp0"
+bash "%SCRIPT_DIR%..\install-on-move.sh" %*
+pause
+
+

--- a/utility-scripts/win/restart-webserver.bat
+++ b/utility-scripts/win/restart-webserver.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Windows wrapper for restart-webserver.sh
+set "SCRIPT_DIR=%~dp0"
+bash "%SCRIPT_DIR%..\restart-webserver.sh" %*
+pause
+

--- a/utility-scripts/win/setup-ssh-and-install-on-move.bat
+++ b/utility-scripts/win/setup-ssh-and-install-on-move.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Windows wrapper for setup-ssh-and-install-on-move.sh
+set "SCRIPT_DIR=%~dp0"
+bash "%SCRIPT_DIR%..\setup-ssh-and-install-on-move.sh" %*
+pause
+

--- a/utility-scripts/win/update-on-move.bat
+++ b/utility-scripts/win/update-on-move.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Windows wrapper for update-on-move.sh
+set "SCRIPT_DIR=%~dp0"
+bash "%SCRIPT_DIR%..\update-on-move.sh" %*
+pause
+


### PR DESCRIPTION
## Summary
- add a `win` directory under `utility-scripts`
- provide `.bat` wrappers for running the shell scripts on Windows

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684121ee3ba083258c2f788c62836f64