### PR TITLE
Update drift param editor layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -126,19 +126,46 @@ class SynthParamEditorHandler(BaseHandler):
             'default_preset_path': DEFAULT_PRESET,
         }
 
+    SECTION_ORDER = [
+        "Oscillator",
+        "Mixer",
+        "Filter",
+        "Envelopes",
+        "LFO + Mod",
+        "Global",
+        "Other",
+    ]
+
+    def _get_section(self, name):
+        if name.startswith(("Oscillator1_", "Oscillator2_", "PitchModulation_")):
+            return "Oscillator"
+        if name.startswith("Mixer_"):
+            return "Mixer"
+        if name.startswith("Filter_"):
+            return "Filter"
+        if name.startswith(("Envelope1_", "Envelope2_")):
+            return "Envelopes"
+        if name.startswith(("CyclingEnvelope_", "ModulationMatrix_")):
+            return "LFO + Mod"
+        if name.startswith("Global_"):
+            return "Global"
+        return "Other"
+
     def generate_params_html(self, params):
         """Return HTML controls for the given parameter values."""
         if not params:
             return '<p>No parameters found.</p>'
 
         schema = load_drift_schema()
-        html = '<div class="params-list">'
+        sections = {s: [] for s in self.SECTION_ORDER}
+
         for i, item in enumerate(params):
             name = item['name']
             val = item['value']
             meta = schema.get(name, {})
             p_type = meta.get('type')
-            html += '<div class="param-item">'
+
+            html = '<div class="param-item">'
             html += f'<label>{name}: '
             if p_type == 'enum' and meta.get('options'):
                 html += f'<select name="param_{i}_value">'
@@ -147,7 +174,6 @@ class SynthParamEditorHandler(BaseHandler):
                     html += f'<option value="{opt}"{selected}>{opt}</option>'
                 html += '</select>'
             else:
-                # Numeric knob using NexusUI dial
                 min_attr = f' data-min="{meta.get("min")}"' if meta.get("min") is not None else ''
                 max_attr = f' data-max="{meta.get("max")}"' if meta.get("max") is not None else ''
                 val_attr = f' data-value="{val}"'
@@ -156,8 +182,21 @@ class SynthParamEditorHandler(BaseHandler):
                 )
                 html += f'<input type="hidden" name="param_{i}_value" value="{val}">' 
             html += '</label>'
-            html += f'<input type="hidden" name="param_{i}_name" value="{name}">'
+            html += f'<input type="hidden" name="param_{i}_name" value="{name}">' 
             html += '</div>'
-        html += '</div>'
-        return html
+
+            section = self._get_section(name)
+            sections[section].append(html)
+
+        out_html = '<div class="drift-param-panels">'
+        for sec in self.SECTION_ORDER:
+            items = sections.get(sec)
+            if not items:
+                continue
+            cls = sec.lower().replace(' ', '-').replace('+', '')
+            out_html += f'<div class="param-panel {cls}"><h3>{sec}</h3><div class="param-items">'
+            out_html += ''.join(items)
+            out_html += '</div></div>'
+        out_html += '</div>'
+        return out_html
 

--- a/static/style.css
+++ b/static/style.css
@@ -481,3 +481,36 @@ select {
     margin: 0.25rem;
     display: inline-block;
 }
+
+/* Layout for the Drift parameter editor */
+.drift-param-panels {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.param-panel {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.param-panel.oscillator,
+.param-panel.envelopes {
+    flex: 2;
+}
+
+.param-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.param-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 90px;
+}


### PR DESCRIPTION
## Summary
- organize drift parameter editor into layout panels similar to the synth UI
- add flexbox styling for new panel layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447f9816748325a59a1c7ec0a2112b