### PR TITLE
Revise Drift filter layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -252,6 +252,7 @@ class SynthParamEditorHandler(BaseHandler):
 
         schema = load_drift_schema()
         sections = {s: [] for s in self.SECTION_ORDER}
+        filter_items = {}
 
         for i, item in enumerate(params):
             name = item['name']
@@ -285,7 +286,29 @@ class SynthParamEditorHandler(BaseHandler):
             html += '</div>'
 
             section = self._get_section(name)
-            sections[section].append(html)
+            if section == "Filter":
+                filter_items[name] = html
+            else:
+                sections[section].append(html)
+
+        if filter_items:
+            filter_rows = [
+                ["Filter_Frequency", "Filter_Type", "Filter_Tracking"],
+                ["Filter_Resonance", "Filter_HiPassFrequency"],
+                [
+                    "Filter_ModSource1",
+                    "Filter_ModAmount1",
+                    "Filter_ModSource2",
+                    "Filter_ModAmount2",
+                ],
+            ]
+            ordered = []
+            for row in filter_rows:
+                row_html = "".join(filter_items.pop(p, "") for p in row if p in filter_items)
+                if row_html:
+                    ordered.append(f'<div class="param-row">{row_html}</div>')
+            ordered.extend(filter_items.values())
+            sections["Filter"] = ordered
 
         out_html = '<div class="drift-param-panels">'
         for sec in self.SECTION_ORDER:

--- a/static/style.css
+++ b/static/style.css
@@ -502,6 +502,15 @@ select {
     flex: 2;
 }
 
+.param-panel.filter .param-items {
+    flex-direction: column;
+}
+
+.param-row {
+    display: flex;
+    gap: 0.5rem;
+}
+
 .param-items {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- update CSS for filter rows
- arrange Drift filter parameters into three rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448738f3788325b4c030caee3c5ee2