### PR TITLE
Add shared MIDI set template loader

### DIFF
--- a/core/midi_pattern_generator.py
+++ b/core/midi_pattern_generator.py
@@ -6,10 +6,7 @@ import os
 import json
 from typing import Dict, List, Any, Tuple, Optional
 
-def load_set_template(template_path: str) -> Dict[str, Any]:
-    """Load a set template from file."""
-    with open(template_path, 'r') as f:
-        return json.load(f)
+from core.utils import load_set_template
 
 def generate_pattern_set(
     set_name: str,

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -4,6 +4,8 @@ import copy
 import mido
 from typing import Dict, List, Any, Optional
 
+from core.utils import load_set_template
+
 def create_set(set_name):
     """
     Create a blank set file in the UserLibrary/Sets directory.
@@ -16,22 +18,6 @@ def create_set(set_name):
         return {'success': True, 'message': f"Set '{set_name}' created successfully", 'path': path}
     except Exception as e:
         return {'success': False, 'message': str(e)}
-
-def load_set_template(template_path: str) -> Dict[str, Any]:
-    """
-    Load a set template from file.
-    
-    Args:
-        template_path: Path to the template .abl file
-        
-    Returns:
-        Dictionary containing the parsed set data
-    """
-    try:
-        with open(template_path, 'r') as f:
-            return json.load(f)
-    except Exception as e:
-        raise Exception(f"Failed to load template: {str(e)}")
 
 def generate_c_major_chord_example(set_name: str, tempo: float = 120.0) -> Dict[str, Any]:
     """

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,12 @@
+import json
+from typing import Any, Dict
+
+
+def load_set_template(template_path: str) -> Dict[str, Any]:
+    """Load a set template from ``template_path`` and return the parsed data."""
+    try:
+        with open(template_path, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        raise Exception(f"Failed to load template: {str(e)}")
+

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -5,7 +5,7 @@ import tempfile
 import shutil
 from core.set_management_handler import (
     create_set, generate_midi_set_from_file, generate_drum_set_from_file,
-    generate_c_major_chord_example, load_set_template
+    generate_c_major_chord_example
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle


### PR DESCRIPTION
## Summary
- centralize `load_set_template` in `core/utils.py`
- import the new utility in `midi_pattern_generator` and `set_management_handler`
- clean up unused import in `SetManagementHandler`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417bb6a3fc8325a7cf66e0d5c77927