### PR TITLE
Refine Drift params layout

### DIFF
--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -28,6 +28,38 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    const sliders = document.querySelectorAll('.param-slider');
+    sliders.forEach(el => {
+        const min = parseFloat(el.dataset.min);
+        const max = parseFloat(el.dataset.max);
+        const val = parseFloat(el.dataset.value);
+        const target = el.dataset.target;
+        const decimals = parseInt(el.dataset.decimals || '2', 10);
+        const unit = el.dataset.unit || '';
+        const displayId = el.dataset.display;
+        const slider = new Nexus.Slider(el, {
+            size: [80,20],
+            mode: 'absolute',
+            min: isNaN(min) ? 0 : min,
+            max: isNaN(max) ? 1 : max,
+            step: 0,
+            value: isNaN(val) ? 0 : val,
+            orientation: 'horizontal'
+        });
+        const format = (v) => Number(v).toFixed(decimals) + (unit ? ' ' + unit : '');
+        const displayEl = displayId ? document.getElementById(displayId) : null;
+        if (displayEl) {
+            displayEl.textContent = isNaN(val) ? 'not set' : format(val);
+        }
+        const input = document.querySelector(`input[name="${target}"]`);
+        if (input) {
+            slider.on('change', v => {
+                input.value = v;
+                if (displayEl) displayEl.textContent = format(v);
+            });
+        }
+    });
+
     const toggles = document.querySelectorAll('.param-toggle');
     toggles.forEach(el => {
         const val = parseFloat(el.dataset.value);

--- a/static/style.css
+++ b/static/style.css
@@ -482,6 +482,34 @@ select {
     display: inline-block;
 }
 
+.param-slider {
+    margin: 0.25rem;
+    display: inline-block;
+}
+
+.param-label {
+    font-size: 0.8rem;
+    text-align: center;
+    margin-bottom: 0.25rem;
+}
+
+.param-pair {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.pitch-mod-label {
+    width: 100%;
+    text-align: center;
+    font-weight: bold;
+    margin-top: 0.5rem;
+}
+
+.pitch-mod-row {
+    justify-content: center;
+}
+
 .param-toggle {
     margin: 0.25rem;
     display: inline-block;


### PR DESCRIPTION
## Summary
- refine oscillator layout in `synth_param_editor_handler_class.py`
- add slider and label styling
- handle sliders in `params_knobs.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a1d42c6c8325812a25db419a3e59