### PR TITLE
Update mixer rows for synth parameters

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -255,6 +255,7 @@ class SynthParamEditorHandler(BaseHandler):
         filter_items = {}
         osc_items = {}
         env_items = {}
+        mixer_items = {}
 
         for i, item in enumerate(params):
             name = item['name']
@@ -294,6 +295,8 @@ class SynthParamEditorHandler(BaseHandler):
                 osc_items[name] = html
             elif section == "Envelopes":
                 env_items[name] = html
+            elif section == "Mixer":
+                mixer_items[name] = html
             else:
                 sections[section].append(html)
 
@@ -316,26 +319,37 @@ class SynthParamEditorHandler(BaseHandler):
             ordered.extend(filter_items.values())
             sections["Filter"] = ordered
 
+        if mixer_items:
+            mixer_rows = [
+                ["Mixer_OscillatorOn1", "Mixer_OscillatorGain1", "Filter_OscillatorThrough1"],
+                ["Mixer_OscillatorOn2", "Mixer_OscillatorGain2", "Filter_OscillatorThrough2"],
+                ["Mixer_NoiseOn", "Mixer_NoiseLevel", "Filter_NoiseThrough"],
+            ]
+            ordered = []
+            for row in mixer_rows:
+                row_html = "".join(mixer_items.pop(p, "") for p in row if p in mixer_items)
+                if row_html:
+                    ordered.append(f'<div class="param-row">{row_html}</div>')
+            ordered.extend(mixer_items.values())
+            sections["Mixer"] = ordered
+
         if osc_items:
             osc_rows = [
                 [
                     "Oscillator1_Type",
                     "Oscillator1_Transpose",
                     "Oscillator1_Shape",
-                    "Mixer_OscillatorGain1",
                 ],
                 [
                     "Oscillator2_Type",
                     "Oscillator2_Transpose",
                     "Oscillator2_Detune",
-                    "Mixer_OscillatorGain2",
                 ],
                 [
                     "PitchModulation_Source1",
                     "PitchModulation_Amount1",
                     "PitchModulation_Source2",
                     "PitchModulation_Amount2",
-                    "Mixer_NoiseLevel",
                 ],
             ]
             ordered = []


### PR DESCRIPTION
## Summary
- organize mixer controls into three dedicated rows
- remove mixer values from oscillator section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684499b018348325bb2d78218cdc294e