### PR TITLE
Add drift params tool

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -416,6 +416,11 @@ def chord():
     return render_template("chord.html", active_tab="chord")
 
 
+@app.route("/drift-params", methods=["GET"])
+def drift_params():
+    return render_template("drift_params.html", active_tab="drift-params")
+
+
 
 
 

--- a/offline-tools/drift_params.html
+++ b/offline-tools/drift_params.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Drift Parameter Tool</title>
+  <link rel="stylesheet" href="shared.css">
+  <link rel="stylesheet" href="https://unpkg.com/nexusui@2.0.10/dist/nexusui.css">
+  <style>
+    .drift-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; text-align: center; }
+    .pitch-mod-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; text-align: center; }
+    .control-pair { display: flex; flex-direction: column; align-items: center; }
+    .control-pair label { margin-bottom: 0.25rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>Drift Parameter Tool</h2>
+    <div class="drift-grid" id="osc1-row">
+      <div class="control-pair">
+        <label>Osc 1</label>
+        <select id="osc1_type">
+          <option>Sine</option>
+          <option>Square</option>
+          <option>Saw</option>
+        </select>
+      </div>
+      <div class="control-pair">
+        <label>Semitone</label>
+        <div id="osc1_semitone"></div>
+        <span id="osc1_semitone_val"></span>
+      </div>
+      <div class="control-pair">
+        <label>Shape</label>
+        <div id="osc1_shape"></div>
+        <span id="osc1_shape_val"></span>
+      </div>
+      <div class="control-pair">
+        <select id="osc1_shape_mod_source">
+          <option>None</option>
+          <option>LFO 1</option>
+          <option>Env 2</option>
+        </select>
+        <div id="osc1_shape_mod_amt"></div>
+      </div>
+    </div>
+    <div class="drift-grid" id="osc2-row" style="margin-top:1rem;">
+      <div class="control-pair">
+        <label>Osc 2</label>
+        <select id="osc2_type">
+          <option>Sine</option>
+          <option>Square</option>
+          <option>Saw</option>
+        </select>
+      </div>
+      <div class="control-pair">
+        <label>Semitone</label>
+        <div id="osc2_semitone"></div>
+        <span id="osc2_semitone_val"></span>
+      </div>
+      <div class="control-pair">
+        <label>Shape</label>
+        <div id="osc2_shape"></div>
+        <span id="osc2_shape_val"></span>
+      </div>
+      <div class="control-pair">
+        <label>Detune</label>
+        <div id="osc2_detune"></div>
+        <span id="osc2_detune_val"></span>
+      </div>
+    </div>
+    <div style="margin-top:1.5rem;">
+      <h3 style="text-align:center;">Pitch Mod</h3>
+      <div class="pitch-mod-grid">
+        <div class="control-pair">
+          <select id="pitch_mod_src1">
+            <option>None</option>
+            <option>LFO 1</option>
+            <option>Env 2</option>
+          </select>
+          <div id="pitch_mod_amt1"></div>
+        </div>
+        <div class="control-pair">
+          <select id="pitch_mod_src2">
+            <option>None</option>
+            <option>LFO 2</option>
+            <option>Env 3</option>
+          </select>
+          <div id="pitch_mod_amt2"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://unpkg.com/nexusui@2.0.10/dist/NexusUI.min.js"></script>
+  <script src="drift_params.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', initDriftParams);
+  </script>
+</body>
+</html>

--- a/offline-tools/drift_params.js
+++ b/offline-tools/drift_params.js
@@ -1,0 +1,19 @@
+function initDriftParams() {
+  const osc1Semi = new Nexus.Dial('#osc1_semitone', {size:[60,60],min:-24,max:24,value:0});
+  const osc1Shape = new Nexus.Dial('#osc1_shape', {size:[60,60],min:0,max:1,value:0});
+  const osc2Semi = new Nexus.Dial('#osc2_semitone', {size:[60,60],min:-24,max:24,value:0});
+  const osc2Shape = new Nexus.Dial('#osc2_shape', {size:[60,60],min:0,max:1,value:0});
+  const osc2Detune = new Nexus.Dial('#osc2_detune', {size:[60,60],min:-50,max:50,value:0});
+  const shapeModAmt = new Nexus.Slider('#osc1_shape_mod_amt', {size:[120,20],mode:'absolute',min:0,max:1,value:0});
+  const pitchAmt1 = new Nexus.Slider('#pitch_mod_amt1', {size:[120,20],mode:'absolute',min:0,max:1,value:0});
+  const pitchAmt2 = new Nexus.Slider('#pitch_mod_amt2', {size:[120,20],mode:'absolute',min:0,max:1,value:0});
+
+  osc1Semi.on('change', v => document.getElementById('osc1_semitone_val').textContent = v.toFixed(0));
+  osc1Shape.on('change', v => document.getElementById('osc1_shape_val').textContent = (v*100).toFixed(0) + '%');
+  osc2Semi.on('change', v => document.getElementById('osc2_semitone_val').textContent = v.toFixed(0));
+  osc2Shape.on('change', v => document.getElementById('osc2_shape_val').textContent = (v*100).toFixed(0) + '%');
+  osc2Detune.on('change', v => document.getElementById('osc2_detune_val').textContent = v.toFixed(1) + 'c');
+  shapeModAmt.on('change', v => {});
+  pitchAmt1.on('change', v => {});
+  pitchAmt2.on('change', v => {});
+}

--- a/offline-tools/shared.css
+++ b/offline-tools/shared.css
@@ -155,3 +155,24 @@ select {
     letter-spacing: normal;
   }
 }
+
+/* Layout helpers for Drift params tool */
+.drift-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  text-align: center;
+}
+
+.pitch-mod-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  text-align: center;
+}
+
+.control-pair {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/static/drift_params.js
+++ b/static/drift_params.js
@@ -1,0 +1,16 @@
+function initDriftParams() {
+  const osc1Semi = new Nexus.Dial('#osc1_semitone', {size:[60,60],min:-24,max:24,value:0});
+  const osc1Shape = new Nexus.Dial('#osc1_shape', {size:[60,60],min:0,max:1,value:0});
+  const osc2Semi = new Nexus.Dial('#osc2_semitone', {size:[60,60],min:-24,max:24,value:0});
+  const osc2Shape = new Nexus.Dial('#osc2_shape', {size:[60,60],min:0,max:1,value:0});
+  const osc2Detune = new Nexus.Dial('#osc2_detune', {size:[60,60],min:-50,max:50,value:0});
+  const shapeModAmt = new Nexus.Slider('#osc1_shape_mod_amt', {size:[120,20],mode:'absolute',min:0,max:1,value:0});
+  const pitchAmt1 = new Nexus.Slider('#pitch_mod_amt1', {size:[120,20],mode:'absolute',min:0,max:1,value:0});
+  const pitchAmt2 = new Nexus.Slider('#pitch_mod_amt2', {size:[120,20],mode:'absolute',min:0,max:1,value:0});
+
+  osc1Semi.on('change', v => document.getElementById('osc1_semitone_val').textContent = v.toFixed(0));
+  osc1Shape.on('change', v => document.getElementById('osc1_shape_val').textContent = (v*100).toFixed(0)+'%');
+  osc2Semi.on('change', v => document.getElementById('osc2_semitone_val').textContent = v.toFixed(0));
+  osc2Shape.on('change', v => document.getElementById('osc2_shape_val').textContent = (v*100).toFixed(0)+'%');
+  osc2Detune.on('change', v => document.getElementById('osc2_detune_val').textContent = v.toFixed(1)+'c');
+}

--- a/static/style.css
+++ b/static/style.css
@@ -457,3 +457,24 @@ select {
     cursor: pointer;
 }
 
+/* Layout helpers for Drift params tool */
+.drift-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    text-align: center;
+}
+
+.pitch-mod-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    text-align: center;
+}
+
+.control-pair {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -14,6 +14,7 @@
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
         <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>
         <a href="{{ host_prefix }}/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Macros</a>
+        <a href="{{ host_prefix }}/drift-params" class="{% if active_tab == 'drift-params' %}active{% endif %}">Drift Params</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
     </nav>

--- a/templates_jinja/drift_params.html
+++ b/templates_jinja/drift_params.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Drift Parameter Tool</h2>
+<div class="drift-grid" id="osc1-row">
+  <div class="control-pair">
+    <label>Osc 1</label>
+    <select id="osc1_type">
+      <option>Sine</option>
+      <option>Square</option>
+      <option>Saw</option>
+    </select>
+  </div>
+  <div class="control-pair">
+    <label>Semitone</label>
+    <div id="osc1_semitone"></div>
+    <span id="osc1_semitone_val"></span>
+  </div>
+  <div class="control-pair">
+    <label>Shape</label>
+    <div id="osc1_shape"></div>
+    <span id="osc1_shape_val"></span>
+  </div>
+  <div class="control-pair">
+    <select id="osc1_shape_mod_source">
+      <option>None</option>
+      <option>LFO 1</option>
+      <option>Env 2</option>
+    </select>
+    <div id="osc1_shape_mod_amt"></div>
+  </div>
+</div>
+<div class="drift-grid" id="osc2-row" style="margin-top:1rem;">
+  <div class="control-pair">
+    <label>Osc 2</label>
+    <select id="osc2_type">
+      <option>Sine</option>
+      <option>Square</option>
+      <option>Saw</option>
+    </select>
+  </div>
+  <div class="control-pair">
+    <label>Semitone</label>
+    <div id="osc2_semitone"></div>
+    <span id="osc2_semitone_val"></span>
+  </div>
+  <div class="control-pair">
+    <label>Shape</label>
+    <div id="osc2_shape"></div>
+    <span id="osc2_shape_val"></span>
+  </div>
+  <div class="control-pair">
+    <label>Detune</label>
+    <div id="osc2_detune"></div>
+    <span id="osc2_detune_val"></span>
+  </div>
+</div>
+<div style="margin-top:1.5rem;">
+  <h3 style="text-align:center;">Pitch Mod</h3>
+  <div class="pitch-mod-grid">
+    <div class="control-pair">
+      <select id="pitch_mod_src1">
+        <option>None</option>
+        <option>LFO 1</option>
+        <option>Env 2</option>
+      </select>
+      <div id="pitch_mod_amt1"></div>
+    </div>
+    <div class="control-pair">
+      <select id="pitch_mod_src2">
+        <option>None</option>
+        <option>LFO 2</option>
+        <option>Env 3</option>
+      </select>
+      <div id="pitch_mod_amt2"></div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/nexusui@2.0.10/dist/nexusui.css">
+<script src="https://unpkg.com/nexusui@2.0.10/dist/NexusUI.min.js"></script>
+<script src="{{ host_prefix }}/static/drift_params.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', initDriftParams);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new Drift Params tool page using NexusUI
- wire up `/drift-params` route and navigation
- style helper classes for new layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449f38c1d88325a06aaac5f3c44704