### PR TITLE
Fix chord sample length

### DIFF
--- a/offline-tools/chord.js
+++ b/offline-tools/chord.js
@@ -420,12 +420,16 @@ async function processChordSample(buffer, intervals, keepLength = false) {
     pitched = trimLeadingSilence(pitched);
     if (keepLength) {
       pitched = await soundtouchStretch(pitched, buffer.length);
+      // Do not trim again so we keep the stretched length
+    } else {
       pitched = trimLeadingSilence(pitched);
     }
     pitchedBuffers.push(pitched);
   }
   let mixed = mixAudioBuffers(pitchedBuffers);
-  mixed = trimLeadingSilence(mixed);
+  if (!keepLength) {
+    mixed = trimLeadingSilence(mixed);
+  }
   const normalized = normalizeAudioBuffer(mixed, 0.9);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });

--- a/static/chord.js
+++ b/static/chord.js
@@ -472,12 +472,16 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
     pitched = trimLeadingSilence(pitched);
     if (keepLength) {
       pitched = await soundtouchStretch(pitched, buffer.length);
+      // Avoid trimming again so the stretched length is preserved
+    } else {
       pitched = trimLeadingSilence(pitched);
     }
     pitchedBuffers.push(pitched);
   }
   let mixed = mixAudioBuffers(pitchedBuffers);
-  mixed = trimLeadingSilence(mixed);
+  if (!keepLength) {
+    mixed = trimLeadingSilence(mixed);
+  }
   const normalized = normalizeAudioBuffer(mixed, 0.9);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });


### PR DESCRIPTION
## Summary
- ensure chord generation keeps stretched length

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_6841e09e138c8325944bf474a67e0078