### PR TITLE
Make MIDI pattern generator respect MOVE_SET_DIR

### DIFF
--- a/MIDI_PATTERN_GUIDE.md
+++ b/MIDI_PATTERN_GUIDE.md
@@ -29,6 +29,7 @@ This creates a 4-beat measure with C major triads (C, E, G) on beats 1, 2, 3, an
 For more control, use the pattern generator directly:
 
 ```python
+import os
 from core.midi_pattern_generator import generate_pattern_set
 
 # Define your pattern
@@ -44,7 +45,8 @@ result = generate_pattern_set(
     set_name="My_Pattern",
     pattern=pattern,
     clip_length=4.0,  # 4 beats
-    tempo=120.0
+    tempo=120.0,
+    output_dir=os.environ.get("MOVE_SET_DIR")  # Optional
 )
 ```
 

--- a/core/midi_pattern_generator.py
+++ b/core/midi_pattern_generator.py
@@ -12,7 +12,8 @@ def generate_pattern_set(
     set_name: str,
     pattern: List[Dict[str, Any]],
     clip_length: float = 4.0,
-    tempo: float = 120.0
+    tempo: float = 120.0,
+    output_dir: Optional[str] = None
 ) -> Dict[str, Any]:
     """
     Generate an Ableton Live set with a custom pattern of notes.
@@ -26,6 +27,9 @@ def generate_pattern_set(
             - 'velocity': Optional velocity (1-127, default 100)
         clip_length: Length of the clip in beats (default 4.0)
         tempo: Tempo in BPM (default 120)
+        output_dir: Optional directory to save the generated set. Uses the
+            ``MOVE_SET_DIR`` environment variable or the default Move path if
+            not provided.
         
     Returns:
         Result dictionary with success status and message
@@ -80,7 +84,8 @@ def generate_pattern_set(
         song['tempo'] = tempo
         
         # Save the modified set
-        output_dir = "/data/UserData/UserLibrary/Sets"
+        if output_dir is None:
+            output_dir = os.environ.get("MOVE_SET_DIR", "/data/UserData/UserLibrary/Sets")
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, set_name)
         if not output_path.endswith('.abl'):

--- a/examples/pattern_examples.py
+++ b/examples/pattern_examples.py
@@ -7,6 +7,8 @@ import sys
 import os
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
+OUTPUT_DIR = os.environ.get("MOVE_SET_DIR", "/data/UserData/UserLibrary/Sets")
+
 from core.midi_pattern_generator import (
     generate_pattern_set,
     create_c_major_downbeats,
@@ -26,7 +28,8 @@ def example_1_c_major_chords():
         set_name="C_Major_Downbeats",
         pattern=pattern,
         clip_length=4.0,
-        tempo=120.0
+        tempo=120.0,
+        output_dir=OUTPUT_DIR
     )
     
     if result['success']:
@@ -65,7 +68,8 @@ def example_2_custom_pattern():
         set_name="Chord_Progression",
         pattern=pattern,
         clip_length=4.0,
-        tempo=120.0
+        tempo=120.0,
+        output_dir=OUTPUT_DIR
     )
     
     if result['success']:
@@ -89,7 +93,8 @@ def example_3_scale_pattern():
         set_name="C_Major_Scale",
         pattern=pattern,
         clip_length=4.0,
-        tempo=120.0
+        tempo=120.0,
+        output_dir=OUTPUT_DIR
     )
     
     if result['success']:
@@ -122,7 +127,8 @@ def example_4_rhythm_pattern():
         set_name="Syncopated_Rhythm",
         pattern=pattern,
         clip_length=4.0,
-        tempo=120.0
+        tempo=120.0,
+        output_dir=OUTPUT_DIR
     )
     
     if result['success']:
@@ -160,7 +166,8 @@ def example_5_complex_pattern():
         set_name="Melody_And_Bass",
         pattern=pattern,
         clip_length=4.0,
-        tempo=120.0
+        tempo=120.0,
+        output_dir=OUTPUT_DIR
     )
     
     if result['success']:
@@ -201,7 +208,8 @@ def example_6_longer_clip():
         set_name="Eight_Bar_Pattern",
         pattern=pattern,
         clip_length=32.0,  # 8 bars * 4 beats
-        tempo=120.0
+        tempo=120.0,
+        output_dir=OUTPUT_DIR
     )
     
     if result['success']:
@@ -222,5 +230,5 @@ if __name__ == "__main__":
     example_6_longer_clip()
     
     print("\n✓ All examples completed!")
-    print("\nNote: These examples assume the Move device is connected and")
-    print("the output directory '/data/UserData/UserLibrary/Sets' exists.")
+    print("\nNote: These examples assume the Move device is connected.")
+    print("The output directory is configurable via the MOVE_SET_DIR environment variable.")

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -46,19 +46,10 @@ def test_detect_transients(tmp_path):
     assert regions[0]['start'] <= regions[0]['end']
 
 
-def test_generate_pattern_set(tmp_path, monkeypatch):
+def test_generate_pattern_set(tmp_path):
     pattern = create_c_major_downbeats(1)
 
-    real_join = os.path.join
-
-    def fake_join(a, *rest):
-        if a == "/data/UserData/UserLibrary/Sets":
-            return real_join(tmp_path, *rest)
-        return real_join(a, *rest)
-
-    monkeypatch.setattr(os.path, "join", fake_join)
-
-    result = generate_pattern_set("TestSet", pattern)
+    result = generate_pattern_set("TestSet", pattern, output_dir=str(tmp_path))
     assert result['success'], result.get('message')
     output_path = os.path.join(tmp_path, "TestSet.abl")
     assert os.path.exists(output_path)


### PR DESCRIPTION
## Summary
- allow `generate_pattern_set` to store output in a configurable directory
- update unit test to use the new argument
- document `MOVE_SET_DIR` usage in examples and guide

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418e2733188325a7123f2b60ea3194