### PR TITLE
Add keyboard playback to drum & chord grids

### DIFF
--- a/static/chord.js
+++ b/static/chord.js
@@ -47,6 +47,16 @@ for (let i = 0; i < keys.length; i++) {
 }
 // --- End of new CHORDS generation code
 
+// Map keyboard keys to pad numbers for playback
+const chordKeyMap = {
+  '1': 13, '2': 14, '3': 15, '4': 16,
+  'q': 9,  'w': 10, 'e': 11, 'r': 12,
+  'a': 5,  's': 6,  'd': 7,  'f': 8,
+  'z': 1,  'x': 2,  'c': 3,  'v': 4
+};
+
+let chordKeyHandler = null;
+
 if (!window.selectedChords) {
     const defaultChords = [
         "Cm9",
@@ -137,6 +147,30 @@ function populateChordList() {
           regenerateChordPreview(padNumber);
       }
   }
+}
+
+function playChordPad(padNumber) {
+  if (window.chordWaveforms && window.chordWaveforms[padNumber - 1]) {
+    const ws = window.chordWaveforms[padNumber - 1];
+    window.chordWaveforms.forEach(inst => { if (inst && inst.isPlaying()) inst.stop(); });
+    ws.stop();
+    ws.seekTo(0);
+    requestAnimationFrame(() => ws.play(0));
+  }
+}
+
+function attachChordKeyHandler() {
+  if (chordKeyHandler) {
+    document.removeEventListener('keydown', chordKeyHandler);
+  }
+  chordKeyHandler = function(e) {
+    const pad = chordKeyMap[e.key.toLowerCase()];
+    if (pad) {
+      e.preventDefault();
+      playChordPad(pad);
+    }
+  };
+  document.addEventListener('keydown', chordKeyHandler);
 }
 
 
@@ -606,5 +640,6 @@ function initChordTab() {
   }
   
   populateChordList();
+  attachChordKeyHandler();
 }
 

--- a/static/drum_rack.js
+++ b/static/drum_rack.js
@@ -1,5 +1,15 @@
 let drumRackWaveforms = [];
 
+// Map keyboard keys to drum pad numbers
+const drumKeyMap = {
+    '1': 13, '2': 14, '3': 15, '4': 16,
+    'q': 9,  'w': 10, 'e': 11, 'r': 12,
+    'a': 5,  's': 6,  'd': 7,  'f': 8,
+    'z': 1,  'x': 2,  'c': 3,  'v': 4
+};
+
+let drumKeyHandler = null;
+
 function initializeDrumRackWaveforms() {
     drumRackWaveforms.forEach(ws => {
         try { ws.destroy(); } catch (e) { console.error('destroy error', e); }
@@ -58,6 +68,31 @@ function initializeDrumRackWaveforms() {
     });
 }
 
+function playDrumPad(padNumber) {
+    const container = document.getElementById(`waveform-${padNumber}`);
+    if (container && container.wavesurfer) {
+        drumRackWaveforms.forEach(other => { if (other.isPlaying()) other.stop(); });
+        const ws = container.wavesurfer;
+        ws.stop();
+        ws.seekTo(0);
+        requestAnimationFrame(() => ws.play(0));
+    }
+}
+
+function attachDrumRackKeyHandler() {
+    if (drumKeyHandler) {
+        document.removeEventListener('keydown', drumKeyHandler);
+    }
+    drumKeyHandler = function(e) {
+        const pad = drumKeyMap[e.key.toLowerCase()];
+        if (pad) {
+            e.preventDefault();
+            playDrumPad(pad);
+        }
+    };
+    document.addEventListener('keydown', drumKeyHandler);
+}
+
 function initializeTimeStretchModal() {
     const modal = document.getElementById('timeStretchModal');
     if (!modal) return;
@@ -89,6 +124,7 @@ function initializeTimeStretchModal() {
 function initDrumRackTab() {
     initializeDrumRackWaveforms();
     initializeTimeStretchModal();
+    attachDrumRackKeyHandler();
 }
 
 export { initDrumRackTab };


### PR DESCRIPTION
## Summary
- enable keyboard triggers for drum rack pads
- add similar keyboard playback for chord preview grid

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b6eb3ba08325a7d8de64e753d0d1