### PR TITLE
Force http scheme for all forms and links

### DIFF
--- a/static/chord.js
+++ b/static/chord.js
@@ -503,17 +503,17 @@ function initChordTab() {
       samplesForm.append("mode", "zip");
       samplesForm.append("file", samplesZipBlob);
       samplesForm.append("destination", "/data/UserData/UserLibrary/Samples/Preset Samples");
-      const resp1 = await fetch("/place-files", { method: "POST", body: samplesForm });
+      const resp1 = await fetch('http://' + location.host + '/place-files', { method: 'POST', body: samplesForm });
       if (!resp1.ok) throw new Error('sample placement failed');
 
       const presetForm = new FormData();
       presetForm.append("mode", "place");
       presetForm.append("file", new Blob([presetJson], { type: "application/json" }), presetName + ".ablpreset");
       presetForm.append("destination", "/data/UserData/UserLibrary/Track Presets");
-      const resp2 = await fetch("/place-files", { method: "POST", body: presetForm });
+      const resp2 = await fetch('http://' + location.host + '/place-files', { method: 'POST', body: presetForm });
       if (!resp2.ok) throw new Error('preset placement failed');
 
-      const resp3 = await fetch("/refresh", {
+      const resp3 = await fetch('http://' + location.host + '/refresh', {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: "action=refresh_library"

--- a/static/slice_page.js
+++ b/static/slice_page.js
@@ -69,7 +69,7 @@ function detectTransients() {
   formData.append('file', fileInput.files[0]);
   const sens = document.getElementById('sensitivity');
   formData.append('sensitivity', sens ? sens.value : 0.07);
-  fetch('/detect-transients', { method: 'POST', body: formData })
+  fetch('http://' + location.host + '/detect-transients', { method: 'POST', body: formData })
     .then(r => r.json())
     .then(data => {
       if (data.success && data.regions) {

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -1,20 +1,21 @@
+{% set host_prefix = 'http://' + request.host %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Move - Extended</title>
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="{{ host_prefix }}/static/style.css">
 </head>
 <body>
     <h1 id="header">Move - Extended</h1>
     <nav class="tab">
-        <a href="/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
-        <a href="/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice</a>
-        <a href="/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
-        <a href="/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>
-        <a href="/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Macros</a>
-        <a href="/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
-        <a href="/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
+        <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
+        <a href="{{ host_prefix }}/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice</a>
+        <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
+        <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>
+        <a href="{{ host_prefix }}/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Macros</a>
+        <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
+        <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/chord.html
+++ b/templates_jinja/chord.html
@@ -19,8 +19,8 @@
 {% block scripts %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
 <script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
-<script src="/static/shared.js"></script>
-<script src="/static/chord.js"></script>
+<script src="{{ host_prefix }}/static/shared.js"></script>
+<script src="{{ host_prefix }}/static/chord.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     if (typeof initChordTab === 'function') {

--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -5,7 +5,7 @@
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
-<form method="POST" action="/drum-rack-inspector">
+<form method="POST" action="{{ host_prefix }}/drum-rack-inspector">
     <input type="hidden" name="action" value="select_preset">
     <label for="preset_select">Select a Drum Rack:</label>
     <select name="preset_select" id="preset_select">
@@ -58,7 +58,7 @@
   <div class="modal-content">
     <span class="modal-close">&times;</span>
     <div id="ts_loading" class="loading-overlay hidden">Time stretching…</div>
-    <form method="POST" action="/drum-rack-inspector" id="timeStretchForm">
+    <form method="POST" action="{{ host_prefix }}/drum-rack-inspector" id="timeStretchForm">
       <input type="hidden" name="action" value="time_stretch_sample">
       <input type="hidden" name="sample_path" id="ts_sample_path">
       <input type="hidden" name="preset_path" id="ts_preset_path">
@@ -82,9 +82,9 @@
 {% endblock %}
 {% block scripts %}
 <script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
-<script type="module" src="/static/drum_rack.js"></script>
+<script type="module" src="{{ host_prefix }}/static/drum_rack.js"></script>
 <script type="module">
-  import { initDrumRackTab } from '/static/drum_rack.js';
+  import { initDrumRackTab } from '{{ host_prefix }}/static/drum_rack.js';
   document.addEventListener('DOMContentLoaded', initDrumRackTab);
 </script>
 {% endblock %}

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -8,7 +8,7 @@
     <div  >
         <h3>Upload MIDI File</h3>
         <p>Upload a MIDI file to generate an Ableton Live set with the notes from the file.</p>
-        <form method="post" action="/midi-upload" enctype="multipart/form-data">
+        <form method="post" action="{{ host_prefix }}/midi-upload" enctype="multipart/form-data">
             <input type="hidden" name="action" value="upload_midi" />
             <div class="form-group">
                 <label for="midi_type">MIDI Type:</label>

--- a/templates_jinja/restore.html
+++ b/templates_jinja/restore.html
@@ -4,7 +4,7 @@
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
-<form action="/restore" method="post" enctype="multipart/form-data">
+<form action="{{ host_prefix }}/restore" method="post" enctype="multipart/form-data">
     <label for="ablbundle">Select .ablbundle file:</label>
     <input type="file" name="ablbundle" accept=".ablbundle" required>
     <br>
@@ -18,5 +18,5 @@
     <input type="hidden" name="action" value="restore_ablbundle">
     <button type="submit">Upload & Restore</button>
 </form>
-<img src="/static/img/move_pads.png" alt="Pad map" style="width:30%;" />
+<img src="{{ host_prefix }}/static/img/move_pads.png" alt="Pad map" style="width:30%;" />
 {% endblock %}

--- a/templates_jinja/reverse.html
+++ b/templates_jinja/reverse.html
@@ -5,7 +5,7 @@
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
-<form method="post">
+<form method="post" action="{{ host_prefix }}/reverse">
     <input type="hidden" name="action" value="reverse_file">
     <label for="wav_file">Select WAV file:</label>
     <select name="wav_file" required>

--- a/templates_jinja/slice.html
+++ b/templates_jinja/slice.html
@@ -5,7 +5,7 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 <p id="slice-message"></p>
-<form id="slice-form" action="/slice" method="post" enctype="multipart/form-data">
+<form id="slice-form" action="{{ host_prefix }}/slice" method="post" enctype="multipart/form-data">
   <input type="hidden" name="action" value="slice">
   <input type="hidden" name="regions" id="regions-input">
 
@@ -47,5 +47,5 @@
 {% block scripts %}
 <script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
 <script src="https://unpkg.com/wavesurfer.js@6/dist/plugin/wavesurfer.regions.js"></script>
-<script src="/static/slice_page.js"></script>
+<script src="{{ host_prefix }}/static/slice_page.js"></script>
 {% endblock %}

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -7,7 +7,7 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 
-<form method="post" action="/synth-macros" id="preset-form">
+<form method="post" action="{{ host_prefix }}/synth-macros" id="preset-form">
     <input type="hidden" name="action" id="action-input" value="select_preset">
     <input type="hidden" name="param_path" id="param-path-input" value="">
     <input type="hidden" name="param_name" id="param-name-input" value="">


### PR DESCRIPTION
## Summary
- always use explicit `http://` scheme
- reference server host for navigation links
- send fetch requests to absolute http URLs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413b2562e883258905118297042562