### PR TITLE
Fix newline on param editor output

### DIFF
--- a/core/synth_param_editor_handler.py
+++ b/core/synth_param_editor_handler.py
@@ -86,6 +86,7 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
         dest = output_path or preset_path
         with open(dest, "w") as f:
             json.dump(preset_data, f, indent=2)
+            f.write("\n")
 
         return {
             "success": True,

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -16,6 +16,7 @@ from core.midi_pattern_generator import (
     generate_pattern_set,
     create_c_major_downbeats,
 )
+from core.synth_param_editor_handler import update_parameter_values
 
 
 def test_reverse_wav_file(tmp_path):
@@ -99,3 +100,22 @@ def test_time_stretch_wav(tmp_path, monkeypatch):
 def test_get_rubberband_binary_exists():
     path = get_rubberband_binary()
     assert path.exists()
+
+
+def test_update_parameter_values(tmp_path):
+    src = Path("examples/Track Presets/Drift/Analog Shape.ablpreset")
+    dest = tmp_path / "out.ablpreset"
+    result = update_parameter_values(str(src), {"Oscillator1_Shape": "0.5"}, str(dest))
+    assert result["success"], result.get("message")
+    with open(dest, "rb") as f:
+        data = f.read()
+    assert data.endswith(b"\n")
+    preset = json.loads(data)
+    val = (
+        preset["chains"][0]
+        ["devices"][0]
+        ["chains"][0]
+        ["devices"][0]
+        ["parameters"]["Oscillator1_Shape"]["value"]
+    )
+    assert abs(val - 0.5) < 1e-6


### PR DESCRIPTION
## Summary
- ensure drift param editor writes trailing newline like example presets
- test update_parameter_values format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449a5f8e4c832599c43ec76f69951f