### PR TITLE
Fix silence at start of chord timestretch

### DIFF
--- a/offline-tools/chord.js
+++ b/offline-tools/chord.js
@@ -420,10 +420,12 @@ async function processChordSample(buffer, intervals, keepLength = false) {
     pitched = trimLeadingSilence(pitched);
     if (keepLength) {
       pitched = await soundtouchStretch(pitched, buffer.length);
+      pitched = trimLeadingSilence(pitched);
     }
     pitchedBuffers.push(pitched);
   }
-  const mixed = mixAudioBuffers(pitchedBuffers);
+  let mixed = mixAudioBuffers(pitchedBuffers);
+  mixed = trimLeadingSilence(mixed);
   const normalized = normalizeAudioBuffer(mixed, 0.9);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });

--- a/static/chord.js
+++ b/static/chord.js
@@ -465,21 +465,23 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
   return buffer;
 }
 
-async function processChordSample(buffer, intervals, keepLength = false) {
+  async function processChordSample(buffer, intervals, keepLength = false) {
   const pitchedBuffers = [];
   for (let semitone of intervals) {
     let pitched = await pitchShiftOffline(buffer, semitone);
     pitched = trimLeadingSilence(pitched);
     if (keepLength) {
       pitched = await soundtouchStretch(pitched, buffer.length);
+      pitched = trimLeadingSilence(pitched);
     }
     pitchedBuffers.push(pitched);
   }
-  const mixed = mixAudioBuffers(pitchedBuffers);
+  let mixed = mixAudioBuffers(pitchedBuffers);
+  mixed = trimLeadingSilence(mixed);
   const normalized = normalizeAudioBuffer(mixed, 0.9);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });
-}
+  }
 
 function showChordMessage(text, type = 'info') {
   const msgEl = document.getElementById('chord-message');


### PR DESCRIPTION
## Summary
- trim any silence introduced when stretching chord samples
- trim silence again after mixing to keep previews tight

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841d8fec1288325b4fa5c3de986a3a5