### PR TITLE
Fix tests when sets directory is absent

### DIFF
--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -37,6 +37,12 @@ def list_msets(return_free_ids=False):
     msets = []
     used_ids = set()
 
+    if not os.path.isdir(MSETS_DIRECTORY):
+        if return_free_ids:
+            free = list(range(32))
+            return msets, {"used": used_ids, "free": free}
+        return msets
+
     for uuid in os.listdir(MSETS_DIRECTORY):
         uuid_path = os.path.join(MSETS_DIRECTORY, uuid)
         if os.path.isdir(uuid_path):


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError in `list_msets`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68418b6851888325b64082b98ba1a9cb