### PR TITLE
Revamp filter mod layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -236,6 +236,10 @@ class SynthParamEditorHandler(BaseHandler):
         "PitchModulation_Source2",
         "PitchModulation_Amount1",
         "PitchModulation_Amount2",
+        "Filter_ModSource1",
+        "Filter_ModSource2",
+        "Filter_ModAmount1",
+        "Filter_ModAmount2",
     }
 
     # Parameters that use a horizontal slider instead of a dial
@@ -243,6 +247,8 @@ class SynthParamEditorHandler(BaseHandler):
         "Oscillator1_ShapeMod",
         "PitchModulation_Amount1",
         "PitchModulation_Amount2",
+        "Filter_ModAmount1",
+        "Filter_ModAmount2",
     }
 
     def _build_param_item(self, idx, name, value, meta, label=None,
@@ -371,6 +377,7 @@ class SynthParamEditorHandler(BaseHandler):
             pair1 = f'<div class="param-pair">{src1}{amt1}</div>' if (src1 or amt1) else ""
             pair2 = f'<div class="param-pair">{src2}{amt2}</div>' if (src2 or amt2) else ""
             if pair1.strip() or pair2.strip():
+                ordered.append('<div class="freq-mod-label">Freq Mod</div>')
                 ordered.append(f'<div class="param-row filter-mod-row">{pair1}{pair2}</div>')
 
             ordered.extend(filter_items.values())

--- a/static/style.css
+++ b/static/style.css
@@ -506,6 +506,13 @@ select {
     margin-top: 0.5rem;
 }
 
+.freq-mod-label {
+    width: 100%;
+    text-align: center;
+    font-weight: bold;
+    margin-top: 0.5rem;
+}
+
 .pitch-mod-row {
     justify-content: center;
 }


### PR DESCRIPTION
## Summary
- tweak Drift parameter editor to support freq mod section
- hide filter mod labels and use sliders for amounts
- add a Freq Mod label for filter modulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a7b2ab448325b70545834fee7c25