### PR TITLE
Add Drift parameter smoke test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ Located in `utility-scripts/`:
 - `install-on-move.sh` / `.command`: Content installation
 - `update-on-move.sh` / `.command`: Update with latest files
 - `restart-webserver.sh`: Restart the webserver
+- `drift_param_smoke_test.py`: Generate preset files with boundary values for every Drift parameter
+
+To create the presets, run:
+
+```bash
+python utility-scripts/drift_param_smoke_test.py --output-dir my_presets
+```
+
+This writes every generated `.ablpreset` and a `results.csv` file to `my_presets/`.
 
 
 ## How to Auto-start on Boot

--- a/tests/test_drift_param_validation.py
+++ b/tests/test_drift_param_validation.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from core.synth_preset_inspector_handler import (
+    load_drift_schema,
+    extract_parameter_values,
+)
+from core.synth_param_editor_handler import update_parameter_values
+
+SCHEMA = load_drift_schema()
+BASE_PRESET = Path('examples/Track Presets/Drift/Analog Shape.ablpreset')
+
+
+def validate_value(name, value):
+    meta = SCHEMA.get(name)
+    if not meta:
+        return True
+    typ = meta.get('type')
+    if typ == 'number':
+        if not isinstance(value, (int, float)):
+            return False
+        if meta.get('min') is not None and value < meta['min']:
+            return False
+        if meta.get('max') is not None and value > meta['max']:
+            return False
+        if meta.get('decimals') == 0 and not float(value).is_integer():
+            return False
+    elif typ == 'boolean':
+        if isinstance(value, bool):
+            return True
+        if value not in (0, 1):
+            return False
+    elif typ == 'enum':
+        if value not in meta.get('options', []):
+            return False
+    return True
+
+
+def load_values(preset):
+    info = extract_parameter_values(str(preset))
+    assert info['success'], info['message']
+    return {p['name']: p['value'] for p in info['parameters']}
+
+
+def test_base_preset_key_params_valid(tmp_path):
+    values = load_values(BASE_PRESET)
+    assert validate_value('Global_Transpose', values['Global_Transpose'])
+    assert validate_value('Filter_NoiseThrough', values['Filter_NoiseThrough'])
+
+
+def test_invalid_transpose(tmp_path):
+    dest = tmp_path / 'invalid.ablpreset'
+    update_parameter_values(str(BASE_PRESET), {'Global_Transpose': '0.5'}, str(dest))
+    vals = load_values(dest)
+    assert not validate_value('Global_Transpose', vals['Global_Transpose'])
+
+
+def test_invalid_filter_through(tmp_path):
+    dest = tmp_path / 'invalid.ablpreset'
+    update_parameter_values(str(BASE_PRESET), {'Filter_NoiseThrough': '2'}, str(dest))
+    vals = load_values(dest)
+    assert not validate_value('Filter_NoiseThrough', vals['Filter_NoiseThrough'])

--- a/utility-scripts/drift_param_smoke_test.py
+++ b/utility-scripts/drift_param_smoke_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate Drift presets with boundary values for each parameter.
+
+This script iterates over all parameters present in the example
+`Analog Shape` preset and creates copies of the preset with the
+parameter set to -1, 0, 0.5, and 1. The results are written to a CSV
+file along with whether each generated preset still passes the schema
+validation check.
+"""
+
+from pathlib import Path
+import argparse
+import csv
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.synth_preset_inspector_handler import (
+    load_drift_schema,
+    extract_available_parameters,
+    extract_parameter_values,
+)
+from core.synth_param_editor_handler import update_parameter_values
+
+TEST_VALUES = [-1, 0, 0.5, 1]
+BASE_PRESET = Path("examples/Track Presets/Drift/Analog Shape.ablpreset")
+SCHEMA = load_drift_schema()
+
+
+def validate_value(name: str, value):
+    """Return True if *value* conforms to the schema entry for *name*."""
+    meta = SCHEMA.get(name)
+    if not meta:
+        return True
+    typ = meta.get("type")
+    if typ == "number":
+        if meta.get("min") is not None and value < meta["min"]:
+            return False
+        if meta.get("max") is not None and value > meta["max"]:
+            return False
+        if meta.get("decimals") == 0 and not float(value).is_integer():
+            return False
+    elif typ == "boolean":
+        if value not in (0, 1, True, False):
+            return False
+    elif typ == "enum":
+        if value not in meta.get("options", []):
+            return False
+    return True
+
+
+def main(output_dir: str) -> None:
+    info = extract_available_parameters(str(BASE_PRESET))
+    if not info["success"]:
+        raise RuntimeError(info["message"])
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / "results.csv"
+
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["parameter", "value", "update_success", "valid"])
+
+        for param in sorted(info["parameters"]):
+            for val in TEST_VALUES:
+                safe_name = param.replace("/", "_").replace(" ", "_")
+                dest = out_dir / f"{safe_name}_{val}.ablpreset"
+                result = update_parameter_values(
+                    str(BASE_PRESET), {param: str(val)}, str(dest)
+                )
+                valid = False
+                if result["success"]:
+                    vals = extract_parameter_values(str(dest))
+                    if vals["success"]:
+                        param_vals = {
+                            p["name"]: p["value"] for p in vals["parameters"]
+                        }
+                        valid = validate_value(param, param_vals.get(param))
+                writer.writerow([param, val, result["success"], valid])
+                status = "OK" if result["success"] else "FAIL"
+                print(f"{param}={val}: {status}, valid={valid}")
+
+    print(f"Results written to {csv_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Create test presets for all Drift parameters"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="generated_presets",
+        help="Directory where presets and results.csv will be written",
+    )
+    args = parser.parse_args()
+    main(args.output_dir)


### PR DESCRIPTION
## Summary
- add `drift_param_smoke_test.py` utility script for generating presets with boundary parameter values
- iterate over all parameters in example preset and validate them against schema
- ensure the script can be run directly and outputs all presets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449f9420c8832591b3af581b5a1541