### PR TITLE
Improve color dropdown previews

### DIFF
--- a/core/pad_colors.py
+++ b/core/pad_colors.py
@@ -26,8 +26,41 @@ PAD_COLORS = {
     25: (217, 43, 255),
 }
 
+# CSS-style names for each pad color based on nearest match
+PAD_COLOR_NAMES = {
+    1: "red",
+    2: "darkorange",
+    3: "orangered",
+    4: "lightsalmon",
+    5: "chocolate",
+    6: "tan",
+    7: "khaki",
+    8: "palegreen",
+    9: "lightgreen",
+    10: "limegreen",
+    11: "yellowgreen",
+    12: "aquamarine",
+    13: "darkturquoise",
+    14: "darkturquoise",
+    15: "lightseagreen",
+    16: "steelblue",
+    17: "darkcyan",
+    18: "darkslateblue",
+    19: "darkcyan",
+    20: "darkslateblue",
+    21: "darkslateblue",
+    22: "slateblue",
+    23: "darkorchid",
+    24: "crimson",
+    25: "fuchsia",
+}
+
 def rgb_string(color_id):
     rgb = PAD_COLORS.get(color_id)
     if rgb:
         return f"rgb({rgb[0]}, {rgb[1]}, {rgb[2]})"
     return ""
+
+def color_name(color_id):
+    """Return a CSS-style color name for the given pad color ID."""
+    return PAD_COLOR_NAMES.get(color_id, "")

--- a/handlers/restore_handler_class.py
+++ b/handlers/restore_handler_class.py
@@ -3,7 +3,7 @@ import logging
 from handlers.base_handler import BaseHandler
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
-from core.pad_colors import PAD_COLORS, rgb_string
+from core.pad_colors import PAD_COLORS, rgb_string, color_name
 
 class RestoreHandler(BaseHandler):
     """
@@ -178,10 +178,12 @@ class RestoreHandler(BaseHandler):
         return '<div class="pad-grid">' + ''.join(cells) + '</div>'
 
     def generate_color_options(self):
+        """Generate HTML <option> elements for pad colors with previews."""
         options = ['<option value="" disabled selected>-- Select Color --</option>']
         for i in range(1, 26):
             rgb = rgb_string(i)
+            name = color_name(i)
             options.append(
-                f'<option value="{i}" style="background-color: {rgb};">&#9632; {i}</option>'
+                f'<option value="{i}" style="color: {rgb};">&#9632; {name}</option>'
             )
         return ''.join(options)

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -10,7 +10,7 @@ from core.set_management_handler import (
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
-from core.pad_colors import PAD_COLORS, rgb_string
+from core.pad_colors import PAD_COLORS, rgb_string, color_name
 import json
 
 logger = logging.getLogger(__name__)
@@ -214,10 +214,12 @@ class SetManagementHandler(BaseHandler):
         return '<div class="pad-grid">' + ''.join(cells) + '</div>'
 
     def generate_color_options(self):
+        """Generate HTML <option> elements for pad colors with previews."""
         options = ['<option value="" disabled selected>-- Select Color --</option>']
         for i in range(1, 26):
             rgb = rgb_string(i)
+            name = color_name(i)
             options.append(
-                f'<option value="{i}" style="background-color: {rgb};">&#9632; {i}</option>'
+                f'<option value="{i}" style="color: {rgb};">&#9632; {name}</option>'
             )
         return ''.join(options)


### PR DESCRIPTION
## Summary
- map pad colors to human-readable names
- show colored options in restore and set management pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a499fcc4832585dcdb7e5eb0e786