### PR TITLE
Remove cgi dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Before You Start
 
 **Integration Reminders:**
-- If you use `cgi.FieldStorage` in your handler, ensure you `import cgi` at the top of your file.
+- Use Flask's built-in `request.form` and `request.files` for form data; the server no longer requires the `cgi` module.
 - The legacy server relies on JavaScript form handlers in `static/main.js`. If you add multiple forms per tab you must update that script accordingly.  The new Flask server uses standard HTML forms so no extra JavaScript is required.
 - Tab names/IDs must match exactly between your HTML (`index.html`), JavaScript (`static/main.js`), and route definitions (in your handler classes and webserver routing).
 
@@ -601,6 +601,6 @@ Remember to:
 
 ## Troubleshooting & Common Pitfalls
 
-- **Importing cgi**: If you use `cgi.FieldStorage` in your handler, be sure to `import cgi` at the top of your file.
+- **Using Flask Forms**: Handle form data with `request.form` and `request.files`. The server no longer relies on `cgi`.
 - **Multiple forms per tab**: If your tab contains more than one form, you must update `static/main.js` to attach event listeners to all forms in that tab (see "AJAX Forms and Dynamic Tabs").
 - **Tab name/ID consistency**: The tab name/ID must match exactly between your JS (`static/main.js`), HTML (`index.html`), and route handler code. Mismatches will break AJAX loading or form submission.

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -41,7 +41,12 @@ PID_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "move-webser
 
 
 class SimpleForm(dict):
-    """Simple form wrapper providing ``getvalue`` like ``cgi.FieldStorage``."""
+    """Simple form wrapper with a ``getvalue`` method similar to ``cgi.FieldStorage``.
+
+    The webserver no longer depends on the ``cgi`` module, but some handler code
+    still expects this interface. This lightweight wrapper keeps compatibility
+    without importing ``cgi``.
+    """
 
     def getvalue(self, name, default=None):
         return self.get(name, default)


### PR DESCRIPTION
## Summary
- clarify AGENTS instructions that cgi is no longer required
- document cgi removal in `move-webserver.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68418c9c277c8325a33dd4a577395124