### PR TITLE
Force HTTP for all resources

### DIFF
--- a/static/chord.js
+++ b/static/chord.js
@@ -479,17 +479,17 @@ function initChordTab() {
     samplesForm.append("mode", "zip");
     samplesForm.append("file", samplesZipBlob);
     samplesForm.append("destination", "/data/UserData/UserLibrary/Samples/Preset Samples");
-    await fetch("/place-files", { method: "POST", body: samplesForm });
+    await fetch(getHttpUrl("/place-files"), { method: "POST", body: samplesForm });
     
     // Place the preset file via the File Placer API (place mode)
     const presetForm = new FormData();
     presetForm.append("mode", "place");
     presetForm.append("file", new Blob([presetJson], { type: "application/json" }), presetName + ".ablpreset");
     presetForm.append("destination", "/data/UserData/UserLibrary/Track Presets");
-    await fetch("/place-files", { method: "POST", body: presetForm });
+    await fetch(getHttpUrl("/place-files"), { method: "POST", body: presetForm });
     
     // Refresh the library after placement.
-    await fetch("/refresh", {
+    await fetch(getHttpUrl("/refresh"), {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: "action=refresh_library"

--- a/static/main.js
+++ b/static/main.js
@@ -35,12 +35,15 @@ async function fetchContent(tabName) {
         const urlPath = tabName.replace(/([A-Z])/g, '-$1')  // Add hyphens before capitals
             .toLowerCase()  // Convert to lowercase
             .replace(/^-/, '');  // Remove leading hyphen if present
-        const response = await fetch(`/${urlPath}`);
+        const response = await fetch(getHttpUrl(`/${urlPath}`));
         if (!response.ok) {
             throw new Error('Network response was not ok');
         }
         const data = await response.text();
         document.getElementById(tabName).innerHTML = data;
+        if (typeof forceHttpForms === 'function') {
+            forceHttpForms();
+        }
         
         // Find and re-run any scripts in the loaded content
         const scripts = document.getElementById(tabName).querySelectorAll("script");
@@ -72,7 +75,7 @@ function initializeRestoreForm() {
 async function handleRestoreSubmit(form) {
     const formData = new FormData(form);
     try {
-        const response = await fetch("/restore", {
+        const response = await fetch(getHttpUrl("/restore"), {
             method: "POST",
             body: formData
         });
@@ -166,7 +169,7 @@ function attachFormHandler(tabName) {
                 formData.append('sensitivity', sensitivity);
                 // --- End sensitivity slider support ---
                 try {
-                    const response = await fetch('/detect-transients', {
+                    const response = await fetch(getHttpUrl('/detect-transients'), {
                         method: 'POST',
                         body: formData
                     });
@@ -298,7 +301,7 @@ async function submitForm(form, tabName) {
     const method = form.method.toUpperCase();
 
     try {
-        const response = await fetch(url, {
+        const response = await fetch(getHttpUrl(url), {
             method: method,
             body: formData
         });
@@ -417,7 +420,7 @@ function initializeDrumRackWaveforms() {
         
         // Load only the slice of the audio file
         const audioContext = wavesurfer.backend.getAudioContext();
-        fetch(audioPath)
+        fetch(getHttpUrl(audioPath))
           .then(res => res.arrayBuffer())
           .then(data => audioContext.decodeAudioData(data))
           .then(buffer => {
@@ -683,7 +686,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const formData = new FormData();
             formData.append('file', fileInput.files[0]);
             try {
-                const response = await fetch('/detect-transients', {
+                const response = await fetch(getHttpUrl('/detect-transients'), {
                     method: 'POST',
                     body: formData
                 });

--- a/static/shared.js
+++ b/static/shared.js
@@ -150,3 +150,33 @@ function createDrumCellChain(receivingNote, name, params, sampleUri) {
     }
   };
 }
+
+/**
+ * Convert a relative or HTTPS URL to an explicit HTTP URL for the current host.
+ * @param {string} path - The path or URL to convert.
+ * @returns {string} - An HTTP URL.
+ */
+function getHttpUrl(path) {
+  if (!path) return 'http://' + window.location.host + '/';
+  // If already absolute, just replace https with http
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path.replace(/^https:/, 'http:');
+  }
+  if (!path.startsWith('/')) path = '/' + path;
+  return 'http://' + window.location.host + path;
+}
+
+/**
+ * Ensure all forms submit over HTTP by adjusting their action attributes.
+ */
+function forceHttpForms() {
+  document.querySelectorAll('form').forEach(form => {
+    const action = form.getAttribute('action') || window.location.pathname;
+    form.setAttribute('action', getHttpUrl(action));
+  });
+}
+
+// Force HTTP when the page loads
+if (typeof window !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', forceHttpForms);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,17 @@
         <title>Move - Extended</title>
         <link rel="stylesheet" href="/static/style.css">
         
-        <!-- Include WaveSurfer core and the Regions plugin -->
-        <script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
-        <script src="https://unpkg.com/wavesurfer.js@6/dist/plugin/wavesurfer.regions.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
+        <!-- Force HTTP protocol on page load -->
+        <script>
+            if (location.protocol !== 'http:') {
+                location.href = 'http:' + location.href.substring(location.protocol.length);
+            }
+        </script>
+
+        <!-- Include WaveSurfer core and the Regions plugin using HTTP -->
+        <script src="http://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
+        <script src="http://unpkg.com/wavesurfer.js@6/dist/plugin/wavesurfer.regions.js"></script>
+        <script src="http://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
         <script src="/static/main.js"></script>
         <script src="/static/shared.js"></script>
         <script src="/static/chord.js"></script>


### PR DESCRIPTION
## Summary
- redirect to HTTP in the main page and load external scripts via http
- provide helper functions to convert URLs and update forms to http
- apply forced http URLs in main.js and chord.js fetch calls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684138b56ffc83258e48d02294997ec1