### PR TITLE
Implement HTML file browser for preset tools

### DIFF
--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -79,17 +79,21 @@ def generate_dir_html(
         if rel_path else '<ul class="file-tree root" data-path="">'
     for d in dirs:
         sub_rel = os.path.join(rel_path, d) if rel_path else d
-        html += f'<li class="dir" data-path="{sub_rel}"><span>{d}</span><ul class="hidden"></ul></li>'
+        html += (
+            f'<li class="dir closed" data-path="{sub_rel}">'
+            f'<span>📁 {d}</span>'
+            '<ul class="hidden"></ul></li>'
+        )
     for f in files:
         full = os.path.join(base_dir, rel_path, f)
         if filter_func(full):
             rel = os.path.join(rel_path, f) if rel_path else f
             html += (
                 '<li class="file">'
-                f'<form method="post" action="{action_url}" class="file-select-form">'
+                f'<form method="post" action="{action_url}" class="file-entry">'
                 f'<input type="hidden" name="action" value="{action_value}">' \
                 f'<input type="hidden" name="{field_name}" value="{full}">' \
-                f'<button type="submit" class="file-link">{f}</button>'
+                f'<button type="submit">📄 {f}</button>'
                 '</form>'
                 '</li>'
             )

--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -1,42 +1,97 @@
 import os
-from typing import List
+import json
+from typing import Callable, Tuple
+
+from core.cache_manager import get_cache, set_cache
+
+_CACHE_PREFIX = "file_browser:"
 
 
-def build_file_tree(paths: List[str]):
-    """Build a nested dictionary representing directories and files."""
-    tree = {}
-    for rel_path in paths:
-        parts = rel_path.split(os.sep)
-        node = tree
-        for part in parts[:-1]:
-            node = node.setdefault(part, {})
-        node.setdefault('__files__', []).append(parts[-1])
-    return tree
+def _list_directory(base_dir: str, rel_path: str) -> Tuple[list[str], list[str]]:
+    """List subdirectories and files for the given path with caching."""
+    abs_path = os.path.join(base_dir, rel_path)
+    key = f"{_CACHE_PREFIX}{abs_path}"
+    cached = get_cache(key)
+    if cached is not None:
+        return cached["dirs"], cached["files"]
+
+    try:
+        entries = os.listdir(abs_path)
+    except FileNotFoundError:
+        return [], []
+    dirs: list[str] = []
+    files: list[str] = []
+    for name in sorted(entries):
+        full = os.path.join(abs_path, name)
+        if os.path.isdir(full):
+            dirs.append(name)
+        elif os.path.isfile(full):
+            files.append(name)
+    set_cache(key, {"dirs": dirs, "files": files})
+    return dirs, files
 
 
-def _generate_html(node, base_path, action_url, field_name, action_value):
-    html = '<ul class="file-tree">'
-    for name in sorted(k for k in node.keys() if k != '__files__'):
-        html += f'<li class="dir"><span>{name}</span>'
-        html += _generate_html(node[name], os.path.join(base_path, name), action_url, field_name, action_value)
-        html += '</li>'
-    for fname in sorted(node.get('__files__', [])):
-        rel = os.path.join(base_path, fname)
-        html += (
-            '<li class="file">'
-            f'<form method="post" action="{action_url}" class="file-select-form">'
-            f'<input type="hidden" name="action" value="{action_value}">' 
-            f'<input type="hidden" name="{field_name}" value="{rel}">' 
-            f'<button type="submit" class="file-link">{fname}</button>'
-            '</form>'
-            '</li>'
-        )
+def _check_json_file(file_path: str, predicate: Callable[[dict], bool]) -> bool:
+    """Check JSON file against predicate with caching."""
+    key = f"{_CACHE_PREFIX}{file_path}"
+    cached = get_cache(key)
+    if cached is not None and "result" in cached:
+        return cached["result"]
+    try:
+        with open(file_path, "r") as f:
+            data = json.load(f)
+        result = predicate(data)
+    except Exception:
+        result = False
+    set_cache(key, {"result": result})
+    return result
+
+
+def _has_kind(data: dict | list, kind: str) -> bool:
+    if isinstance(data, dict):
+        if data.get("kind") == kind:
+            return True
+        return any(_has_kind(v, kind) for v in data.values())
+    if isinstance(data, list):
+        return any(_has_kind(item, kind) for item in data)
+    return False
+
+
+FILTERS: dict[str, Callable[[str], bool]] = {
+    "wav": lambda p: p.lower().endswith(".wav"),
+    "drift": lambda p: p.lower().endswith(".ablpreset") and _check_json_file(p, lambda d: _has_kind(d, "drift")),
+    "drumrack": lambda p: p.lower().endswith(".ablpreset") and _check_json_file(p, lambda d: _has_kind(d, "drumRack")),
+}
+
+
+def generate_dir_html(
+    base_dir: str,
+    rel_path: str,
+    action_url: str,
+    field_name: str,
+    action_value: str,
+    filter_key: str | None = None,
+) -> str:
+    """Return HTML listing for the directory."""
+    filter_func = FILTERS.get(filter_key, lambda p: True)
+    dirs, files = _list_directory(base_dir, rel_path)
+    html = f'<ul class="file-tree" data-path="{rel_path}">' \
+        if rel_path else '<ul class="file-tree root" data-path="">'
+    for d in dirs:
+        sub_rel = os.path.join(rel_path, d) if rel_path else d
+        html += f'<li class="dir" data-path="{sub_rel}"><span>{d}</span><ul class="hidden"></ul></li>'
+    for f in files:
+        full = os.path.join(base_dir, rel_path, f)
+        if filter_func(full):
+            rel = os.path.join(rel_path, f) if rel_path else f
+            html += (
+                '<li class="file">'
+                f'<form method="post" action="{action_url}" class="file-select-form">'
+                f'<input type="hidden" name="action" value="{action_value}">' \
+                f'<input type="hidden" name="{field_name}" value="{full}">' \
+                f'<button type="submit" class="file-link">{f}</button>'
+                '</form>'
+                '</li>'
+            )
     html += '</ul>'
     return html
-
-
-def build_file_browser_html(paths: List[str], base_dir: str, action_url: str, field_name: str, action_value: str) -> str:
-    """Generate nested HTML for a simple file browser."""
-    rel_paths = [os.path.relpath(p, base_dir) for p in paths]
-    tree = build_file_tree(rel_paths)
-    return _generate_html(tree, '', action_url, field_name, action_value)

--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -1,0 +1,42 @@
+import os
+from typing import List
+
+
+def build_file_tree(paths: List[str]):
+    """Build a nested dictionary representing directories and files."""
+    tree = {}
+    for rel_path in paths:
+        parts = rel_path.split(os.sep)
+        node = tree
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node.setdefault('__files__', []).append(parts[-1])
+    return tree
+
+
+def _generate_html(node, base_path, action_url, field_name, action_value):
+    html = '<ul class="file-tree">'
+    for name in sorted(k for k in node.keys() if k != '__files__'):
+        html += f'<li class="dir"><span>{name}</span>'
+        html += _generate_html(node[name], os.path.join(base_path, name), action_url, field_name, action_value)
+        html += '</li>'
+    for fname in sorted(node.get('__files__', [])):
+        rel = os.path.join(base_path, fname)
+        html += (
+            '<li class="file">'
+            f'<form method="post" action="{action_url}" class="file-select-form">'
+            f'<input type="hidden" name="action" value="{action_value}">' 
+            f'<input type="hidden" name="{field_name}" value="{rel}">' 
+            f'<button type="submit" class="file-link">{fname}</button>'
+            '</form>'
+            '</li>'
+        )
+    html += '</ul>'
+    return html
+
+
+def build_file_browser_html(paths: List[str], base_dir: str, action_url: str, field_name: str, action_value: str) -> str:
+    """Generate nested HTML for a simple file browser."""
+    rel_paths = [os.path.relpath(p, base_dir) for p in paths]
+    tree = build_file_tree(rel_paths)
+    return _generate_html(tree, '', action_url, field_name, action_value)

--- a/handlers/drum_rack_inspector_handler_class.py
+++ b/handlers/drum_rack_inspector_handler_class.py
@@ -2,9 +2,9 @@
 import cgi
 import os
 import urllib.parse
-from core.file_browser import build_file_browser_html
+from core.file_browser import generate_dir_html
 from handlers.base_handler import BaseHandler
-from core.drum_rack_inspector_handler import scan_for_drum_rack_presets, get_drum_cell_samples, update_drum_cell_sample
+from core.drum_rack_inspector_handler import get_drum_cell_samples, update_drum_cell_sample
 from core.reverse_handler import reverse_wav_file
 from core.refresh_handler import refresh_library
 from core.time_stretch_handler import time_stretch_wav
@@ -12,17 +12,24 @@ from core.time_stretch_handler import time_stretch_wav
 class DrumRackInspectorHandler(BaseHandler):
     def handle_get(self):
         """Return file browser HTML for drum rack presets."""
-        presets = scan_for_drum_rack_presets().get('presets', [])
-        paths = [p['path'] for p in presets]
-        base_dir = os.path.commonpath(paths) if paths else '/'
-        browser_html = build_file_browser_html(
-            paths, base_dir, '/drum-rack-inspector', 'preset_select', 'select_preset'
+        base_dir = "/data/UserData/UserLibrary/Track Presets"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+            base_dir = "examples/Track Presets"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            '/drum-rack-inspector',
+            'preset_select',
+            'select_preset',
+            filter_key='drumrack'
         )
         return {
             'file_browser_html': browser_html,
             'message': '',
             'samples_html': '',
             'selected_preset': None,
+            'browser_root': base_dir,
+            'browser_filter': 'drumrack',
         }
 
     def handle_post(self, form: cgi.FieldStorage):
@@ -132,11 +139,16 @@ class DrumRackInspectorHandler(BaseHandler):
 
             samples_html += '</div>'
 
-            presets = scan_for_drum_rack_presets().get('presets', [])
-            paths = [p['path'] for p in presets]
-            base_dir = os.path.commonpath(paths) if paths else '/'
-            browser_html = build_file_browser_html(
-                paths, base_dir, '/drum-rack-inspector', 'preset_select', 'select_preset'
+            base_dir = "/data/UserData/UserLibrary/Track Presets"
+            if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+                base_dir = "examples/Track Presets"
+            browser_html = generate_dir_html(
+                base_dir,
+                "",
+                '/drum-rack-inspector',
+                'preset_select',
+                'select_preset',
+                filter_key='drumrack'
             )
 
             return {
@@ -144,6 +156,8 @@ class DrumRackInspectorHandler(BaseHandler):
                 'message': result['message'],
                 'samples_html': samples_html,
                 'selected_preset': preset_path,
+                'browser_root': base_dir,
+                'browser_filter': 'drumrack',
             }
 
         except Exception as e:
@@ -180,17 +194,24 @@ class DrumRackInspectorHandler(BaseHandler):
                     </form>
                 </div>
             '''
-            presets = scan_for_drum_rack_presets().get('presets', [])
-            paths = [p['path'] for p in presets]
-            base_dir = os.path.commonpath(paths) if paths else '/'
-            browser_html = build_file_browser_html(
-                paths, base_dir, '/drum-rack-inspector', 'preset_select', 'select_preset'
+            base_dir = "/data/UserData/UserLibrary/Track Presets"
+            if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+                base_dir = "examples/Track Presets"
+            browser_html = generate_dir_html(
+                base_dir,
+                "",
+                '/drum-rack-inspector',
+                'preset_select',
+                'select_preset',
+                filter_key='drumrack'
             )
             return {
                 'file_browser_html': browser_html,
                 'message': '',
                 'samples_html': samples_html,
                 'selected_preset': preset_path,
+                'browser_root': base_dir,
+                'browser_filter': 'drumrack',
             }
 
         # Step 2: Compute target duration
@@ -317,17 +338,24 @@ class DrumRackInspectorHandler(BaseHandler):
 
         samples_html += '</div>'
 
-        presets = scan_for_drum_rack_presets().get('presets', [])
-        paths = [p['path'] for p in presets]
-        base_dir = os.path.commonpath(paths) if paths else '/'
-        browser_html = build_file_browser_html(
-            paths, base_dir, '/drum-rack-inspector', 'preset_select', 'select_preset'
+        base_dir = "/data/UserData/UserLibrary/Track Presets"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+            base_dir = "examples/Track Presets"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            '/drum-rack-inspector',
+            'preset_select',
+            'select_preset',
+            filter_key='drumrack'
         )
         return {
             'file_browser_html': browser_html,
             'message': f"Time-stretched sample created and loaded for pad {pad_number}! {ts_message} {update_message}",
             'samples_html': samples_html,
             'selected_preset': preset_path,
+            'browser_root': base_dir,
+            'browser_filter': 'drumrack',
         }
     def handle_reverse_sample(self, form):
         """Handle reversing a sample."""
@@ -455,17 +483,24 @@ class DrumRackInspectorHandler(BaseHandler):
 
             samples_html += '</div>'
 
-            presets = scan_for_drum_rack_presets().get('presets', [])
-            paths = [p['path'] for p in presets]
-            base_dir = os.path.commonpath(paths) if paths else '/'
-            browser_html = build_file_browser_html(
-                paths, base_dir, '/drum-rack-inspector', 'preset_select', 'select_preset'
+            base_dir = "/data/UserData/UserLibrary/Track Presets"
+            if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+                base_dir = "examples/Track Presets"
+            browser_html = generate_dir_html(
+                base_dir,
+                "",
+                '/drum-rack-inspector',
+                'preset_select',
+                'select_preset',
+                filter_key='drumrack'
             )
             return {
                 'file_browser_html': browser_html,
                 'message': message,
                 'samples_html': samples_html,
                 'selected_preset': preset_path,
+                'browser_root': base_dir,
+                'browser_filter': 'drumrack',
             }
 
         except Exception as e:

--- a/handlers/reverse_handler_class.py
+++ b/handlers/reverse_handler_class.py
@@ -2,23 +2,28 @@
 import cgi
 import os
 from handlers.base_handler import BaseHandler
-from core.reverse_handler import get_wav_files, reverse_wav_file
-from core.file_browser import build_file_browser_html
+from core.reverse_handler import reverse_wav_file
+from core.file_browser import generate_dir_html
 
 class ReverseHandler(BaseHandler):
     def handle_get(self):
         """Provide the file browser HTML for reverse page."""
         base_dir = "/data/UserData/UserLibrary/Samples"
-        wav_files = get_wav_files(base_dir)
-        file_paths = [os.path.join(base_dir, f) for f in wav_files]
-        browser_html = build_file_browser_html(
-            file_paths, base_dir, "/reverse", "wav_file", "reverse_file"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            "/reverse",
+            "wav_file",
+            "reverse_file",
+            filter_key="wav",
         )
         return {
             "file_browser_html": browser_html,
             "message": "Select a WAV file to reverse",
             "message_type": "info",
             "selected_file": None,
+            "browser_root": base_dir,
+            "browser_filter": "wav",
         }
 
     def handle_post(self, form: cgi.FieldStorage):

--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -10,16 +10,21 @@ from core.synth_preset_inspector_handler import (
     update_preset_parameter_mappings,
     delete_parameter_mapping
 )
-from core.file_browser import build_file_browser_html
+from core.file_browser import generate_dir_html
 
 class SynthPresetInspectorHandler(BaseHandler):
     def handle_get(self):
         """Return file browser for synth presets."""
-        presets = scan_for_synth_presets().get('presets', [])
-        paths = [p['path'] for p in presets]
-        base_dir = os.path.commonpath(paths) if paths else '/'
-        browser_html = build_file_browser_html(
-            paths, base_dir, '/synth-macros', 'preset_select', 'select_preset'
+        base_dir = "/data/UserData/UserLibrary/Track Presets"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+            base_dir = "examples/Track Presets"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            '/synth-macros',
+            'preset_select',
+            'select_preset',
+            filter_key='drift'
         )
         return {
             "message": "Select a Drift preset from the list",
@@ -27,6 +32,8 @@ class SynthPresetInspectorHandler(BaseHandler):
             "file_browser_html": browser_html,
             "macros_html": "",
             "selected_preset": None,
+            "browser_root": base_dir,
+            "browser_filter": 'drift',
         }
 
     def handle_post(self, form):
@@ -145,11 +152,16 @@ class SynthPresetInspectorHandler(BaseHandler):
             # Generate HTML for displaying macros
             macros_html = self.generate_macros_html(macro_result['macros'])
             
-            presets = scan_for_synth_presets().get('presets', [])
-            paths = [p['path'] for p in presets]
-            base_dir = os.path.commonpath(paths) if paths else '/'
-            browser_html = build_file_browser_html(
-                paths, base_dir, '/synth-macros', 'preset_select', 'select_preset'
+            base_dir = "/data/UserData/UserLibrary/Track Presets"
+            if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+                base_dir = "examples/Track Presets"
+            browser_html = generate_dir_html(
+                base_dir,
+                "",
+                '/synth-macros',
+                'preset_select',
+                'select_preset',
+                filter_key='drift'
             )
 
             return {
@@ -158,6 +170,8 @@ class SynthPresetInspectorHandler(BaseHandler):
                 "file_browser_html": browser_html,
                 "macros_html": macros_html,
                 "selected_preset": preset_path,
+                "browser_root": base_dir,
+                "browser_filter": 'drift',
             }
         
         return self.format_info_response("Unknown action")

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -28,7 +28,7 @@ from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
 from dash import Dash, html
-from core.reverse_handler import get_wav_files
+from core.file_browser import generate_dir_html
 import cgi
 
 PID_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "move-webserver.pid")
@@ -197,6 +197,18 @@ def index():
     return redirect("/restore")
 
 
+@app.route("/browse-dir")
+def browse_dir():
+    root = request.args.get("root", "")
+    path = request.args.get("path", "")
+    action_url = request.args.get("action_url", "")
+    field_name = request.args.get("field_name", "")
+    action_value = request.args.get("action_value", "")
+    filter_key = request.args.get("filter")
+    html = generate_dir_html(root, path, action_url, field_name, action_value, filter_key)
+    return html
+
+
 @app.route("/reverse", methods=["GET", "POST"])
 def reverse():
     message = None
@@ -212,6 +224,8 @@ def reverse():
     success = message_type != "error" if message_type else False
     browser_html = result.get("file_browser_html")
     selected_file = result.get("selected_file")
+    browser_root = result.get("browser_root")
+    browser_filter = result.get("browser_filter")
     return render_template(
         "reverse.html",
         message=message,
@@ -219,6 +233,8 @@ def reverse():
         message_type=message_type,
         file_browser_html=browser_html,
         selected_file=selected_file,
+        browser_root=browser_root,
+        browser_filter=browser_filter,
         active_tab="reverse",
     )
 
@@ -327,6 +343,8 @@ def synth_macros():
     message_type = result.get("message_type")
     success = message_type != "error" if message_type else False
     browser_html = result.get("file_browser_html")
+    browser_root = result.get("browser_root")
+    browser_filter = result.get("browser_filter")
     macros_html = result.get("macros_html", "")
     selected_preset = result.get("selected_preset")
     preset_selected = bool(selected_preset)
@@ -336,6 +354,8 @@ def synth_macros():
         success=success,
         message_type=message_type,
         file_browser_html=browser_html,
+        browser_root=browser_root,
+        browser_filter=browser_filter,
         macros_html=macros_html,
         preset_selected=preset_selected,
         selected_preset=selected_preset,
@@ -389,6 +409,8 @@ def drum_rack_inspector():
     message_type = result.get("message_type")
     success = message_type != "error" if message_type else False
     browser_html = result.get("file_browser_html")
+    browser_root = result.get("browser_root")
+    browser_filter = result.get("browser_filter")
     samples_html = result.get("samples_html", "")
     selected_preset = result.get("selected_preset")
     return render_template(
@@ -397,6 +419,8 @@ def drum_rack_inspector():
         success=success,
         message_type=message_type,
         file_browser_html=browser_html,
+        browser_root=browser_root,
+        browser_filter=browser_filter,
         samples_html=samples_html,
         selected_preset=selected_preset,
         active_tab="drum-rack-inspector",

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -205,19 +205,20 @@ def reverse():
     if request.method == "POST":
         form = SimpleForm(request.form.to_dict())
         result = reverse_handler.handle_post(form)
-        message = result.get("message")
-        message_type = result.get("message_type")
-        success = message_type != "error"
     else:
-        message = "Select a WAV file to reverse"
-        message_type = "info"
-    wav_list = get_wav_files("/data/UserData/UserLibrary/Samples")
+        result = reverse_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    browser_html = result.get("file_browser_html")
+    selected_file = result.get("selected_file")
     return render_template(
         "reverse.html",
         message=message,
         success=success,
         message_type=message_type,
-        wav_files=wav_list,
+        file_browser_html=browser_html,
+        selected_file=selected_file,
         active_tab="reverse",
     )
 
@@ -316,21 +317,16 @@ def midi_upload():
 
 @app.route("/synth-macros", methods=["GET", "POST"])
 def synth_macros():
-    message = None
-    success = False
-    message_type = None
-    options_html = ""
-    macros_html = ""
-    selected_preset = None
     if request.method == "POST":
         form = SimpleForm(request.form.to_dict())
         result = synth_handler.handle_post(form)
     else:
         result = synth_handler.handle_get()
+
     message = result.get("message")
     message_type = result.get("message_type")
-    success = message_type != "error"
-    options_html = result.get("options", "")
+    success = message_type != "error" if message_type else False
+    browser_html = result.get("file_browser_html")
     macros_html = result.get("macros_html", "")
     selected_preset = result.get("selected_preset")
     preset_selected = bool(selected_preset)
@@ -339,7 +335,7 @@ def synth_macros():
         message=message,
         success=success,
         message_type=message_type,
-        options_html=options_html,
+        file_browser_html=browser_html,
         macros_html=macros_html,
         preset_selected=preset_selected,
         selected_preset=selected_preset,
@@ -383,28 +379,26 @@ def serve_sample(sample_path):
 
 @app.route("/drum-rack-inspector", methods=["GET", "POST"])
 def drum_rack_inspector():
-    message = None
-    success = False
-    message_type = None
-    options_html = ""
-    samples_html = ""
     if request.method == "POST":
         form = SimpleForm(request.form.to_dict())
         result = drum_rack_handler.handle_post(form)
     else:
         result = drum_rack_handler.handle_get()
+
     message = result.get("message")
     message_type = result.get("message_type")
     success = message_type != "error" if message_type else False
-    options_html = result.get("options") or result.get("options_html", "")
+    browser_html = result.get("file_browser_html")
     samples_html = result.get("samples_html", "")
+    selected_preset = result.get("selected_preset")
     return render_template(
         "drum_rack_inspector.html",
         message=message,
         success=success,
         message_type=message_type,
-        options_html=options_html,
+        file_browser_html=browser_html,
         samples_html=samples_html,
+        selected_preset=selected_preset,
         active_tab="drum-rack-inspector",
     )
 

--- a/static/file_browser.js
+++ b/static/file_browser.js
@@ -1,11 +1,31 @@
 export function initFileBrowser() {
-  document.querySelectorAll('.file-tree .dir > span').forEach(el => {
-    el.addEventListener('click', () => {
-      const next = el.nextElementSibling;
-      if (next) {
-        next.classList.toggle('hidden');
-      }
-    });
+  document.querySelectorAll('.file-browser').forEach(container => {
+    const browseUrl = container.dataset.browseUrl || '/browse-dir';
+    function bind(span) {
+      span.addEventListener('click', async () => {
+        const li = span.parentElement;
+        const ul = li.querySelector('ul');
+        if (!ul) return;
+        if (!ul.dataset.loaded) {
+          const params = new URLSearchParams({
+            root: container.dataset.root,
+            path: li.dataset.path || '',
+            action_url: container.dataset.action,
+            field_name: container.dataset.field,
+            action_value: container.dataset.value,
+            filter: container.dataset.filter || ''
+          });
+          const resp = await fetch(`${browseUrl}?${params.toString()}`);
+          if (resp.ok) {
+            ul.innerHTML = await resp.text();
+            ul.dataset.loaded = 'true';
+            ul.querySelectorAll('.dir > span').forEach(s => bind(s));
+          }
+        }
+        ul.classList.toggle('hidden');
+      });
+    }
+    container.querySelectorAll('.file-tree.root .dir > span').forEach(bind);
   });
 }
 

--- a/static/file_browser.js
+++ b/static/file_browser.js
@@ -1,0 +1,12 @@
+export function initFileBrowser() {
+  document.querySelectorAll('.file-tree .dir > span').forEach(el => {
+    el.addEventListener('click', () => {
+      const next = el.nextElementSibling;
+      if (next) {
+        next.classList.toggle('hidden');
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initFileBrowser);

--- a/static/file_browser.js
+++ b/static/file_browser.js
@@ -23,6 +23,8 @@ export function initFileBrowser() {
           }
         }
         ul.classList.toggle('hidden');
+        li.classList.toggle('open');
+        li.classList.toggle('closed');
       });
     }
     container.querySelectorAll('.file-tree.root .dir > span').forEach(bind);

--- a/static/style.css
+++ b/static/style.css
@@ -382,3 +382,11 @@ select {
 .drum-cell .sample-info {
     margin-top: auto;
 }
+/* File browser styling */
+.file-tree { list-style: none; padding-left: 1rem; }
+.file-tree ul { list-style: none; margin-left: 1rem; }
+.file-tree .dir > span { cursor: pointer; font-weight: 500; }
+.file-tree .file-link { background: none; border: none; color: #0066cc; cursor: pointer; padding: 0; text-align: left; }
+.file-tree .file-link:hover { text-decoration: underline; }
+.hidden { display: none; }
+

--- a/static/style.css
+++ b/static/style.css
@@ -389,4 +389,10 @@ select {
 .file-tree .file-link { background: none; border: none; color: #0066cc; cursor: pointer; padding: 0; text-align: left; }
 .file-tree .file-link:hover { text-decoration: underline; }
 .hidden { display: none; }
+.file-browser {
+    max-height: 240px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
 

--- a/static/style.css
+++ b/static/style.css
@@ -383,16 +383,21 @@ select {
     margin-top: auto;
 }
 /* File browser styling */
-.file-tree { list-style: none; padding-left: 1rem; }
-.file-tree ul { list-style: none; margin-left: 1rem; }
-.file-tree .dir > span { cursor: pointer; font-weight: 500; }
-.file-tree .file-link { background: none; border: none; color: #0066cc; cursor: pointer; padding: 0; text-align: left; }
-.file-tree .file-link:hover { text-decoration: underline; }
+.file-tree { list-style: none; padding-left: 0; }
+.file-tree ul { list-style: none; margin-left: 1rem; padding-left: 0; }
+.file-tree li { margin: 0; }
+.file-tree .dir > span,
+.file-tree .file-entry button { display: block; width: 100%; cursor: pointer; border: none; background: none; text-align: left; padding: 0.2rem 0.4rem; }
+.file-tree .dir > span:hover,
+.file-tree .file-entry button:hover { background: #f0f0f0; }
+.file-tree .file-entry button { color: #0066cc; }
+.file-tree .dir.closed > span::before { content: "\25B6"; display: inline-block; width: 1em; }
+.file-tree .dir.open > span::before { content: "\25BC"; display: inline-block; width: 1em; }
 .hidden { display: none; }
 .file-browser {
     max-height: 240px;
     overflow-y: auto;
     border: 1px solid #ccc;
-    padding: 0.5rem;
+    padding: 0.25rem;
 }
 

--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -6,7 +6,7 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 {% if not selected_preset %}
-  <div class="file-browser">
+  <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/drum-rack-inspector" data-field="preset_select" data-value="select_preset" data-filter="drumrack">
     {{ file_browser_html | safe }}
   </div>
 {% else %}

--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -5,17 +5,19 @@
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
-<form method="POST" action="{{ host_prefix }}/drum-rack-inspector">
-    <input type="hidden" name="action" value="select_preset">
-    <label for="preset_select">Select a Drum Rack:</label>
-    <select name="preset_select" id="preset_select">
-        {{ options_html | safe }}
-    </select>
-    <button type="submit">Load</button>
-</form>
-<div class="samples-container">
+{% if not selected_preset %}
+  <div class="file-browser">
+    {{ file_browser_html | safe }}
+  </div>
+{% else %}
+  <form method="post" action="{{ host_prefix }}/drum-rack-inspector" style="margin-bottom:1rem;">
+    <input type="hidden" name="action" value="reset_preset">
+    <button type="submit">Choose Another Preset</button>
+  </form>
+  <div class="samples-container">
     {{ samples_html | safe }}
-</div>
+  </div>
+{% endif %}
 <!-- Time Stretch Modal -->
 <style>
   .modal .loading-overlay {
@@ -87,4 +89,5 @@
   import { initDrumRackTab } from '{{ host_prefix }}/static/drum_rack.js';
   document.addEventListener('DOMContentLoaded', initDrumRackTab);
 </script>
+<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 {% endblock %}

--- a/templates_jinja/reverse.html
+++ b/templates_jinja/reverse.html
@@ -5,15 +5,21 @@
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
-<form method="post" action="{{ host_prefix }}/reverse">
+{% if not selected_file %}
+  <div class="file-browser">
+    {{ file_browser_html | safe }}
+  </div>
+{% else %}
+  <form method="post" action="{{ host_prefix }}/reverse" style="display:inline;">
     <input type="hidden" name="action" value="reverse_file">
-    <label for="wav_file">Select WAV file:</label>
-    <select name="wav_file" required>
-        <option value="" disabled selected>--Select a file--</option>
-        {% for f in wav_files %}
-        <option value="{{ f }}">{{ f }}</option>
-        {% endfor %}
-    </select>
-    <button type="submit">Reverse</button>
-</form>
+    <input type="hidden" name="wav_file" value="{{ selected_file }}">
+    <button type="submit">Reverse Again</button>
+  </form>
+  <form method="get" action="{{ host_prefix }}/reverse" style="display:inline; margin-left:1rem;">
+    <button type="submit">Choose Another File</button>
+  </form>
+{% endif %}
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 {% endblock %}

--- a/templates_jinja/reverse.html
+++ b/templates_jinja/reverse.html
@@ -6,7 +6,7 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 {% if not selected_file %}
-  <div class="file-browser">
+  <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/reverse" data-field="wav_file" data-value="reverse_file" data-filter="wav">
     {{ file_browser_html | safe }}
   </div>
 {% else %}

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -12,19 +12,13 @@
     <input type="hidden" name="param_path" id="param-path-input" value="">
     <input type="hidden" name="param_name" id="param-name-input" value="">
     <input type="hidden" name="macro_index" id="macro-index-input" value="">
-    <div class="preset-selection">
-        <select name="preset_select" id="preset_select" required {% if preset_selected %}disabled{% endif %}>
-            {{ options_html | safe }}
-        </select>
-        {% if preset_selected %}
-        <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
-        <input type="hidden" name="preset_select" value="{{ selected_preset }}">
-        {% else %}
-        <button type="submit">Load Preset</button>
-        {% endif %}
+    {% if not preset_selected %}
+    <div class="file-browser">
+        {{ file_browser_html | safe }}
     </div>
-
-    {% if preset_selected %}
+    {% else %}
+    <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
+    <input type="hidden" name="preset_select" value="{{ selected_preset }}">
     <div class="macro-display">
         {{ macros_html | safe }}
     </div>
@@ -191,4 +185,7 @@
         background-color: #0b7dda;
     }
 </style>
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 {% endblock %}

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -13,7 +13,7 @@
     <input type="hidden" name="param_name" id="param-name-input" value="">
     <input type="hidden" name="macro_index" id="macro-index-input" value="">
     {% if not preset_selected %}
-    <div class="file-browser">
+    <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/synth-macros" data-field="preset_select" data-value="select_preset" data-filter="drift">
         {{ file_browser_html | safe }}
     </div>
     {% else %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -16,11 +16,10 @@ def client(monkeypatch):
     move_webserver.app.config['TESTING'] = True
     return move_webserver.app.test_client()
 
-def test_reverse_get(client, monkeypatch):
-    monkeypatch.setattr(move_webserver, 'get_wav_files', lambda d: ['sample.wav'])
+def test_reverse_get(client):
     resp = client.get('/reverse')
     assert resp.status_code == 200
-    assert b'sample.wav' in resp.data
+    assert b'class="file-browser"' in resp.data
 
 def test_reverse_post(client, monkeypatch):
     def fake_handle_post(form):
@@ -84,42 +83,43 @@ def test_synth_macros_post(client, monkeypatch):
         return {
             'message': 'saved',
             'message_type': 'success',
-            'options': '<option value="x" selected>Sub/preset (Drift)</option>',
             'macros_html': '<p>done</p>',
             'selected_preset': 'x',
+            'browser_root': '/tmp',
         }
     monkeypatch.setattr(move_webserver.synth_handler, 'handle_post', fake_post)
     resp = client.post('/synth-macros', data={'action': 'select_preset'})
     assert resp.status_code == 200
     assert b'saved' in resp.data
-    assert b'name="preset_select" value="x"' in resp.data
-    assert b'id="preset_select"' in resp.data and b'disabled' in resp.data
     assert b'Choose Another Preset' in resp.data
+    assert b'<p>done</p>' in resp.data
 
 def test_drum_rack_inspector_get(client, monkeypatch):
     def fake_get():
         return {
-            'options': '<option value="1">P</option>',
+            'file_browser_html': '<ul></ul>',
             'message': '',
-            'samples_html': ''
+            'samples_html': '',
+            'browser_root': '/tmp'
         }
     monkeypatch.setattr(move_webserver.drum_rack_handler, 'handle_get', fake_get)
     resp = client.get('/drum-rack-inspector')
     assert resp.status_code == 200
-    assert b'<option value="1">P</option>' in resp.data
+    assert b'class="file-browser"' in resp.data
 
 def test_drum_rack_inspector_post(client, monkeypatch):
     def fake_post(form):
         return {
             'message': 'ok',
             'message_type': 'success',
-            'options': '<option value="1">P</option>',
-            'samples_html': '<div>grid</div>'
+            'samples_html': '<div>grid</div>',
+            'browser_root': '/tmp',
+            'selected_preset': 'x',
         }
     monkeypatch.setattr(move_webserver.drum_rack_handler, 'handle_post', fake_post)
     resp = client.post('/drum-rack-inspector', data={'action':'select_preset', 'preset_select':'x'})
     assert resp.status_code == 200
-    assert b'grid' in resp.data
+    assert b'<div>grid</div>' in resp.data
 
 def test_chord_get(client):
     resp = client.get('/chord')


### PR DESCRIPTION
## Summary
- add `core/file_browser.py` for building nested file browser HTML
- integrate file browser into reverse, synth macros and drum rack handlers
- adapt templates to show the new browser and toggle UI
- add small JS helper for collapsing directories
- update routes and styling

## Testing
- `pip install flask mido numpy librosa audiotsm dash`
- `pytest -q` *(fails: ui expectations no longer match)*

------
https://chatgpt.com/codex/tasks/task_e_68415ae90d6083259cd9ec51d41c55bc