### PR TITLE
Add drum rack revert to original sample

### DIFF
--- a/core/drum_rack_inspector_handler.py
+++ b/core/drum_rack_inspector_handler.py
@@ -231,3 +231,36 @@ def scan_for_drum_rack_presets():
             "message": f"Error scanning presets: {e}",
             "presets": [],
         }
+
+
+def find_original_sample(sample_path):
+    """Try to locate the base sample by stripping transformation suffixes."""
+    directory = os.path.dirname(sample_path)
+    filename = os.path.basename(sample_path)
+    base, ext = os.path.splitext(filename)
+
+    candidate = None
+    current = base
+
+    while True:
+        possible = os.path.join(directory, current + ext)
+        if os.path.exists(possible):
+            candidate = possible
+
+        new = current
+        if new.endswith('_reversed'):
+            new = new[:-9]
+        elif new.endswith('_reverse'):
+            new = new[:-8]
+        else:
+            import re
+            m = re.search(r'-slice\d+-(?:stretched|repitched)-[\d.]+-[\d.]+$', new)
+            if m:
+                new = new[:m.start()]
+            else:
+                break
+        if new == current:
+            break
+        current = new
+
+    return candidate

--- a/handlers/drum_rack_inspector_handler_class.py
+++ b/handlers/drum_rack_inspector_handler_class.py
@@ -127,7 +127,17 @@ class DrumRackInspectorHandler(BaseHandler):
                               <svg fill="none" viewBox="0 0 20 18" height="18" width="20" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M10 12.2892V0M10 12.2892L14.6667 8.19277M10 12.2892L5.33333 8.19277M17 17H3" stroke="currentColor" stroke-width="1.5"/>
                               </svg>
-                            </a>
+                            </a>'''
+                    original = find_original_sample(sample['path'])
+                    if original and original != sample['path']:
+                        cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
+                                    <input type="hidden" name="action" value="revert_sample">
+                                    <input type="hidden" name="sample_path" value="{sample['path']}">
+                                    <input type="hidden" name="preset_path" value="{preset_path}">
+                                    <input type="hidden" name="pad_number" value="{pad_num}">
+                                    <button type="submit" class="revert-button" title="Revert to original sample">🔙</button>
+                                  </form>'''
+                    cell += '''
                           </div>
                           <div class="sample-actions">'''
                     cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
@@ -138,19 +148,6 @@ class DrumRackInspectorHandler(BaseHandler):
                                 <button type="submit" class="reverse-button">Reverse</button>
                               </form>'''
                     cell += f'''<button type="button" class="time-stretch-button" data-sample-path="{sample['path']}" data-preset-path="{preset_path}" data-pad-number="{pad_num}" onclick="var modal = document.getElementById('timeStretchModal'); document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path'); document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path'); document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number'); modal.classList.remove('hidden');">Time Stretch</button>'''
-                    original = find_original_sample(sample['path'])
-                    if original and original != sample['path']:
-                        cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
-                                    <input type="hidden" name="action" value="revert_sample">
-                                    <input type="hidden" name="sample_path" value="{sample['path']}">
-                                    <input type="hidden" name="preset_path" value="{preset_path}">
-                                    <input type="hidden" name="pad_number" value="{pad_num}">
-                                    <button type="submit" class="revert-button" title="Revert to original sample">
-                                      <svg viewBox="0 0 20 18" height="18" width="20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M3 9H17M3 9L7 5M3 9L7 13" stroke="currentColor" stroke-width="1.5"/>
-                                      </svg>
-                                    </button>
-                                  </form>'''
                     cell += '</div></div>'
                 elif sample:
                     cell += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>No sample</span></div>'

--- a/handlers/drum_rack_inspector_handler_class.py
+++ b/handlers/drum_rack_inspector_handler_class.py
@@ -4,7 +4,11 @@ import urllib.parse
 import logging
 from core.file_browser import generate_dir_html
 from handlers.base_handler import BaseHandler
-from core.drum_rack_inspector_handler import get_drum_cell_samples, update_drum_cell_sample
+from core.drum_rack_inspector_handler import (
+    get_drum_cell_samples,
+    update_drum_cell_sample,
+    find_original_sample,
+)
 from core.reverse_handler import reverse_wav_file
 from core.refresh_handler import refresh_library
 from core.time_stretch_handler import time_stretch_wav
@@ -45,6 +49,8 @@ class DrumRackInspectorHandler(BaseHandler):
             return self.handle_reverse_sample(form)
         if action == 'time_stretch_sample':
             return self.handle_time_stretch_sample(form)
+        if action == 'revert_sample':
+            return self.handle_revert_sample(form)
         # Validate preset selection action
         valid, error_response = self.validate_action(form, "select_preset")
         if not valid:
@@ -61,86 +67,7 @@ class DrumRackInspectorHandler(BaseHandler):
                 return self.format_error_response(result['message'])
 
             logger.debug("Found samples: %s", result['samples'])
-            logger.debug("Processing samples for display:")
-            # Create a grid container
-            samples_html = '<div class="drum-grid">'
-
-            # Sort samples by pad number and create a 16-element list (some pads might be empty)
-            grid_samples = [None] * 16
-            for sample in result['samples']:
-                pad_num = int(sample['pad'])
-                if 1 <= pad_num <= 16:
-                    grid_samples[pad_num - 1] = sample
-
-            # Generate grid cells in reverse row order (bottom to top)
-            for row in range(3, -1, -1):  # 3,2,1,0 for the four rows
-                samples_html += '<div class="drum-grid-row">'
-                for col in range(4):  # 0,1,2,3 for the four columns
-                    pad_index = row * 4 + col  # Calculate index in grid_samples
-                    pad_num = pad_index + 1  # Actual pad number (1-16)
-
-                    sample = grid_samples[pad_index]
-                    cell_html = '<div class="drum-cell">'
-
-                    if sample:
-                        logger.debug("Sample: %s", sample)
-                        if sample.get('path') and sample['path'].startswith('/data/UserData/UserLibrary/Samples/'):
-                            web_path = '/samples/' + sample['path'].replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
-                            web_path = urllib.parse.quote(web_path)
-                            waveform_id = f'waveform-{pad_num}'
-                            # Add new data-playback-start and data-playback-length attributes
-                            cell_html += f'''
-                                <div class="pad-info">
-                                    <span class="pad-number">Pad {pad_num}</span>
-                                </div>
-                                <div id="{waveform_id}" class="waveform-container"
-                                     data-audio-path="{web_path}"
-                                     data-playback-start="{sample.get('playback_start', 0.0)}"
-                                     data-playback-length="{sample.get('playback_length', 1.0)}"></div>
-                                <div class="sample-info">
-                                    <div class="sample-header">
-                                        <span class="sample-name">{sample["sample"]}</span>
-                                        <a href="{web_path}" target="_blank" class="download-link" aria-label="Download">
-                                            <svg fill="none" viewBox="0 0 20 18" height="18" width="20" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M10 12.2892V0M10 12.2892L14.6667 8.19277M10 12.2892L5.33333 8.19277M17 17H3" stroke="currentColor" stroke-width="1.5"/>
-                                            </svg>
-                                        </a>
-                                    </div>
-                                    <div class="sample-actions">
-                                        <form method="POST" action="/drum-rack-inspector" style="display: inline;">
-                                            <input type="hidden" name="action" value="reverse_sample">
-                                            <input type="hidden" name="sample_path" value="{sample['path']}">
-                                            <input type="hidden" name="preset_path" value="{preset_path}">
-                                            <input type="hidden" name="pad_number" value="{pad_num}">
-                                            <button type="submit" class="reverse-button">Reverse</button>
-                                        </form>
-                                        <button type="button" class="time-stretch-button"
-                                            data-sample-path="{sample['path']}"
-                                            data-preset-path="{preset_path}"
-                                            data-pad-number="{pad_num}"
-                                            onclick="
-                                              var modal = document.getElementById('timeStretchModal');
-                                              document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path');
-                                              document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path');
-                                              document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number');
-                                              modal.classList.remove('hidden');
-                                            ">
-                                            Time Stretch
-                                        </button>
-                                    </div>
-                                </div>
-                            '''
-                        else:
-                            cell_html += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>No sample</span></div>'
-                    else:
-                        cell_html += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>Empty</span></div>'
-
-                    cell_html += '</div>'
-                    samples_html += cell_html
-
-                samples_html += '</div>'
-
-            samples_html += '</div>'
+            samples_html = self.generate_samples_html(result['samples'], preset_path)
 
             base_dir = "/data/UserData/UserLibrary/Track Presets"
             if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
@@ -170,6 +97,70 @@ class DrumRackInspectorHandler(BaseHandler):
     def get_preset_options(self):
         """Deprecated dropdown helper."""
         return ''
+
+    def generate_samples_html(self, samples, preset_path):
+        """Build the drum pad grid HTML."""
+        html = '<div class="drum-grid">'
+        grid = [None] * 16
+        for s in samples:
+            idx = int(s['pad'])
+            if 1 <= idx <= 16:
+                grid[idx - 1] = s
+
+        for row in range(3, -1, -1):
+            html += '<div class="drum-grid-row">'
+            for col in range(4):
+                pad_index = row * 4 + col
+                pad_num = pad_index + 1
+                sample = grid[pad_index]
+                cell = '<div class="drum-cell">'
+                if sample and sample.get('path') and sample['path'].startswith('/data/UserData/UserLibrary/Samples/'):
+                    web_path = '/samples/' + sample['path'].replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
+                    web_path = urllib.parse.quote(web_path)
+                    wf_id = f'waveform-{pad_num}'
+                    cell += f'''<div class="pad-info"><span class="pad-number">Pad {pad_num}</span></div>
+                        <div id="{wf_id}" class="waveform-container" data-audio-path="{web_path}" data-playback-start="{sample.get('playback_start', 0.0)}" data-playback-length="{sample.get('playback_length', 1.0)}"></div>
+                        <div class="sample-info">
+                          <div class="sample-header">
+                            <span class="sample-name">{sample['sample']}</span>
+                            <a href="{web_path}" target="_blank" class="download-link" aria-label="Download">
+                              <svg fill="none" viewBox="0 0 20 18" height="18" width="20" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M10 12.2892V0M10 12.2892L14.6667 8.19277M10 12.2892L5.33333 8.19277M17 17H3" stroke="currentColor" stroke-width="1.5"/>
+                              </svg>
+                            </a>
+                          </div>
+                          <div class="sample-actions">'''
+                    cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
+                                <input type="hidden" name="action" value="reverse_sample">
+                                <input type="hidden" name="sample_path" value="{sample['path']}">
+                                <input type="hidden" name="preset_path" value="{preset_path}">
+                                <input type="hidden" name="pad_number" value="{pad_num}">
+                                <button type="submit" class="reverse-button">Reverse</button>
+                              </form>'''
+                    cell += f'''<button type="button" class="time-stretch-button" data-sample-path="{sample['path']}" data-preset-path="{preset_path}" data-pad-number="{pad_num}" onclick="var modal = document.getElementById('timeStretchModal'); document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path'); document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path'); document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number'); modal.classList.remove('hidden');">Time Stretch</button>'''
+                    original = find_original_sample(sample['path'])
+                    if original and original != sample['path']:
+                        cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
+                                    <input type="hidden" name="action" value="revert_sample">
+                                    <input type="hidden" name="sample_path" value="{sample['path']}">
+                                    <input type="hidden" name="preset_path" value="{preset_path}">
+                                    <input type="hidden" name="pad_number" value="{pad_num}">
+                                    <button type="submit" class="revert-button" title="Revert to original sample">
+                                      <svg viewBox="0 0 20 18" height="18" width="20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M3 9H17M3 9L7 5M3 9L7 13" stroke="currentColor" stroke-width="1.5"/>
+                                      </svg>
+                                    </button>
+                                  </form>'''
+                    cell += '</div></div>'
+                elif sample:
+                    cell += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>No sample</span></div>'
+                else:
+                    cell += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>Empty</span></div>'
+                cell += '</div>'
+                html += cell
+            html += '</div>'
+        html += '</div>'
+        return html
     
     def handle_time_stretch_sample(self, form):
         """Handle time-stretch action."""
@@ -270,78 +261,7 @@ class DrumRackInspectorHandler(BaseHandler):
         if not result['success']:
             return self.format_error_response(result['message'])
 
-        samples_html = '<div class="drum-grid">'
-        grid_samples = [None] * 16
-        for sample in result['samples']:
-            num = int(sample['pad'])
-            if 1 <= num <= 16:
-                grid_samples[num - 1] = sample
-
-        for row in range(3, -1, -1):
-            samples_html += '<div class="drum-grid-row">'
-            for col in range(4):
-                idx = row * 4 + col
-                num = idx + 1
-                sample = grid_samples[idx]
-                cell_html = '<div class="drum-cell">'
-
-                if sample and sample.get('path', '').startswith('/data/UserData/UserLibrary/Samples/'):
-                    web_path = '/samples/' + sample['path'] \
-                                .replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
-                    web_path = urllib.parse.quote(web_path)
-                    wf_id = f'waveform-{num}'
-                    cell_html += f'''
-                        <div class="pad-info">
-                            <span class="pad-number">Pad {num}</span>
-                        </div>
-                        <div id="{wf_id}" class="waveform-container"
-                             data-audio-path="{web_path}"
-                             data-playback-start="{sample.get('playback_start', 0.0)}"
-                             data-playback-length="{sample.get('playback_length', 1.0)}"></div>
-                        <div class="sample-info">
-                            <div class="sample-header">
-                                <span class="sample-name">{sample["sample"]}</span>
-                                <a href="{web_path}" target="_blank" class="download-link" aria-label="Download">
-                                    <svg fill="none" viewBox="0 0 20 18" height="18" width="20" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M10 12.2892V0M10 12.2892L14.6667 8.19277M10 12.2892L5.33333 8.19277M17 17H3" stroke="currentColor" stroke-width="1.5"/>
-                                    </svg>
-                                </a>
-                            </div>
-                            <div class="sample-actions">
-                                <form method="POST" action="/drum-rack-inspector" style="display: inline;">
-                                    <input type="hidden" name="action" value="reverse_sample">
-                                    <input type="hidden" name="sample_path" value="{sample['path']}">
-                                    <input type="hidden" name="preset_path" value="{preset_path}">
-                                    <input type="hidden" name="pad_number" value="{num}">
-                                    <button type="submit" class="reverse-button">Reverse</button>
-                                </form>
-                                <button type="button" class="time-stretch-button"
-                                    data-sample-path="{sample['path']}"
-                                    data-preset-path="{preset_path}"
-                                    data-pad-number="{num}"
-                                    onclick="
-                                      var modal = document.getElementById('timeStretchModal');
-                                      document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path');
-                                      document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path');
-                                      document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number');
-                                      modal.classList.remove('hidden');
-                                    ">
-                                    Time Stretch
-                                </button>
-                            </div>
-                        </div>
-                    '''
-                elif sample:
-                    cell_html += f'<div class="pad-info"><span class="pad-number">Pad {num}</span><span>No sample</span></div>'
-                else:
-                    cell_html += f'<div class="pad-info"><span class="pad-number">Pad {num}</span><span>Empty</span></div>'
-
-                cell_html += '</div>'
-                samples_html += cell_html
-
-            samples_html += '</div>'
-
-        samples_html += '</div>'
+        samples_html = self.generate_samples_html(result['samples'], preset_path)
 
         base_dir = "/data/UserData/UserLibrary/Track Presets"
         if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
@@ -414,80 +334,7 @@ class DrumRackInspectorHandler(BaseHandler):
             if not result['success']:
                 return self.format_error_response(result['message'])
 
-            # Generate grid HTML
-            samples_html = '<div class="drum-grid">'
-            grid_samples = [None] * 16
-            for sample in result['samples']:
-                pad_num = int(sample['pad'])
-                if 1 <= pad_num <= 16:
-                    grid_samples[pad_num - 1] = sample
-
-            for row in range(3, -1, -1):
-                samples_html += '<div class="drum-grid-row">'
-                for col in range(4):
-                    pad_index = row * 4 + col
-                    pad_num = pad_index + 1
-
-                    sample = grid_samples[pad_index]
-                    cell_html = '<div class="drum-cell">'
-
-                    if sample:
-                        if sample.get('path') and sample['path'].startswith('/data/UserData/UserLibrary/Samples/'):
-                            web_path = '/samples/' + sample['path'].replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
-                            web_path = urllib.parse.quote(web_path)
-                            waveform_id = f'waveform-{pad_num}'
-                            cell_html += f'''
-                                <div class="pad-info">
-                                    <span class="pad-number">Pad {pad_num}</span>
-                                </div>
-                                <div id="{waveform_id}" class="waveform-container"
-                                     data-audio-path="{web_path}"
-                                     data-playback-start="{sample.get('playback_start', 0.0)}"
-                                     data-playback-length="{sample.get('playback_length', 1.0)}"></div>
-                                <div class="sample-info">
-                                    <div class="sample-header">
-                                        <span class="sample-name">{sample["sample"]}</span>
-                                        <a href="{web_path}" target="_blank" class="download-link" aria-label="Download">
-                                            <svg fill="none" viewBox="0 0 20 18" height="18" width="20" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M10 12.2892V0M10 12.2892L14.6667 8.19277M10 12.2892L5.33333 8.19277M17 17H3" stroke="currentColor" stroke-width="1.5"/>
-                                            </svg>
-                                        </a>
-                                    </div>
-                                    <div class="sample-actions">
-                                        <form method="POST" action="/drum-rack-inspector" style="display: inline;">
-                                            <input type="hidden" name="action" value="reverse_sample">
-                                            <input type="hidden" name="sample_path" value="{sample['path']}">
-                                            <input type="hidden" name="preset_path" value="{preset_path}">
-                                            <input type="hidden" name="pad_number" value="{pad_num}">
-                                            <button type="submit" class="reverse-button">Reverse</button>
-                                        </form>
-                                        <button type="button" class="time-stretch-button"
-                                            data-sample-path="{sample['path']}"
-                                            data-preset-path="{preset_path}"
-                                            data-pad-number="{pad_num}"
-                                            onclick="
-                                              var modal = document.getElementById('timeStretchModal');
-                                              document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path');
-                                              document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path');
-                                              document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number');
-                                              modal.classList.remove('hidden');
-                                            ">
-                                            Time Stretch
-                                        </button>
-                                    </div>
-                                </div>
-                            '''
-                        else:
-                            cell_html += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>No sample</span></div>'
-                    else:
-                        cell_html += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>Empty</span></div>'
-
-                    cell_html += '</div>'
-                    samples_html += cell_html
-
-                samples_html += '</div>'
-
-            samples_html += '</div>'
+            samples_html = self.generate_samples_html(result['samples'], preset_path)
 
             base_dir = "/data/UserData/UserLibrary/Track Presets"
             if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
@@ -512,3 +359,46 @@ class DrumRackInspectorHandler(BaseHandler):
 
         except Exception as e:
             return self.format_error_response(f"Error reversing sample: {str(e)}")
+
+    def handle_revert_sample(self, form):
+        """Revert a pad to its original sample if available."""
+        sample_path = form.getvalue('sample_path')
+        preset_path = form.getvalue('preset_path')
+        pad_number = form.getvalue('pad_number')
+        if not sample_path or not preset_path or not pad_number:
+            return self.format_error_response("Missing parameters")
+
+        original = find_original_sample(sample_path)
+        if not original or original == sample_path:
+            return self.format_error_response("Original sample not found")
+
+        success, message = update_drum_cell_sample(preset_path, pad_number, original)
+        if not success:
+            return self.format_error_response(f"Failed to update preset: {message}")
+
+        result = get_drum_cell_samples(preset_path)
+        if not result['success']:
+            return self.format_error_response(result['message'])
+
+        samples_html = self.generate_samples_html(result['samples'], preset_path)
+
+        base_dir = "/data/UserData/UserLibrary/Track Presets"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+            base_dir = "examples/Track Presets"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            '/drum-rack-inspector',
+            'preset_select',
+            'select_preset',
+            filter_key='drumrack'
+        )
+        return {
+            'file_browser_html': browser_html,
+            'message': 'Reverted to original sample',
+            'samples_html': samples_html,
+            'selected_preset': preset_path,
+            'browser_root': base_dir,
+            'browser_filter': 'drumrack',
+            'message_type': 'success',
+        }

--- a/static/style.css
+++ b/static/style.css
@@ -407,3 +407,13 @@ select {
     padding: 0.25rem;
 }
 
+/* Small icon button for reverting samples */
+.sample-header .revert-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- recover original sample filenames in drum rack core logic
- rebuild drum rack HTML generation with revert button
- implement handler to revert a pad to its original sample
- use helper function everywhere drum pad grids are built

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c9f62f888325b6cca6af76cd6a5a