### PR TITLE
Prevent clipping in chord generator

### DIFF
--- a/offline-tools/chord.js
+++ b/offline-tools/chord.js
@@ -314,6 +314,17 @@ function mixAudioBuffers(buffers) {
   return mixedBuffer;
 }
 
+function scaleAudioBuffer(buffer, gain) {
+  const numChannels = buffer.numberOfChannels;
+  for (let channel = 0; channel < numChannels; channel++) {
+    const data = buffer.getChannelData(channel);
+    for (let i = 0; i < data.length; i++) {
+      data[i] *= gain;
+    }
+  }
+  return buffer;
+}
+
 function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
   const numChannels = buffer.numberOfChannels;
   let maxVal = 0;
@@ -335,9 +346,11 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
 
 async function processChordSample(buffer, intervals) {
   const pitchedBuffers = [];
+  const perBufferGain = 1 / intervals.length;
   for (let semitone of intervals) {
     const pitched = await pitchShiftOffline(buffer, semitone);
-    pitchedBuffers.push(pitched);
+    const scaled = scaleAudioBuffer(pitched, perBufferGain);
+    pitchedBuffers.push(scaled);
   }
   const mixed = mixAudioBuffers(pitchedBuffers);
   const normalized = normalizeAudioBuffer(mixed, 0.9);

--- a/offline-tools/chord.js
+++ b/offline-tools/chord.js
@@ -325,7 +325,20 @@ function scaleAudioBuffer(buffer, gain) {
   return buffer;
 }
 
-function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
+function getPeakAmplitude(buffer) {
+  let peak = 0;
+  const numChannels = buffer.numberOfChannels;
+  for (let channel = 0; channel < numChannels; channel++) {
+    const data = buffer.getChannelData(channel);
+    for (let i = 0; i < data.length; i++) {
+      const val = Math.abs(data[i]);
+      if (val > peak) peak = val;
+    }
+  }
+  return peak;
+}
+
+function normalizeAudioBuffer(buffer, targetPeak = 0.8) {
   const numChannels = buffer.numberOfChannels;
   let maxVal = 0;
   for (let channel = 0; channel < numChannels; channel++) {
@@ -345,15 +358,21 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
 }
 
 async function processChordSample(buffer, intervals) {
-  const pitchedBuffers = [];
-  const perBufferGain = 1 / intervals.length;
+  const pitched = [];
+  const peaks = [];
   for (let semitone of intervals) {
-    const pitched = await pitchShiftOffline(buffer, semitone);
-    const scaled = scaleAudioBuffer(pitched, perBufferGain);
-    pitchedBuffers.push(scaled);
+    const shifted = await pitchShiftOffline(buffer, semitone);
+    peaks.push(getPeakAmplitude(shifted));
+    pitched.push(shifted);
   }
-  const mixed = mixAudioBuffers(pitchedBuffers);
-  const normalized = normalizeAudioBuffer(mixed, 0.9);
+
+  const perBufferGain = 1 / intervals.length;
+  const predictedPeak = peaks.reduce((sum, p) => sum + p * perBufferGain, 0);
+  const masterGain = predictedPeak > 0 ? 0.8 / predictedPeak : 1;
+
+  const scaledBuffers = pitched.map(b => scaleAudioBuffer(b, perBufferGain * masterGain));
+  const mixed = mixAudioBuffers(scaledBuffers);
+  const normalized = normalizeAudioBuffer(mixed, 0.8);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });
 }

--- a/static/chord.js
+++ b/static/chord.js
@@ -330,6 +330,17 @@ function mixAudioBuffers(buffers) {
   return mixedBuffer;
 }
 
+function scaleAudioBuffer(buffer, gain) {
+  const numChannels = buffer.numberOfChannels;
+  for (let channel = 0; channel < numChannels; channel++) {
+    const data = buffer.getChannelData(channel);
+    for (let i = 0; i < data.length; i++) {
+      data[i] *= gain;
+    }
+  }
+  return buffer;
+}
+
 function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
   const numChannels = buffer.numberOfChannels;
   let maxVal = 0;
@@ -351,9 +362,11 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
 
 async function processChordSample(buffer, intervals) {
   const pitchedBuffers = [];
+  const perBufferGain = 1 / intervals.length;
   for (let semitone of intervals) {
     const pitched = await pitchShiftOffline(buffer, semitone);
-    pitchedBuffers.push(pitched);
+    const scaled = scaleAudioBuffer(pitched, perBufferGain);
+    pitchedBuffers.push(scaled);
   }
   const mixed = mixAudioBuffers(pitchedBuffers);
   const normalized = normalizeAudioBuffer(mixed, 0.9);

--- a/static/chord.js
+++ b/static/chord.js
@@ -375,20 +375,18 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.8) {
 
 async function processChordSample(buffer, intervals) {
   const pitched = [];
-  const peaks = [];
   for (let semitone of intervals) {
     const shifted = await pitchShiftOffline(buffer, semitone);
-    peaks.push(getPeakAmplitude(shifted));
     pitched.push(shifted);
   }
 
   const perBufferGain = 1 / intervals.length;
-  const predictedPeak = peaks.reduce((sum, p) => sum + p * perBufferGain, 0);
-  const masterGain = predictedPeak > 0 ? 0.8 / predictedPeak : 1;
+  const scaled = pitched.map(b => scaleAudioBuffer(b, perBufferGain));
+  const mixed = mixAudioBuffers(scaled);
+  const mixPeak = getPeakAmplitude(mixed);
+  const masterGain = mixPeak > 0 ? 0.8 / mixPeak : 1;
 
-  const scaledBuffers = pitched.map(b => scaleAudioBuffer(b, perBufferGain * masterGain));
-  const mixed = mixAudioBuffers(scaledBuffers);
-  const normalized = normalizeAudioBuffer(mixed, 0.8);
+  const normalized = normalizeAudioBuffer(scaleAudioBuffer(mixed, masterGain), 0.8);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });
 }


### PR DESCRIPTION
## Summary
- avoid clipping by scaling each pitched buffer before mixing
- update offline and client chord generators

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841ac1e95348325876b06478d66fdf0