### PR TITLE
Refactor oscillator layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -285,7 +285,7 @@ class SynthParamEditorHandler(BaseHandler):
             html += '</div>'
 
             section = self._get_section(name)
-            sections[section].append(html)
+            sections[section].append((name, html))
 
         out_html = '<div class="drift-param-panels">'
         for sec in self.SECTION_ORDER:
@@ -294,8 +294,47 @@ class SynthParamEditorHandler(BaseHandler):
                 continue
             cls = sec.lower().replace(' ', '-').replace('+', '')
             out_html += f'<div class="param-panel {cls}"><h3>{sec}</h3><div class="param-items">'
-            out_html += ''.join(items)
+            if sec == 'Oscillators':
+                out_html += self._render_oscillator_rows(items)
+            else:
+                out_html += ''.join(html for _, html in items)
             out_html += '</div></div>'
         out_html += '</div>'
         return out_html
+
+    def _render_oscillator_rows(self, items):
+        mapping = {name: html for name, html in items}
+        rows = [
+            [
+                "Oscillator1_Type",
+                "Oscillator1_Transpose",
+                "Oscillator1_Shape",
+                "Mixer_OscillatorGain1",
+            ],
+            [
+                "Oscillator2_Type",
+                "Oscillator2_Transpose",
+                "Oscillator2_Detune",
+                "Mixer_OscillatorGain2",
+            ],
+            [
+                "PitchModulation_Source1",
+                "PitchModulation_Amount1",
+                "PitchModulation_Source2",
+                "PitchModulation_Amount2",
+                "Mixer_NoiseLevel",
+            ],
+        ]
+
+        out = ''
+        for row in rows:
+            out += '<div class="param-row">'
+            for key in row:
+                html = mapping.pop(key, '')
+                out += html
+            out += '</div>'
+
+        if mapping:
+            out += '<div class="param-row">' + ''.join(mapping.values()) + '</div>'
+        return out
 

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -139,12 +139,13 @@ class SynthParamEditorHandler(BaseHandler):
 
     LABEL_OVERRIDES = {
         # Oscillators
-        "Oscillator1_Type": "Type",
+        # Use explicit oscillator labels for clarity
+        "Oscillator1_Type": "Osc 1",
         "Oscillator1_Transpose": "Oct",
         "Oscillator1_Shape": "Shape",
         "Oscillator1_ShapeModSource": "Shape Mod Source",
         "Oscillator1_ShapeMod": "Shape Mod Amount",
-        "Oscillator2_Type": "Type",
+        "Oscillator2_Type": "Osc 2",
         "Oscillator2_Transpose": "Oct",
         "Oscillator2_Detune": "Detune",
         "PitchModulation_Source1": "Source",
@@ -154,10 +155,10 @@ class SynthParamEditorHandler(BaseHandler):
 
         # Mixer
         "Mixer_OscillatorOn1": "On/Off",
-        "Mixer_OscillatorGain1": "Level",
+        "Mixer_OscillatorGain1": "Osc 1 Mix",
         "Filter_OscillatorThrough1": "Filter",
         "Mixer_OscillatorOn2": "On/Off",
-        "Mixer_OscillatorGain2": "Level",
+        "Mixer_OscillatorGain2": "Osc 2 Mix",
         "Filter_OscillatorThrough2": "Filter",
         "Mixer_NoiseOn": "On/Off",
         "Mixer_NoiseLevel": "Level",

--- a/static/style.css
+++ b/static/style.css
@@ -508,6 +508,12 @@ select {
     gap: 0.5rem;
 }
 
+.param-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 .param-item {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- tweak synth parameter panel layout for Drift
- show oscillator controls in structured rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844871143f48325858d05de9490b392