### PR TITLE
Add drift parameter schema and update macro inspector

### DIFF
--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -6,6 +6,24 @@ from core.cache_manager import get_cache, set_cache
 
 logger = logging.getLogger(__name__)
 
+# Path to the Drift parameter schema relative to the project root
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "static",
+    "schemas",
+    "drift_schema.json",
+)
+
+
+def load_drift_schema():
+    """Load parameter metadata for Drift from ``drift_schema.json``."""
+    try:
+        with open(SCHEMA_PATH, "r") as f:
+            return json.load(f)
+    except Exception as exc:
+        logger.warning("Could not load drift schema: %s", exc)
+        return {}
+
 def extract_available_parameters(preset_path):
     """
     Extract available parameters from drift or wavetable devices in a preset file.
@@ -84,12 +102,16 @@ def extract_available_parameters(preset_path):
         
         # Convert set to sorted list
         parameters_list = sorted(list(parameters))
-        
+
+        schema = load_drift_schema()
+        parameter_info = {p: schema.get(p, {}) for p in parameters_list}
+
         return {
             'success': True,
             'message': f"Found {len(parameters_list)} parameters",
             'parameters': parameters_list,
-            'parameter_paths': parameter_paths
+            'parameter_paths': parameter_paths,
+            'parameter_info': parameter_info,
         }
         
     except Exception as e:

--- a/docs/instrument_schemas.md
+++ b/docs/instrument_schemas.md
@@ -1,0 +1,11 @@
+# Instrument Parameter Schemas
+
+The project automatically extracts the available parameters for several Ableton Live instruments by scanning the preset JSON files under `core library files/`. For each instrument type the minimum and maximum numeric values observed are recorded along with possible enum options.
+
+Generated schema files can be found in `static/schemas/`:
+
+- `drift_schema.json`
+- `wavetable_schema.json`
+- `melodicSampler_schema.json`
+
+These schemas are not currently used beyond documentation but provide a reference for building macro editors or validation tools.

--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -1,6 +1,7 @@
 import re
 import os
 import logging
+import json
 from handlers.base_handler import BaseHandler
 from core.synth_preset_inspector_handler import (
     scan_for_synth_presets, 
@@ -9,7 +10,8 @@ from core.synth_preset_inspector_handler import (
     extract_available_parameters,
     extract_parameter_values,
     update_preset_parameter_mappings,
-    delete_parameter_mapping
+    delete_parameter_mapping,
+    load_drift_schema
 )
 from core.file_browser import generate_dir_html
 
@@ -29,6 +31,7 @@ class SynthPresetInspectorHandler(BaseHandler):
             'select_preset',
             filter_key='drift'
         )
+        schema = load_drift_schema()
         return {
             "message": "Select a Drift preset from the list",
             "message_type": "info",
@@ -38,6 +41,7 @@ class SynthPresetInspectorHandler(BaseHandler):
             "selected_preset": None,
             "browser_root": base_dir,
             "browser_filter": 'drift',
+            "schema_json": json.dumps(schema),
         }
 
     def handle_post(self, form):
@@ -186,6 +190,7 @@ class SynthPresetInspectorHandler(BaseHandler):
                 "selected_preset": preset_path,
                 "browser_root": base_dir,
                 "browser_filter": 'drift',
+                "schema_json": json.dumps(self.parameter_info),
             }
         
         return self.format_info_response("Unknown action")
@@ -210,6 +215,7 @@ class SynthPresetInspectorHandler(BaseHandler):
         available_parameters = []
         parameter_paths = {}
         mapped_parameters = {}
+        self.parameter_info = {}
         if preset_path:
             # Extract the preset path from the form value
             preset_select = self.form.getvalue('preset_select') if hasattr(self, 'form') else None
@@ -219,6 +225,7 @@ class SynthPresetInspectorHandler(BaseHandler):
                 if param_result['success']:
                     all_parameters = param_result['parameters']
                     parameter_paths = param_result.get('parameter_paths', {})
+                    self.parameter_info = param_result.get('parameter_info', {})
                     
                     # Store parameter paths in the class for use in handle_post
                     self.parameter_paths = parameter_paths
@@ -273,24 +280,39 @@ class SynthPresetInspectorHandler(BaseHandler):
             # Add options for all available parameters
             for param in available_parameters:
                 selected = ' selected="selected"' if param == default_param else ''
-                html += f'<option value="{param}"{selected}>{param}</option>'
+                info = self.parameter_info.get(param, {})
+                data_attrs = ''
+                if info.get('type'):
+                    data_attrs += f' data-type="{info["type"]}"'
+                if info.get('min') is not None:
+                    data_attrs += f' data-min="{info["min"]}"'
+                if info.get('max') is not None:
+                    data_attrs += f' data-max="{info["max"]}"'
+                if info.get('options'):
+                    opts = ",".join(map(str, info['options']))
+                    data_attrs += f' data-options="{opts}"'
+                html += f'<option value="{param}"{selected}{data_attrs}>{param}</option>'
             
             html += '</select>'
             
             # Range inputs inline with Add button
-            html += '<div class="range-inputs-inline">'
-            html += f'<label>Min: <input type="number" name="macro_{macro["index"]}_range_min" value="{default_range_min}" step="any"></label>'
-            html += f'<label>Max: <input type="number" name="macro_{macro["index"]}_range_max" value="{default_range_max}" step="any"></label>'
-            
-            # Add the "Add" button inline with range inputs
+            html += (
+                f'<label class="min-wrapper">Min: <input type="number" class="range-min" '
+                f'name="macro_{macro["index"]}_range_min" value="{default_range_min}" step="any"></label>'
+            )
+            html += (
+                f'<label class="max-wrapper">Max: <input type="number" class="range-max" '
+                f'name="macro_{macro["index"]}_range_max" value="{default_range_max}" step="any"></label>'
+            )
+            html += '<div class="options-display"></div>'
+
+            # Add the "Add" button
             html += f'<button type="submit" class="add-mapping-btn" '
             html += f'onclick="document.getElementById(\'action-input\').value=\'add_mapping\'; '
             html += f'document.getElementById(\'macro-index-input\').value=\'{macro["index"]}\';">'
-            html += f'Add</button>'
-            html += '</div>'
-            
+            html += 'Add</button>'
             html += '</div>'  # Close parameter-controls
-            
+
             html += '</div>'
             
             # Display current mappings
@@ -301,7 +323,11 @@ class SynthPresetInspectorHandler(BaseHandler):
                 html += '<ul class="parameters-list">'
                 for param in macro["parameters"]:
                     param_info = f'{param["name"]}'
-                    if "rangeMin" in param and "rangeMax" in param:
+                    info = self.parameter_info.get(param["name"], {})
+                    if info.get("options"):
+                        opts = ", ".join(map(str, info["options"]))
+                        param_info += f' [Options: {opts}]'
+                    elif "rangeMin" in param and "rangeMax" in param:
                         param_info += f' (Range: {param["rangeMin"]} - {param["rangeMax"]})'
                     
                     # Add delete button with onclick handler to set action and parameter info

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -394,6 +394,7 @@ def synth_macros():
     macros_html = result.get("macros_html", "")
     all_params_html = result.get("all_params_html", "")
     selected_preset = result.get("selected_preset")
+    schema_json = result.get("schema_json", "{}")
     preset_selected = bool(selected_preset)
     return render_template(
         "synth_macros.html",
@@ -407,6 +408,7 @@ def synth_macros():
         all_params_html=all_params_html,
         preset_selected=preset_selected,
         selected_preset=selected_preset,
+        schema_json=schema_json,
         active_tab="synth-macros",
     )
 

--- a/static/schemas/drift_schema.json
+++ b/static/schemas/drift_schema.json
@@ -1,0 +1,646 @@
+{
+  "CyclingEnvelope_Hold": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "CyclingEnvelope_MidPoint": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "CyclingEnvelope_Mode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Freq",
+      "Ratio",
+      "Sync",
+      "Time"
+    ]
+  },
+  "CyclingEnvelope_Rate": {
+    "type": "number",
+    "min": 0.17,
+    "max": 1700.0,
+    "options": []
+  },
+  "CyclingEnvelope_Ratio": {
+    "type": "number",
+    "min": 0.25,
+    "max": 5.787109,
+    "options": []
+  },
+  "CyclingEnvelope_SyncedRate": {
+    "type": "number",
+    "min": 15,
+    "max": 17,
+    "options": []
+  },
+  "CyclingEnvelope_Time": {
+    "type": "number",
+    "min": 0.1,
+    "max": 1.147904,
+    "options": []
+  },
+  "Envelope1_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 2.0,
+    "options": []
+  },
+  "Envelope1_Decay": {
+    "type": "number",
+    "min": 0.0,
+    "max": 45.086365,
+    "options": []
+  },
+  "Envelope1_Release": {
+    "type": "number",
+    "min": 0.0,
+    "max": 4.201648,
+    "options": []
+  },
+  "Envelope1_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Envelope2_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 35.476055,
+    "options": []
+  },
+  "Envelope2_Decay": {
+    "type": "number",
+    "min": 0.0,
+    "max": 60.0,
+    "options": []
+  },
+  "Envelope2_Release": {
+    "type": "number",
+    "min": 0.0,
+    "max": 60.0,
+    "options": []
+  },
+  "Envelope2_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Filter_Frequency": {
+    "type": "number",
+    "min": 40.790009,
+    "max": 20000.0,
+    "options": []
+  },
+  "Filter_HiPassFrequency": {
+    "type": "number",
+    "min": 10.0,
+    "max": 612.444885,
+    "options": []
+  },
+  "Filter_ModAmount1": {
+    "type": "number",
+    "min": -0.439532,
+    "max": 1.0,
+    "options": []
+  },
+  "Filter_ModAmount2": {
+    "type": "number",
+    "min": -1.0,
+    "max": 0.852254,
+    "options": []
+  },
+  "Filter_ModSource1": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "Key",
+      "LFO",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "Filter_ModSource2": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "LFO",
+      "Modwheel",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "Filter_NoiseThrough": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Filter_OscillatorThrough1": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Filter_OscillatorThrough2": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Filter_Resonance": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.75,
+    "options": []
+  },
+  "Filter_Tracking": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Filter_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "I",
+      "II"
+    ]
+  },
+  "Global_DriftDepth": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Global_Envelope2Mode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Cyc",
+      "Env"
+    ]
+  },
+  "Global_Glide": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.336857,
+    "options": []
+  },
+  "Global_HiQuality": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Global_Legato": {
+    "type": "boolean",
+    "min": false,
+    "max": false,
+    "options": []
+  },
+  "Global_MonoVoiceDepth": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Global_NotePitchBend": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Global_PitchBendRange": {
+    "type": "number",
+    "min": 2,
+    "max": 12,
+    "options": []
+  },
+  "Global_PolyVoiceDepth": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Global_ResetOscillatorPhase": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Global_SerialNumber": {
+    "type": "number",
+    "min": 0,
+    "max": 8388607,
+    "options": []
+  },
+  "Global_StereoVoiceDepth": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Global_Transpose": {
+    "type": "number",
+    "min": -24,
+    "max": 36,
+    "options": []
+  },
+  "Global_UnisonVoiceDepth": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Global_VoiceCount": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "4",
+      "8"
+    ]
+  },
+  "Global_VoiceMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Mono",
+      "Poly",
+      "Stereo",
+      "Unison"
+    ]
+  },
+  "Global_VolVelMod": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.726562,
+    "options": []
+  },
+  "Global_Volume": {
+    "type": "number",
+    "min": 0.183872,
+    "max": 1.0,
+    "options": []
+  },
+  "Lfo_Amount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Lfo_ModAmount": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Lfo_ModSource": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "Key",
+      "LFO",
+      "Modwheel",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "Lfo_Mode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Freq",
+      "Ratio",
+      "Sync",
+      "Time"
+    ]
+  },
+  "Lfo_Rate": {
+    "type": "number",
+    "min": 0.17,
+    "max": 1700.0,
+    "options": []
+  },
+  "Lfo_Ratio": {
+    "type": "number",
+    "min": 0.25,
+    "max": 16.0,
+    "options": []
+  },
+  "Lfo_Retrigger": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Lfo_Shape": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Exponential Env",
+      "Sample & Hold",
+      "Saw Down",
+      "Saw Up",
+      "Sine",
+      "Square",
+      "Triangle",
+      "Wander"
+    ]
+  },
+  "Lfo_SyncedRate": {
+    "type": "number",
+    "min": 9,
+    "max": 21,
+    "options": []
+  },
+  "Lfo_Time": {
+    "type": "number",
+    "min": 0.1,
+    "max": 60.0,
+    "options": []
+  },
+  "Mixer_NoiseLevel": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Mixer_NoiseOn": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Mixer_OscillatorGain1": {
+    "type": "number",
+    "min": 0.169407,
+    "max": 2.0,
+    "options": []
+  },
+  "Mixer_OscillatorGain2": {
+    "type": "number",
+    "min": 0.0,
+    "max": 2.0,
+    "options": []
+  },
+  "Mixer_OscillatorOn1": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Mixer_OscillatorOn2": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "ModulationMatrix_Amount1": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "ModulationMatrix_Amount2": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "ModulationMatrix_Amount3": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "ModulationMatrix_Source1": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "LFO",
+      "Modwheel",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "ModulationMatrix_Source2": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "LFO",
+      "Modwheel",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "ModulationMatrix_Source3": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "LFO",
+      "Modwheel",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "ModulationMatrix_Target1": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Cyc Env Rate",
+      "HP Frequency",
+      "LFO Rate",
+      "LP Frequency",
+      "LP Resonance",
+      "Noise Gain",
+      "None",
+      "Osc 1 Gain",
+      "Osc 1 Shape",
+      "Osc 2 Detune"
+    ]
+  },
+  "ModulationMatrix_Target2": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "HP Frequency",
+      "LFO Rate",
+      "LP Frequency",
+      "LP Resonance",
+      "Main Volume",
+      "Noise Gain",
+      "None",
+      "Osc 1 Gain",
+      "Osc 1 Shape",
+      "Osc 2 Detune",
+      "Osc 2 Gain"
+    ]
+  },
+  "ModulationMatrix_Target3": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Cyc Env Rate",
+      "HP Frequency",
+      "LFO Rate",
+      "LP Frequency",
+      "LP Resonance",
+      "Noise Gain",
+      "None",
+      "Osc 1 Gain",
+      "Osc 1 Shape",
+      "Osc 2 Detune",
+      "Osc 2 Gain"
+    ]
+  },
+  "Oscillator1_Shape": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Oscillator1_ShapeMod": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Oscillator1_ShapeModSource": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "Key",
+      "LFO",
+      "Modwheel",
+      "Pressure",
+      "Slide",
+      "Velocity"
+    ]
+  },
+  "Oscillator1_Transpose": {
+    "type": "number",
+    "min": -2,
+    "max": 3,
+    "options": []
+  },
+  "Oscillator1_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Pulse",
+      "Rectangle",
+      "Saturated",
+      "Saw",
+      "Shark Tooth",
+      "Sine",
+      "Triangle"
+    ]
+  },
+  "Oscillator2_Detune": {
+    "type": "number",
+    "min": -7.0,
+    "max": 7.0,
+    "options": []
+  },
+  "Oscillator2_Transpose": {
+    "type": "number",
+    "min": -3,
+    "max": 2,
+    "options": []
+  },
+  "Oscillator2_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Rectangle",
+      "Saturated",
+      "Saw",
+      "Sine",
+      "Triangle"
+    ]
+  },
+  "PitchModulation_Amount1": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.720503,
+    "options": []
+  },
+  "PitchModulation_Amount2": {
+    "type": "number",
+    "min": -0.121687,
+    "max": 1.0,
+    "options": []
+  },
+  "PitchModulation_Source1": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "Pressure",
+      "Velocity"
+    ]
+  },
+  "PitchModulation_Source2": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Env 1",
+      "Env 2 / Cyc",
+      "LFO",
+      "Modwheel",
+      "Slide",
+      "Velocity"
+    ]
+  }
+}

--- a/static/schemas/melodicSampler_schema.json
+++ b/static/schemas/melodicSampler_schema.json
@@ -1,0 +1,174 @@
+{
+  "Voice_AmplitudeEnvelope_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.15449,
+    "options": []
+  },
+  "Voice_AmplitudeEnvelope_Decay": {
+    "type": "number",
+    "min": 0.0,
+    "max": 60.0,
+    "options": []
+  },
+  "Voice_AmplitudeEnvelope_Release": {
+    "type": "number",
+    "min": 0.0,
+    "max": 23.0,
+    "options": []
+  },
+  "Voice_AmplitudeEnvelope_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_AmplitudeEnvelope_SustainMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Gate"
+    ]
+  },
+  "Voice_Detune": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_FilterEnvelope_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_FilterEnvelope_Decay": {
+    "type": "number",
+    "min": 0.173683,
+    "max": 2.962276,
+    "options": []
+  },
+  "Voice_FilterEnvelope_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_FilterEnvelope_Release": {
+    "type": "number",
+    "min": 0.05,
+    "max": 3.833659,
+    "options": []
+  },
+  "Voice_FilterEnvelope_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.726562,
+    "options": []
+  },
+  "Voice_Filter_Frequency": {
+    "type": "number",
+    "min": 30.0,
+    "max": 22000.0,
+    "options": []
+  },
+  "Voice_Filter_FrequencyModulationAmounts_EnvelopeAmount": {
+    "type": "number",
+    "min": -72,
+    "max": 0,
+    "options": []
+  },
+  "Voice_Filter_FrequencyModulationAmounts_LfoAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 21.732283,
+    "options": []
+  },
+  "Voice_Filter_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Filter_Resonance": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.677548,
+    "options": []
+  },
+  "Voice_Filter_Slope": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "12",
+      "24"
+    ]
+  },
+  "Voice_Filter_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Highpass",
+      "Lowpass"
+    ]
+  },
+  "Voice_Gain": {
+    "type": "number",
+    "min": 1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Lfo_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Lfo_Rate": {
+    "type": "number",
+    "min": 1.0,
+    "max": 9.0,
+    "options": []
+  },
+  "Voice_Lfo_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Sine"
+    ]
+  },
+  "Voice_PlaybackLength": {
+    "type": "number",
+    "min": 1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_PlaybackStart": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_Transpose": {
+    "type": "number",
+    "min": -36,
+    "max": 36,
+    "options": []
+  },
+  "Voice_VelocityToVolume": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.35,
+    "options": []
+  },
+  "Volume": {
+    "type": "number",
+    "min": -23.799999,
+    "max": 0.0,
+    "options": []
+  }
+}

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -1,0 +1,687 @@
+{
+  "HiQ": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "MonoPoly": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Mono",
+      "Poly"
+    ]
+  },
+  "PolyVoices": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "2",
+      "4"
+    ]
+  },
+  "Voice_Filter1_CircuitBpNoMo": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Clean"
+    ]
+  },
+  "Voice_Filter1_CircuitLpHp": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Clean"
+    ]
+  },
+  "Voice_Filter1_Drive": {
+    "type": "number",
+    "min": 0.0,
+    "max": 17.8125,
+    "options": []
+  },
+  "Voice_Filter1_Frequency": {
+    "type": "number",
+    "min": 20.0,
+    "max": 20480.0,
+    "options": []
+  },
+  "Voice_Filter1_Morph": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.304688,
+    "options": []
+  },
+  "Voice_Filter1_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Filter1_Resonance": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.694444,
+    "options": []
+  },
+  "Voice_Filter1_Slope": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "12",
+      "24"
+    ]
+  },
+  "Voice_Filter1_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Bandpass",
+      "Highpass",
+      "Lowpass",
+      "Morph",
+      "Notch"
+    ]
+  },
+  "Voice_Filter2_CircuitBpNoMo": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Clean",
+      "OSR"
+    ]
+  },
+  "Voice_Filter2_CircuitLpHp": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Clean",
+      "MS2"
+    ]
+  },
+  "Voice_Filter2_Drive": {
+    "type": "number",
+    "min": 0.0,
+    "max": 24.0,
+    "options": []
+  },
+  "Voice_Filter2_Frequency": {
+    "type": "number",
+    "min": 20.0,
+    "max": 20480.0,
+    "options": []
+  },
+  "Voice_Filter2_Morph": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.617188,
+    "options": []
+  },
+  "Voice_Filter2_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Filter2_Resonance": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.813492,
+    "options": []
+  },
+  "Voice_Filter2_Slope": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "12",
+      "24"
+    ]
+  },
+  "Voice_Filter2_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Bandpass",
+      "Highpass",
+      "Lowpass",
+      "Morph",
+      "Notch"
+    ]
+  },
+  "Voice_Global_FilterRouting": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Parallel",
+      "Serial",
+      "Split"
+    ]
+  },
+  "Voice_Global_Glide": {
+    "type": "number",
+    "min": 0.0,
+    "max": 3.149017,
+    "options": []
+  },
+  "Voice_Global_Transpose": {
+    "type": "number",
+    "min": -48,
+    "max": 24,
+    "options": []
+  },
+  "Voice_Modulators_Amount": {
+    "type": "number",
+    "min": 0.07874,
+    "max": 2.0,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_LoopMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Loop",
+      "None",
+      "Trigger"
+    ]
+  },
+  "Voice_Modulators_AmpEnvelope_Slopes_Attack": {
+    "type": "number",
+    "min": -1.0,
+    "max": 0.821138,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_Slopes_Decay": {
+    "type": "number",
+    "min": -0.162162,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_Slopes_Release": {
+    "type": "number",
+    "min": -0.269231,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_Times_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_Times_Decay": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_AmpEnvelope_Times_Release": {
+    "type": "number",
+    "min": 0.0,
+    "max": 3.053029,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_LoopMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Loop",
+      "None",
+      "Trigger"
+    ]
+  },
+  "Voice_Modulators_Envelope2_Slopes_Attack": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Slopes_Decay": {
+    "type": "number",
+    "min": -0.6,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Slopes_Release": {
+    "type": "number",
+    "min": -1.0,
+    "max": 0.692308,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Times_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Times_Decay": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Times_Release": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Values_Final": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Values_Initial": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Values_Peak": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope2_Values_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_LoopMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Loop",
+      "None",
+      "Trigger"
+    ]
+  },
+  "Voice_Modulators_Envelope3_Slopes_Attack": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Slopes_Decay": {
+    "type": "number",
+    "min": -0.859375,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Slopes_Release": {
+    "type": "number",
+    "min": -0.75,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Times_Attack": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Times_Decay": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Times_Release": {
+    "type": "number",
+    "min": 0.0,
+    "max": 20.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Values_Final": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Values_Initial": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Values_Peak": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Envelope3_Values_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Retrigger": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Shape_Amount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Shape_PhaseOffset": {
+    "type": "number",
+    "min": 0.0,
+    "max": 270.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Shape_Shaping": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Shape_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Noise",
+      "Rectangle",
+      "Sawtooth",
+      "Sine",
+      "Triangle"
+    ]
+  },
+  "Voice_Modulators_Lfo1_Time_AttackTime": {
+    "type": "number",
+    "min": 0.0,
+    "max": 14.44502,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Time_Rate": {
+    "type": "number",
+    "min": 0.0,
+    "max": 30.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo1_Time_Sync": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Free",
+      "Tempo"
+    ]
+  },
+  "Voice_Modulators_Lfo1_Time_SyncedRate": {
+    "type": "number",
+    "min": 0,
+    "max": 19,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Retrigger": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Shape_Amount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Shape_PhaseOffset": {
+    "type": "number",
+    "min": 0.0,
+    "max": 360.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Shape_Shaping": {
+    "type": "number",
+    "min": -0.84375,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Shape_Type": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Noise",
+      "Sawtooth",
+      "Sine",
+      "Triangle"
+    ]
+  },
+  "Voice_Modulators_Lfo2_Time_AttackTime": {
+    "type": "number",
+    "min": 0.0,
+    "max": 14.940941,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Time_Rate": {
+    "type": "number",
+    "min": 0.0,
+    "max": 30.0,
+    "options": []
+  },
+  "Voice_Modulators_Lfo2_Time_Sync": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Free",
+      "Tempo"
+    ]
+  },
+  "Voice_Modulators_Lfo2_Time_SyncedRate": {
+    "type": "number",
+    "min": 0,
+    "max": 18,
+    "options": []
+  },
+  "Voice_Modulators_TimeScale": {
+    "type": "number",
+    "min": -1.0,
+    "max": 0.546875,
+    "options": []
+  },
+  "Voice_Oscillator1_Effects_Effect1": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator1_Effects_Effect2": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator1_Effects_EffectMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Classic",
+      "Fm",
+      "Modern",
+      "None"
+    ]
+  },
+  "Voice_Oscillator1_Gain": {
+    "type": "number",
+    "min": 0.193371,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator1_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Oscillator1_Pan": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator1_Pitch_Detune": {
+    "type": "number",
+    "min": -0.13,
+    "max": 0.48,
+    "options": []
+  },
+  "Voice_Oscillator1_Pitch_Transpose": {
+    "type": "number",
+    "min": -24,
+    "max": 24,
+    "options": []
+  },
+  "Voice_Oscillator1_Wavetables_WavePosition": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator2_Effects_Effect1": {
+    "type": "number",
+    "min": -1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator2_Effects_Effect2": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator2_Effects_EffectMode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Classic",
+      "Fm",
+      "Modern",
+      "None"
+    ]
+  },
+  "Voice_Oscillator2_Gain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator2_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_Oscillator2_Pan": {
+    "type": "number",
+    "min": -0.5625,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Oscillator2_Pitch_Detune": {
+    "type": "number",
+    "min": -0.226562,
+    "max": 0.351562,
+    "options": []
+  },
+  "Voice_Oscillator2_Pitch_Transpose": {
+    "type": "number",
+    "min": -24,
+    "max": 24,
+    "options": []
+  },
+  "Voice_Oscillator2_Wavetables_WavePosition": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_SubOscillator_Gain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_SubOscillator_On": {
+    "type": "boolean",
+    "min": null,
+    "max": null,
+    "options": []
+  },
+  "Voice_SubOscillator_Tone": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_SubOscillator_Transpose": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "-1",
+      "-2",
+      "0"
+    ]
+  },
+  "Voice_Unison_Amount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Unison_Mode": {
+    "type": "enum",
+    "min": null,
+    "max": null,
+    "options": [
+      "Classic",
+      "Noise",
+      "None"
+    ]
+  },
+  "Voice_Unison_VoiceCount": {
+    "type": "number",
+    "min": 2,
+    "max": 6,
+    "options": []
+  },
+  "Volume": {
+    "type": "number",
+    "min": 0.085572,
+    "max": 1.0,
+    "options": []
+  }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -170,7 +170,7 @@ input[type="number"],
 input[type="file"],
 select {
     /* display: block; */
-    width: 100%;
+    /* width: 100%; */
     max-width: 400px;
     padding: 0.625rem;
     /* margin-bottom: 1rem; */

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -32,7 +32,7 @@
 </form>
 {% endif %}
 
-<!-- The dropdown change event is handled by main.js using AJAX -->
+<!-- Dropdown changes are handled by the inline script below -->
 
 <style>
     .preset-selection {
@@ -91,39 +91,40 @@
     }
     
     .parameter-mapping select {
-        display: block;
-        width: 100%;
         padding: 8px;
-        margin: 8px 0 15px;
         border: 1px solid #ccc;
         border-radius: 4px;
     }
-    
+
     .parameter-controls {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
         gap: 15px;
         margin-bottom: 10px;
     }
     
-    .range-inputs-inline {
-        display: flex;
-        gap: 10px;
-    }
-    
-    .range-inputs-inline label {
+    .min-wrapper,
+    .max-wrapper {
         display: flex;
         align-items: center;
         font-size: 0.9em;
         color: #555;
     }
-    
-    .range-inputs-inline input {
+
+    .range-min,
+    .range-max {
         padding: 6px;
         border: 1px solid #ccc;
         border-radius: 3px;
         width: 80px;
         margin-left: 5px;
+    }
+
+    .options-display {
+        font-size: 0.85em;
+        color: #555;
+        margin-left: 10px;
     }
     
     .current-mappings {
@@ -214,4 +215,56 @@
 {% endblock %}
 {% block scripts %}
 <script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
+<script>
+const driftSchema = {{ schema_json|safe }};
+(function() {
+  function updateControls(sel) {
+    const opt = sel.options[sel.selectedIndex];
+    const info = {
+      type: opt.dataset.type,
+      min: opt.dataset.min ? parseFloat(opt.dataset.min) : null,
+      max: opt.dataset.max ? parseFloat(opt.dataset.max) : null,
+      options: opt.dataset.options ? opt.dataset.options.split(',') : null,
+    };
+
+    const container = sel.closest('.parameter-mapping');
+    const minWrap = container.querySelector('.min-wrapper');
+    const maxWrap = container.querySelector('.max-wrapper');
+    const minInput = container.querySelector('.range-min');
+    const maxInput = container.querySelector('.range-max');
+    const optDiv = container.querySelector('.options-display');
+
+    if (!info.type || info.type === 'enum' || info.type === 'boolean') {
+      minInput.value = '';
+      maxInput.value = '';
+      minInput.placeholder = '';
+      maxInput.placeholder = '';
+      minInput.disabled = true;
+      maxInput.disabled = true;
+      if (minWrap) minWrap.style.display = 'none';
+      if (maxWrap) maxWrap.style.display = 'none';
+    } else {
+      minInput.disabled = false;
+      maxInput.disabled = false;
+      minInput.placeholder = info.min !== null ? info.min : '';
+      maxInput.placeholder = info.max !== null ? info.max : '';
+      if (minWrap) minWrap.style.display = 'inline-block';
+      if (maxWrap) maxWrap.style.display = 'inline-block';
+    }
+
+    if (info.options && Array.isArray(info.options) && info.options.length > 0) {
+      optDiv.textContent = 'Options: ' + info.options.join(', ');
+      optDiv.style.display = 'inline';
+    } else {
+      optDiv.textContent = '';
+      optDiv.style.display = 'none';
+    }
+  }
+
+  document.querySelectorAll('.parameter-mapping select').forEach(sel => {
+    sel.addEventListener('change', () => updateControls(sel));
+    updateControls(sel);
+  });
+})();
+</script>
 {% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -78,6 +78,7 @@ def test_synth_macros_get(client, monkeypatch):
             'options': '<option value="p">p</option>',
             'macros_html': '',
             'selected_preset': None,
+            'schema_json': '{}',
         }
     monkeypatch.setattr(move_webserver.synth_handler, 'handle_get', fake_get)
     resp = client.get('/synth-macros')
@@ -94,6 +95,7 @@ def test_synth_macros_post(client, monkeypatch):
             'all_params_html': '<ul></ul>',
             'selected_preset': 'x',
             'browser_root': '/tmp',
+            'schema_json': '{}',
         }
     monkeypatch.setattr(move_webserver.synth_handler, 'handle_post', fake_post)
     resp = client.post('/synth-macros', data={'action': 'select_preset'})


### PR DESCRIPTION
## Summary
- gather all Drift preset parameters and create `drift_schema.json`
- expose parameter metadata in `extract_available_parameters`
- load schema in the synth macro inspector UI
- add JavaScript logic to show ranges for numeric parameters
- update Flask route and tests to include schema JSON

## Testing
- `pip install numpy soundfile mido Flask pyrubberband audiotsm librosa`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dab00bf08325adcad8d5ff34cccf