### PR TITLE
Add waveform dropdown demo

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -266,11 +266,41 @@ class SynthParamEditorHandler(BaseHandler):
             html = '<div class="param-item">'
             html += f'<label>{label}: '
             if p_type == 'enum' and meta.get('options'):
-                html += f'<select name="param_{i}_value">'
-                for opt in meta['options']:
-                    selected = ' selected' if str(val) == str(opt) else ''
-                    html += f'<option value="{opt}"{selected}>{opt}</option>'
-                html += '</select>'
+                if name in ("Oscillator1_Type", "Oscillator2_Type"):
+                    dropdown_id = f"waveformDropdown{i}"
+                    sprite_path = "/static/osc_waveform_sprite.svg"
+                    icon_map = {
+                        "Pulse": "pulse",
+                        "Rectangle": "rectangle",
+                        "Saturated": "saturated",
+                        "Saw": "saw",
+                        "Shark Tooth": "sharktooth",
+                        "Sine": "sine",
+                        "Triangle": "triangle",
+                    }
+                    use_href = f"{sprite_path}#{icon_map.get(val, 'sine')}"
+                    html += (
+                        f'<div class="waveform-dropdown" id="{dropdown_id}">' 
+                        f'<button type="button" class="dropdown-toggle" aria-haspopup="listbox" aria-expanded="false">'
+                        f'<svg class="waveform-icon" aria-hidden="true"><use xlink:href="{use_href}"></use></svg>'
+                        f'<span class="visually-hidden">{val}</span></button>'
+                        f'<ul class="dropdown-menu" role="listbox" tabindex="-1">'
+                    )
+                    for opt in meta['options']:
+                        icon_id = icon_map.get(opt, 'sine')
+                        selected_attr = ' aria-selected="true"' if str(val) == str(opt) else ''
+                        html += (
+                            f'<li role="option" data-waveform="{icon_id}" data-value="{opt}"{selected_attr}>'
+                            f'<svg class="waveform-icon" aria-hidden="true"><use xlink:href="{sprite_path}#{icon_id}"></use></svg>'
+                            f'<span class="visually-hidden">{opt}</span></li>'
+                        )
+                    html += f'</ul><input type="hidden" name="param_{i}_value" value="{val}"></div>'
+                else:
+                    html += f'<select name="param_{i}_value">'
+                    for opt in meta['options']:
+                        selected = ' selected' if str(val) == str(opt) else ''
+                        html += f'<option value="{opt}"{selected}>{opt}</option>'
+                    html += '</select>'
             else:
                 min_attr = f' data-min="{meta.get("min")}"' if meta.get("min") is not None else ''
                 max_attr = f' data-max="{meta.get("max")}"' if meta.get("max") is not None else ''

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -461,6 +461,12 @@ def synth_knobs():
     return render_template("synth_knobs.html", active_tab="synth-knobs")
 
 
+@app.route("/waveform-dropdown", methods=["GET"])
+def waveform_dropdown():
+    """Demo page for oscillator waveform dropdown."""
+    return render_template("waveform_dropdown.html", active_tab="waveform-dropdown")
+
+
 
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -533,3 +533,73 @@ select {
 .param-item {
     margin-bottom: 0.75rem;
   }
+
+/* Waveform dropdown styles */
+.waveform-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.waveform-dropdown .dropdown-toggle {
+  background: white;
+  border: 1px solid #ccc;
+  padding: 2px 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  position: relative;
+}
+.waveform-dropdown .dropdown-toggle::after {
+  content: '';
+  border: 4px solid transparent;
+  border-top-color: #000;
+  margin-left: 4px;
+  align-self: center;
+}
+
+.waveform-dropdown .dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: white;
+  border: 1px solid #ccc;
+  padding: 2px;
+  margin: 0;
+  list-style: none;
+  z-index: 1000;
+  min-width: 40px;
+}
+
+.waveform-dropdown .dropdown-menu li {
+  padding: 2px 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.waveform-dropdown .dropdown-menu li:hover,
+.waveform-dropdown .dropdown-menu li:focus {
+  background-color: #f0f0f0;
+  outline: none;
+}
+
+.waveform-icon {
+  width: 20px;
+  height: 20px;
+  stroke: black;
+  fill: none;
+  stroke-width: 2;
+  display: inline-block;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}

--- a/static/waveform_dropdown.js
+++ b/static/waveform_dropdown.js
@@ -1,0 +1,88 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const dropdowns = document.querySelectorAll('.waveform-dropdown');
+  dropdowns.forEach(dropdown => {
+    const toggle = dropdown.querySelector('.dropdown-toggle');
+    const menu = dropdown.querySelector('.dropdown-menu');
+    const options = Array.from(menu.querySelectorAll('li'));
+
+    let selected = options.find(opt => opt.getAttribute('aria-selected') === 'true') || options[0];
+    let focusedIndex = options.indexOf(selected);
+
+    function closeMenu() {
+      menu.style.display = 'none';
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+
+    function openMenu() {
+      menu.style.display = 'block';
+      toggle.setAttribute('aria-expanded', 'true');
+      menu.focus();
+    }
+
+    function updateSelection(option) {
+      selected = option;
+      const use = toggle.querySelector('use');
+      const newHref = `${use.getAttribute('xlink:href').split('#')[0]}#${option.dataset.waveform}`;
+      use.setAttribute('xlink:href', newHref);
+      toggle.querySelector('.visually-hidden').textContent = option.querySelector('.visually-hidden').textContent;
+      const hidden = dropdown.querySelector('input[type="hidden"]');
+      if (hidden) hidden.value = option.dataset.value || option.dataset.waveform;
+      options.forEach(opt => opt.removeAttribute('aria-selected'));
+      option.setAttribute('aria-selected', 'true');
+    }
+
+    // Initialize selection and ensure menu is closed
+    if (selected) {
+      updateSelection(selected);
+    }
+    closeMenu();
+
+    toggle.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (menu.style.display === 'block') {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    options.forEach((opt, idx) => {
+      opt.addEventListener('click', () => {
+        updateSelection(opt);
+        closeMenu();
+        toggle.focus();
+      });
+      if (opt === selected) {
+        opt.setAttribute('aria-selected', 'true');
+        focusedIndex = idx;
+      }
+    });
+
+    menu.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        focusedIndex = (focusedIndex + 1) % options.length;
+        options[focusedIndex].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        focusedIndex = (focusedIndex - 1 + options.length) % options.length;
+        options[focusedIndex].focus();
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        updateSelection(options[focusedIndex]);
+        closeMenu();
+        toggle.focus();
+      } else if (e.key === 'Escape') {
+        closeMenu();
+        toggle.focus();
+      }
+    });
+
+    // Close menu when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!dropdown.contains(e.target)) {
+        closeMenu();
+      }
+    });
+  });
+});

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -16,6 +16,7 @@
         <a href="{{ host_prefix }}/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Macros</a>
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Params</a>
         <a href="{{ host_prefix }}/synth-knobs" class="{% if active_tab == 'synth-knobs' %}active{% endif %}">Knobs</a>
+        <a href="{{ host_prefix }}/waveform-dropdown" class="{% if active_tab == 'waveform-dropdown' %}active{% endif %}">Waveform</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
     </nav>

--- a/templates_jinja/waveform_dropdown.html
+++ b/templates_jinja/waveform_dropdown.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Oscillator Waveform</h2>
+<div class="waveform-dropdown">
+  <button type="button" class="dropdown-toggle" aria-haspopup="listbox" aria-expanded="false">
+    <svg class="waveform-icon" aria-hidden="true">
+      <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#sine"></use>
+    </svg>
+    <span class="visually-hidden">Sine</span>
+  </button>
+  <ul class="dropdown-menu" role="listbox" tabindex="-1">
+    <li role="option" data-waveform="pulse">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#pulse"></use>
+      </svg>
+      <span class="visually-hidden">Pulse</span>
+    </li>
+    <li role="option" data-waveform="rectangle">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#rectangle"></use>
+      </svg>
+      <span class="visually-hidden">Rectangle</span>
+    </li>
+    <li role="option" data-waveform="saturated">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#saturated"></use>
+      </svg>
+      <span class="visually-hidden">Saturated</span>
+    </li>
+    <li role="option" data-waveform="saw">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#saw"></use>
+      </svg>
+      <span class="visually-hidden">Saw</span>
+    </li>
+    <li role="option" data-waveform="sharktooth">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#sharktooth"></use>
+      </svg>
+      <span class="visually-hidden">Sharktooth</span>
+    </li>
+    <li role="option" data-waveform="sine">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#sine"></use>
+      </svg>
+      <span class="visually-hidden">Sine</span>
+    </li>
+    <li role="option" data-waveform="triangle">
+      <svg class="waveform-icon" aria-hidden="true">
+        <use xlink:href="{{ host_prefix }}/static/osc_waveform_sprite.svg#triangle"></use>
+      </svg>
+      <span class="visually-hidden">Triangle</span>
+    </li>
+  </ul>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/waveform_dropdown.js"></script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -361,3 +361,9 @@ def test_synth_knobs_get(client):
     resp = client.get('/synth-knobs')
     assert resp.status_code == 200
     assert b'id="knob-container"' in resp.data
+
+
+def test_waveform_dropdown_get(client):
+    resp = client.get('/waveform-dropdown')
+    assert resp.status_code == 200
+    assert b'waveform-dropdown' in resp.data


### PR DESCRIPTION
## Summary
- add demo page for waveform dropdown
- style dropdown and icons with CSS
- add JavaScript to manage selection and accessibility
- wire route and navigation link
- test new route
- refine dropdown styling and integrate into parameter editor
- prevent form submission when using waveform dropdown

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844954d0d908325815af5daf1db3218