### PR TITLE
Disable chord key play while editing text

### DIFF
--- a/static/chord.js
+++ b/static/chord.js
@@ -211,6 +211,11 @@ function attachChordKeyHandler() {
     document.removeEventListener('keydown', chordKeyHandler);
   }
   chordKeyHandler = function(e) {
+    // Ignore key events while typing in input fields or editable elements
+    const tag = (e.target && e.target.tagName) ? e.target.tagName.toUpperCase() : '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) {
+      return;
+    }
     const pad = chordKeyMap[e.key.toLowerCase()];
     if (pad) {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- don't play chord sounds when keys are typed inside input fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f69d9b8883258b490202a1d8d557