### PR TITLE
Add parameter viewer in synth macro inspector

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -392,6 +392,7 @@ def synth_macros():
     browser_root = result.get("browser_root")
     browser_filter = result.get("browser_filter")
     macros_html = result.get("macros_html", "")
+    all_params_html = result.get("all_params_html", "")
     selected_preset = result.get("selected_preset")
     preset_selected = bool(selected_preset)
     return render_template(
@@ -403,6 +404,7 @@ def synth_macros():
         browser_root=browser_root,
         browser_filter=browser_filter,
         macros_html=macros_html,
+        all_params_html=all_params_html,
         preset_selected=preset_selected,
         selected_preset=selected_preset,
         active_tab="synth-macros",

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -23,6 +23,12 @@
     <div class="macro-display">
         {{ macros_html | safe }}
     </div>
+    <details class="all-params">
+        <summary>View All Parameters</summary>
+        <div class="all-params-content">
+            {{ all_params_html | safe }}
+        </div>
+    </details>
 </form>
 {% endif %}
 
@@ -184,6 +190,25 @@
     
     .save-name-btn:hover {
         background-color: #0b7dda;
+    }
+
+    .all-params {
+        margin-top: 20px;
+    }
+
+    .all-params summary {
+        cursor: pointer;
+        font-weight: bold;
+        margin-bottom: 10px;
+    }
+
+    .all-params-list {
+        list-style-type: none;
+        padding-left: 0;
+    }
+
+    .all-params-list li {
+        margin-bottom: 5px;
     }
 </style>
 {% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -91,6 +91,7 @@ def test_synth_macros_post(client, monkeypatch):
             'message': 'saved',
             'message_type': 'success',
             'macros_html': '<p>done</p>',
+            'all_params_html': '<ul></ul>',
             'selected_preset': 'x',
             'browser_root': '/tmp',
         }
@@ -101,6 +102,7 @@ def test_synth_macros_post(client, monkeypatch):
     assert b'Choose Another Preset' in resp.data
     assert b'<p>done</p>' in resp.data
     assert b'Currently loaded preset:' in resp.data
+    assert b'View All Parameters' in resp.data
 
 def test_drum_rack_inspector_get(client, monkeypatch):
     def fake_get():


### PR DESCRIPTION
## Summary
- show all parameter values for a selected preset in synth macro inspector
- toggle parameter list with a `View All Parameters` section
- expose new HTML in route
- adjust unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d51237ec8325a63cddfdc947e784