### PR TITLE
Document config constants

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,10 +1,23 @@
-# config.py
+"""Configuration constants for Move server paths and allowed ranges.
 
-# Paths and 
+This module centralizes the absolute paths used when working with Move
+sets and samples on the device. It also defines the valid numeric ranges
+accepted from users when restoring a set.  All ranges are inclusive.
+"""
+
+# Path where Move sets are stored.  Each restored set is placed in a
+# unique UUID-named folder beneath this directory.
 MSETS_DIRECTORY = "/data/UserData/UserLibrary/Sets"
+
+# Root directory of the sample library.  When rewriting sample references
+# inside a restored set, paths are redirected here.
 MSET_SAMPLE_PATH = "/data/UserData/UserLibrary/Samples"
+
+# Base URI prefix inserted into Song.abl files to reference set contents.
 MSET_ABLETON_URI = "ableton:/user-library/Sets"
 
-# Allowed ranges for user inputs
-MSET_INDEX_RANGE = (0, 31)  # Slot IDs
-MSET_COLOR_RANGE = (1, 26)  # Color values
+# Inclusive range of valid pad indices (0–31).
+MSET_INDEX_RANGE = (0, 31)
+
+# Inclusive range of valid color IDs used by Move's UI (1–26).
+MSET_COLOR_RANGE = (1, 26)


### PR DESCRIPTION
## Summary
- add a module docstring in `core/config.py`
- clarify what each constant represents

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417bc5fe20832582ceb9de54be6790