### PR TITLE
Fix chord sample length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /uploads
 /midi-env
 *server.log
+node_modules

--- a/offline-tools/chord.html
+++ b/offline-tools/chord.html
@@ -28,6 +28,7 @@
     <label for="presetName">Preset Name (optional): </label>
     <input type="text" id="presetName" placeholder="Preset name"><br>
     <label><input type="checkbox" id="stretchOption"> Keep original length (SoundTouch)</label><br>
+    <label><input type="checkbox" id="trimOption" checked> Trim leading silence</label><br>
     <button id="generatePreset">Download Preset</button>
     <div id="loadingIndicator" style="display:none; margin-top:10px;">
       Generating bundle... <span id="progressPercent">0%</span>

--- a/static/chord.js
+++ b/static/chord.js
@@ -229,8 +229,6 @@ async function regenerateChordPreview(padNumber) {
     const intervals = getChordIntervals(selectedChord, inversion, octave);
     const keepLen = document.getElementById('stretchOption')?.checked;
     const trimSilence = document.getElementById('trimOption')?.checked;
-    const trimSilence = document.getElementById('trimOption')?.checked;
-    const trimSilence = document.getElementById('trimOption')?.checked;
     const blob = await processChordSample(window.decodedBuffer, intervals, keepLen, trimSilence);
     const url = URL.createObjectURL(blob);
     const previewContainer = document.getElementById(`chord-preview-${padNumber}`);

--- a/static/chord.js
+++ b/static/chord.js
@@ -228,7 +228,10 @@ async function regenerateChordPreview(padNumber) {
     const octave = window.selectedOctaves[padNumber - 1] || 0;
     const intervals = getChordIntervals(selectedChord, inversion, octave);
     const keepLen = document.getElementById('stretchOption')?.checked;
-    const blob = await processChordSample(window.decodedBuffer, intervals, keepLen);
+    const trimSilence = document.getElementById('trimOption')?.checked;
+    const trimSilence = document.getElementById('trimOption')?.checked;
+    const trimSilence = document.getElementById('trimOption')?.checked;
+    const blob = await processChordSample(window.decodedBuffer, intervals, keepLen, trimSilence);
     const url = URL.createObjectURL(blob);
     const previewContainer = document.getElementById(`chord-preview-${padNumber}`);
     if (previewContainer) {
@@ -465,19 +468,24 @@ function normalizeAudioBuffer(buffer, targetPeak = 0.9) {
   return buffer;
 }
 
-  async function processChordSample(buffer, intervals, keepLength = false) {
+  async function processChordSample(buffer, intervals, keepLength = false, trimSilence = true) {
   const pitchedBuffers = [];
   for (let semitone of intervals) {
     let pitched = await pitchShiftOffline(buffer, semitone);
-    pitched = trimLeadingSilence(pitched);
+    if (trimSilence) {
+      pitched = trimLeadingSilence(pitched);
+    }
     if (keepLength) {
       pitched = await soundtouchStretch(pitched, buffer.length);
+    } else if (trimSilence) {
       pitched = trimLeadingSilence(pitched);
     }
     pitchedBuffers.push(pitched);
   }
   let mixed = mixAudioBuffers(pitchedBuffers);
-  mixed = trimLeadingSilence(mixed);
+  if (!keepLength && trimSilence) {
+    mixed = trimLeadingSilence(mixed);
+  }
   const normalized = normalizeAudioBuffer(mixed, 0.9);
   const wavData = toWav(normalized);
   return new Blob([new DataView(wavData)], { type: 'audio/wav' });
@@ -527,7 +535,7 @@ function initChordTab() {
         window.selectedVoicings[i] || 0,
         window.selectedOctaves[i] || 0
       );
-      const blob = await processChordSample(decodedBuffer, intervals, keepLen);
+      const blob = await processChordSample(decodedBuffer, intervals, keepLen, trimSilence);
       let safeChordName = chordName.replace(/\s+/g, '');
       let filename = `${baseName}_chord_${safeChordName}.wav`;
       sampleFilenames.push(filename);
@@ -600,7 +608,7 @@ function initChordTab() {
         window.selectedVoicings[i] || 0,
         window.selectedOctaves[i] || 0
       );
-      const blob = await processChordSample(decodedBuffer, intervals, keepLen);
+      const blob = await processChordSample(decodedBuffer, intervals, keepLen, trimSilence);
       let safeChordName = chordName.replace(/\s+/g, '');
       let filename = `${baseName}_chord_${safeChordName}.wav`;
       sampleFilenames.push(filename);
@@ -698,6 +706,7 @@ function initChordTab() {
       
       // Process each chord sample and create its waveform preview sequentially
       const keepLen = document.getElementById('stretchOption')?.checked;
+      const trimSilence = document.getElementById('trimOption')?.checked;
       for (let i = 0; i < chordNames.length; i++) {
           const chordName = chordNames[i];
           console.log("Processing chord:", chordName);
@@ -706,7 +715,7 @@ function initChordTab() {
               window.selectedVoicings[i] || 0,
               window.selectedOctaves[i] || 0
           );
-          const blob = await processChordSample(decodedBuffer, intervals, keepLen);
+          const blob = await processChordSample(decodedBuffer, intervals, keepLen, trimSilence);
           const url = URL.createObjectURL(blob);
           const padNumber = i + 1;  // Adjust this if your grid order differs
           const previewContainer = document.getElementById(`chord-preview-${padNumber}`);
@@ -750,6 +759,17 @@ function initChordTab() {
   const stretchOption = document.getElementById('stretchOption');
   if (stretchOption) {
     stretchOption.addEventListener('change', () => {
+      if (!window.decodedBuffer) return;
+      for (let pad = 1; pad <= 16; pad++) {
+        if (window.selectedChords[pad - 1]) {
+          regenerateChordPreview(pad);
+        }
+      }
+    });
+  }
+  const trimOption = document.getElementById('trimOption');
+  if (trimOption) {
+    trimOption.addEventListener('change', () => {
       if (!window.decodedBuffer) return;
       for (let pad = 1; pad <= 16; pad++) {
         if (window.selectedChords[pad - 1]) {

--- a/templates_jinja/chord.html
+++ b/templates_jinja/chord.html
@@ -6,6 +6,7 @@
 <label for="presetName">Preset Name (optional): </label>
 <input type="text" id="presetName" placeholder="Preset name"><br>
 <label><input type="checkbox" id="stretchOption"> Keep original length (SoundTouch)</label><br>
+<label><input type="checkbox" id="trimOption" checked> Trim leading silence</label><br>
 <button id="generatePreset">Download .ablpresetbundle</button>
 <button id="placePreset">Save Preset directly on Move</button>
 <div id="loadingIndicator" style="display:none; margin-top:10px;">

--- a/tests/test_chord_audio.py
+++ b/tests/test_chord_audio.py
@@ -15,6 +15,12 @@ def active_duration(y, sr, threshold=1e-4):
         return 0.0
     return (idx[-1] - idx[0]) / sr
 
+def active_bounds(y, sr, threshold=1e-4):
+    idx = np.where(np.abs(y) > threshold)[0]
+    if len(idx) == 0:
+        return 0.0, 0.0
+    return idx[0] / sr, idx[-1] / sr
+
 def generate_chord(y, sr, intervals):
     buffers = []
     for semitone in intervals:
@@ -33,7 +39,11 @@ def test_examples_have_equal_length():
     for p in paths:
         y, sr = load_mono(p)
         orig_dur = active_duration(y, sr)
+        orig_start, orig_end = active_bounds(y, sr)
         chord = generate_chord(y, sr, intervals)
         assert len(chord) == len(y)
         chord_dur = active_duration(chord, sr)
+        chord_start, chord_end = active_bounds(chord, sr)
         assert abs(chord_dur - orig_dur) < 0.01
+        assert abs(chord_start - orig_start) < 0.01
+        assert abs(chord_end - orig_end) < 0.01

--- a/tests/test_chord_audio.py
+++ b/tests/test_chord_audio.py
@@ -1,0 +1,39 @@
+import os
+import numpy as np
+import soundfile as sf
+import librosa
+
+def load_mono(path):
+    data, sr = sf.read(path, dtype='float32')
+    if data.ndim > 1:
+        data = np.mean(data, axis=1)
+    return data, sr
+
+def active_duration(y, sr, threshold=1e-4):
+    idx = np.where(np.abs(y) > threshold)[0]
+    if len(idx) == 0:
+        return 0.0
+    return (idx[-1] - idx[0]) / sr
+
+def generate_chord(y, sr, intervals):
+    buffers = []
+    for semitone in intervals:
+        shifted = librosa.effects.pitch_shift(y, sr=sr, n_steps=semitone)
+        shifted = librosa.util.fix_length(shifted, size=len(y))
+        buffers.append(shifted)
+    mix = np.sum(buffers, axis=0) / len(buffers)
+    return mix
+
+def test_examples_have_equal_length():
+    paths = [
+        'examples/Samples/010 Pizz Str.wav',
+        'examples/Samples/organ.wav',
+    ]
+    intervals = [0, 4, 7]
+    for p in paths:
+        y, sr = load_mono(p)
+        orig_dur = active_duration(y, sr)
+        chord = generate_chord(y, sr, intervals)
+        assert len(chord) == len(y)
+        chord_dur = active_duration(chord, sr)
+        assert abs(chord_dur - orig_dur) < 0.01

--- a/tests/test_chord_js.js
+++ b/tests/test_chord_js.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+async function runProcessChordSample(file, keepLength, trimSilence = true) {
+  const code = fs.readFileSync(file, 'utf8');
+  const match = code.match(/async function processChordSample[\s\S]*?\n}\n/);
+  if (!match) throw new Error('function not found');
+  const context = {
+    pitchShiftOffline: async (buf, semitone) => ({ length: buf.length }),
+    trimLeadingSilence: buf => ({ length: buf.length - 1 }),
+    soundtouchStretch: async (buf, len) => ({ length: len }),
+    mixAudioBuffers: buffers => {
+      context.mixedLen = Math.max(...buffers.map(b => b.length));
+      return { length: context.mixedLen };
+    },
+    normalizeAudioBuffer: buf => buf,
+    toWav: buf => new ArrayBuffer(buf.length || 0),
+    Blob: function(arr, opt) {},
+  };
+  vm.createContext(context);
+  vm.runInContext(match[0], context);
+  await context.processChordSample({ length: 10 }, [0], keepLength, trimSilence);
+  return context.mixedLen;
+}
+
+(async () => {
+  assert.strictEqual(await runProcessChordSample('offline-tools/chord.js', true), 10);
+  assert.strictEqual(await runProcessChordSample('static/chord.js', true), 10);
+  assert.strictEqual(await runProcessChordSample('offline-tools/chord.js', false), 8);
+  assert.strictEqual(await runProcessChordSample('static/chord.js', false), 8);
+  assert.strictEqual(await runProcessChordSample('offline-tools/chord.js', false, false), 10);
+  assert.strictEqual(await runProcessChordSample('static/chord.js', false, false), 10);
+  console.log('All chord.js tests passed');
+})();


### PR DESCRIPTION
## Summary
- ensure chord generation keeps stretched length
- add Node-based regression tests for chord.js files
- make silence trimming optional to help debug short chords

## Testing
- `pytest -q`
- `node tests/test_chord_js.js`


------
https://chatgpt.com/codex/tasks/task_e_6841e09e138c8325944bf474a67e0078