### PR TITLE
Refine Drift params layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -378,17 +378,13 @@ class SynthParamEditorHandler(BaseHandler):
             pm_src2 = extra_controls.pop("PitchModulation_Source2", "")
             pm_amt1 = extra_controls.pop("PitchModulation_Amount1", "")
             pm_amt2 = extra_controls.pop("PitchModulation_Amount2", "")
-            pitch_html = ""
             if pm_src1 or pm_src2 or pm_amt1 or pm_amt2:
-                pitch_html += '<div class="pitch-mod"><h4>Pitch Mod</h4>'
-                row_a = pm_src1 + pm_src2
-                row_b = pm_amt1 + pm_amt2
-                if row_a:
-                    pitch_html += f'<div class="param-row">{row_a}</div>'
-                if row_b:
-                    pitch_html += f'<div class="param-row">{row_b}</div>'
-                pitch_html += '</div>'
-            if pitch_html:
+                pitch_html = (
+                    '<div class="pitch-mod"><h4>Pitch Mod</h4>'
+                    f'<div class="pitch-mod-pair">{pm_src1}{pm_amt1}</div>'
+                    f'<div class="pitch-mod-pair">{pm_src2}{pm_amt2}</div>'
+                    '</div>'
+                )
                 ordered.append(pitch_html)
 
             ordered.extend(osc_items.values())

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -257,7 +257,7 @@ class SynthParamEditorHandler(BaseHandler):
         env_items = {}
         extra_controls = {}
 
-        def build_control(idx, val, meta):
+        def build_control(idx, name, val, meta):
             p_type = meta.get('type')
             if p_type == 'enum' and meta.get('options'):
                 ctrl = '<select name="param_%d_value">' % idx
@@ -270,24 +270,32 @@ class SynthParamEditorHandler(BaseHandler):
                 max_attr = f' data-max="{meta.get("max")}"' if meta.get("max") is not None else ''
                 val_attr = f' data-value="{val}"'
                 unit_attr = ''
-                if meta.get("unit"):
-                    unit = meta.get("unit")
-                    if unit == 'st':
-                        unit = 'semitone'
-                    unit_attr = f' data-unit="{unit}"'
+                if meta.get("unit") and meta.get("unit") != 'st':
+                    unit_attr = f' data-unit="{meta.get("unit")}"'
                 dec_attr = f' data-decimals="{meta.get("decimals")}"' if meta.get("decimals") is not None else ''
                 display_id = f'param_{idx}_display'
-                ctrl = (
-                    f'<div id="param_{idx}_dial" class="param-dial" data-target="param_{idx}_value" '
-                    f'data-display="{display_id}"{min_attr}{max_attr}{val_attr}{unit_attr}{dec_attr}></div>'
-                )
+                slider_names = {
+                    "Oscillator1_ShapeMod",
+                    "PitchModulation_Amount1",
+                    "PitchModulation_Amount2",
+                }
+                if name in slider_names:
+                    ctrl = (
+                        f'<div id="param_{idx}_slider" class="param-slider" data-target="param_{idx}_value" '
+                        f'data-display="{display_id}"{min_attr}{max_attr}{val_attr}{unit_attr}{dec_attr}></div>'
+                    )
+                else:
+                    ctrl = (
+                        f'<div id="param_{idx}_dial" class="param-dial" data-target="param_{idx}_value" '
+                        f'data-display="{display_id}"{min_attr}{max_attr}{val_attr}{unit_attr}{dec_attr}></div>'
+                    )
                 ctrl += f'<span id="{display_id}" class="param-number"></span>'
-                ctrl += f'<input type="hidden" name="param_{idx}_value" value="{val}">' 
+                ctrl += f'<input type="hidden" name="param_{idx}_value" value="{val}">'
             return ctrl
 
         def build_item(idx, name, val, meta, hide_label=False):
             label = self.LABEL_OVERRIDES.get(name, name)
-            ctrl = build_control(idx, val, meta)
+            ctrl = build_control(idx, name, val, meta)
             html = '<div class="param-item">'
             if not hide_label:
                 html += f'<span class="param-label">{label}</span>'

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -378,13 +378,14 @@ class SynthParamEditorHandler(BaseHandler):
             pm_src2 = extra_controls.pop("PitchModulation_Source2", "")
             pm_amt1 = extra_controls.pop("PitchModulation_Amount1", "")
             pm_amt2 = extra_controls.pop("PitchModulation_Amount2", "")
-                pitch_html = (
+            if any((pm_src1, pm_src2, pm_amt1, pm_amt2)):
                     '<div class="pitch-mod">'
                     '<h4>Pitch Mod</h4>'
                     '<div class="param-row pitch-mod-row">'
                     f'<div class="pitch-mod-pair">{pm_src1}{pm_amt1}</div>'
                     f'<div class="pitch-mod-pair">{pm_src2}{pm_amt2}</div>'
-                    '</div></div>'
+                    '</div>'
+                    '</div>'
                 )
             sections["Oscillators"] = ordered
 

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -379,10 +379,12 @@ class SynthParamEditorHandler(BaseHandler):
             pm_amt1 = extra_controls.pop("PitchModulation_Amount1", "")
             pm_amt2 = extra_controls.pop("PitchModulation_Amount2", "")
                 pitch_html = (
-                    '<div class="pitch-mod"><h4>Pitch Mod</h4>'
+                    '<div class="pitch-mod">'
+                    '<h4>Pitch Mod</h4>'
+                    '<div class="param-row pitch-mod-row">'
                     f'<div class="pitch-mod-pair">{pm_src1}{pm_amt1}</div>'
                     f'<div class="pitch-mod-pair">{pm_src2}{pm_amt2}</div>'
-                    '</div>'
+                    '</div></div>'
                 )
             sections["Oscillators"] = ordered
 

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -378,16 +378,12 @@ class SynthParamEditorHandler(BaseHandler):
             pm_src2 = extra_controls.pop("PitchModulation_Source2", "")
             pm_amt1 = extra_controls.pop("PitchModulation_Amount1", "")
             pm_amt2 = extra_controls.pop("PitchModulation_Amount2", "")
-            if pm_src1 or pm_src2 or pm_amt1 or pm_amt2:
                 pitch_html = (
                     '<div class="pitch-mod"><h4>Pitch Mod</h4>'
                     f'<div class="pitch-mod-pair">{pm_src1}{pm_amt1}</div>'
                     f'<div class="pitch-mod-pair">{pm_src2}{pm_amt2}</div>'
                     '</div>'
                 )
-                ordered.append(pitch_html)
-
-            ordered.extend(osc_items.values())
             sections["Oscillators"] = ordered
 
         if env_items:

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -38,7 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const unit = el.dataset.unit || '';
         const displayId = el.dataset.display;
         const slider = new Nexus.Slider(el, {
-            size: [20, 70],
+            size: [70, 20],
+            orientation: 'horizontal',
             min: isNaN(min) ? 0 : min,
             max: isNaN(max) ? 1 : max,
             value: isNaN(val) ? 0 : val,

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -27,4 +27,34 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     });
+
+    const sliders = document.querySelectorAll('.param-slider');
+    sliders.forEach(el => {
+        const min = parseFloat(el.dataset.min);
+        const max = parseFloat(el.dataset.max);
+        const val = parseFloat(el.dataset.value);
+        const target = el.dataset.target;
+        const decimals = parseInt(el.dataset.decimals || '2', 10);
+        const unit = el.dataset.unit || '';
+        const displayId = el.dataset.display;
+        const slider = new Nexus.Slider(el, {
+            size: [20, 70],
+            min: isNaN(min) ? 0 : min,
+            max: isNaN(max) ? 1 : max,
+            value: isNaN(val) ? 0 : val,
+            mode: 'absolute'
+        });
+        const format = (v) => Number(v).toFixed(decimals) + (unit ? ' ' + unit : '');
+        const displayEl = displayId ? document.getElementById(displayId) : null;
+        if (displayEl) {
+            displayEl.textContent = isNaN(val) ? 'not set' : format(val);
+        }
+        const input = document.querySelector(`input[name="${target}"]`);
+        if (input) {
+            slider.on('change', v => {
+                input.value = v;
+                if (displayEl) displayEl.textContent = format(v);
+            });
+        }
+    });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -529,7 +529,7 @@ select {
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 90px;
+}
 
 .param-number {
     margin-top: 0.25rem;

--- a/static/style.css
+++ b/static/style.css
@@ -531,8 +531,17 @@ select {
     align-items: center;
 }
 }
+}
 
     display: flex;
+    display: flex;
+    gap: 1rem;
+}
+
+.pitch-mod-pair {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     gap: 1rem;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -530,7 +530,16 @@ select {
     flex-direction: column;
     align-items: center;
 }
+}
 
+    display: flex;
+    gap: 1rem;
+}
+
+.pitch-mod-pair {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 .param-number {
     margin-top: 0.25rem;
     min-width: 60px;

--- a/static/style.css
+++ b/static/style.css
@@ -482,6 +482,14 @@ select {
     display: inline-block;
 }
 
+/* Slider controls */
+.param-slider {
+    margin: 0.25rem;
+    display: inline-block;
+    height: 70px;
+    width: 20px;
+}
+
 /* Layout for the Drift parameter editor */
 .drift-param-panels {
     display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -486,8 +486,8 @@ select {
 .param-slider {
     margin: 0.25rem;
     display: inline-block;
-    height: 70px;
-    width: 20px;
+    height: 20px;
+    width: 70px;
 }
 
 /* Layout for the Drift parameter editor */

--- a/static/style.css
+++ b/static/style.css
@@ -534,6 +534,9 @@ select {
 }
 
     display: flex;
+}
+
+.pitch-mod-row {
     display: flex;
     gap: 1rem;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -524,10 +524,26 @@ select {
     width: 90px;
 
 .param-number {
-    margin-left: 0.5rem;
+    margin-top: 0.25rem;
     min-width: 60px;
     display: inline-block;
-    text-align: right;
+    text-align: center;
+}
+
+.param-label {
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+    text-align: center;
+}
+
+.shape-mod {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.pitch-mod {
+    margin-top: 0.5rem;
 }
   
 .param-item {


### PR DESCRIPTION
## Summary
- adjust oscillator layout in `synth_param_editor_handler_class`
- center knob labels and values via CSS
- add containers for shape modulation and pitch modulation controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844917c19248325a3e922f31e6afa32