### PR TITLE
Add units and value display for Drift params

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -151,10 +151,14 @@ class SynthParamEditorHandler(BaseHandler):
                 min_attr = f' data-min="{meta.get("min")}"' if meta.get("min") is not None else ''
                 max_attr = f' data-max="{meta.get("max")}"' if meta.get("max") is not None else ''
                 val_attr = f' data-value="{val}"'
+                unit_attr = f' data-unit="{meta.get("unit")}"' if meta.get("unit") else ''
+                dec_attr = f' data-decimals="{meta.get("decimals")}"' if meta.get("decimals") is not None else ''
+                display_id = f'param_{i}_display'
                 html += (
-                    f'<div id="param_{i}_dial" class="param-dial" data-target="param_{i}_value"{min_attr}{max_attr}{val_attr}></div>'
+                    f'<div id="param_{i}_dial" class="param-dial" data-target="param_{i}_value" data-display="{display_id}"{min_attr}{max_attr}{val_attr}{unit_attr}{dec_attr}></div>'
                 )
-                html += f'<input type="hidden" name="param_{i}_value" value="{val}">' 
+                html += f'<span id="{display_id}" class="param-number"></span>'
+                html += f'<input type="hidden" name="param_{i}_value" value="{val}">'
             html += '</label>'
             html += f'<input type="hidden" name="param_{i}_name" value="{name}">'
             html += '</div>'

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -5,16 +5,25 @@ document.addEventListener('DOMContentLoaded', () => {
         const max = parseFloat(el.dataset.max);
         const val = parseFloat(el.dataset.value);
         const target = el.dataset.target;
+        const decimals = parseInt(el.dataset.decimals || '2', 10);
+        const unit = el.dataset.unit || '';
+        const displayId = el.dataset.display;
         const dial = new Nexus.Dial(el, {
             size: [60,60],
             min: isNaN(min) ? 0 : min,
             max: isNaN(max) ? 1 : max,
             value: isNaN(val) ? 0 : val,
         });
+        const format = (v) => Number(v).toFixed(decimals) + (unit ? ' ' + unit : '');
+        const displayEl = displayId ? document.getElementById(displayId) : null;
+        if (displayEl) {
+            displayEl.textContent = isNaN(val) ? 'not set' : format(val);
+        }
         const input = document.querySelector(`input[name="${target}"]`);
         if (input) {
             dial.on('change', v => {
                 input.value = v;
+                if (displayEl) displayEl.textContent = format(v);
             });
         }
     });

--- a/static/schemas/drift_schema.json
+++ b/static/schemas/drift_schema.json
@@ -3,7 +3,8 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "decimals": 2
   },
   "CyclingEnvelope_MidPoint": {
     "type": "number",
@@ -26,7 +27,8 @@
     "type": "number",
     "min": 0.17,
     "max": 1700.0,
-    "options": []
+    "options": [],
+    "decimals": 1
   },
   "CyclingEnvelope_Ratio": {
     "type": "number",
@@ -50,73 +52,97 @@
     "type": "number",
     "min": 0.0,
     "max": 2.0,
-    "options": []
+    "options": [],
+    "unit": "ms",
+    "decimals": 2
   },
   "Envelope1_Decay": {
     "type": "number",
     "min": 0.0,
     "max": 45.086365,
-    "options": []
+    "options": [],
+    "unit": "ms",
+    "decimals": 0
   },
   "Envelope1_Release": {
     "type": "number",
     "min": 0.0,
     "max": 4.201648,
-    "options": []
+    "options": [],
+    "unit": "ms",
+    "decimals": 2
   },
   "Envelope1_Sustain": {
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "Envelope2_Attack": {
     "type": "number",
     "min": 0.0,
     "max": 35.476055,
-    "options": []
+    "options": [],
+    "unit": "ms",
+    "decimals": 2
   },
   "Envelope2_Decay": {
     "type": "number",
     "min": 0.0,
     "max": 60.0,
-    "options": []
+    "options": [],
+    "unit": "ms",
+    "decimals": 0
   },
   "Envelope2_Release": {
     "type": "number",
     "min": 0.0,
     "max": 60.0,
-    "options": []
+    "options": [],
+    "unit": "ms",
+    "decimals": 2
   },
   "Envelope2_Sustain": {
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "Filter_Frequency": {
     "type": "number",
     "min": 40.790009,
     "max": 20000.0,
-    "options": []
+    "options": [],
+    "unit": "Hz",
+    "decimals": 0
   },
   "Filter_HiPassFrequency": {
     "type": "number",
     "min": 10.0,
     "max": 612.444885,
-    "options": []
+    "options": [],
+    "unit": "Hz",
+    "decimals": 2
   },
   "Filter_ModAmount1": {
     "type": "number",
     "min": -0.439532,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "Filter_ModAmount2": {
     "type": "number",
     "min": -1.0,
     "max": 0.852254,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "Filter_ModSource1": {
     "type": "enum",
@@ -189,7 +215,8 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "decimals": 1
   },
   "Global_Envelope2Mode": {
     "type": "enum",
@@ -204,7 +231,9 @@
     "type": "number",
     "min": 0.0,
     "max": 0.336857,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Global_HiQuality": {
     "type": "boolean",
@@ -234,7 +263,9 @@
     "type": "number",
     "min": 2,
     "max": 12,
-    "options": []
+    "options": [],
+    "unit": "st",
+    "decimals": 0
   },
   "Global_PolyVoiceDepth": {
     "type": "number",
@@ -264,13 +295,17 @@
     "type": "number",
     "min": -24,
     "max": 36,
-    "options": []
+    "options": [],
+    "unit": "st",
+    "decimals": 0
   },
   "Global_UnisonVoiceDepth": {
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "Global_VoiceCount": {
     "type": "enum",
@@ -308,13 +343,17 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Lfo_ModAmount": {
     "type": "number",
     "min": -1.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Lfo_ModSource": {
     "type": "enum",
@@ -391,7 +430,9 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
   },
   "Mixer_NoiseOn": {
     "type": "boolean",
@@ -403,13 +444,17 @@
     "type": "number",
     "min": 0.169407,
     "max": 2.0,
-    "options": []
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
   },
   "Mixer_OscillatorGain2": {
     "type": "number",
     "min": 0.0,
     "max": 2.0,
-    "options": []
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
   },
   "Mixer_OscillatorOn1": {
     "type": "boolean",
@@ -427,19 +472,25 @@
     "type": "number",
     "min": -1.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "ModulationMatrix_Amount2": {
     "type": "number",
     "min": -1.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "ModulationMatrix_Amount3": {
     "type": "number",
     "min": -1.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
   "ModulationMatrix_Source1": {
     "type": "enum",
@@ -567,7 +618,9 @@
     "type": "number",
     "min": -2,
     "max": 3,
-    "options": []
+    "options": [],
+    "unit": "st",
+    "decimals": 0
   },
   "Oscillator1_Type": {
     "type": "enum",
@@ -593,7 +646,9 @@
     "type": "number",
     "min": -3,
     "max": 2,
-    "options": []
+    "options": [],
+    "unit": "st",
+    "decimals": 0
   },
   "Oscillator2_Type": {
     "type": "enum",
@@ -611,13 +666,17 @@
     "type": "number",
     "min": 0.0,
     "max": 0.720503,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 1
   },
   "PitchModulation_Amount2": {
     "type": "number",
     "min": -0.121687,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 1
   },
   "PitchModulation_Source1": {
     "type": "enum",

--- a/static/style.css
+++ b/static/style.css
@@ -481,3 +481,12 @@ select {
     margin: 0.25rem;
     display: inline-block;
 }
+.param-number {
+    margin-left: 0.5rem;
+    min-width: 60px;
+    display: inline-block;
+    text-align: right;
+}
+.param-item {
+    margin-bottom: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- show parameter units in drift schema and expose decimals for display rounding
- enhance param editor to show Nexus dial values with units
- style numeric value display
- show "not set" when parameter value is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447f38f6708325be9bce632af71fdc