### PR TITLE
Fix percent parameter display

### DIFF
--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -14,7 +14,11 @@ document.addEventListener('DOMContentLoaded', () => {
             max: isNaN(max) ? 1 : max,
             value: isNaN(val) ? 0 : val,
         });
-        const format = (v) => Number(v).toFixed(decimals) + (unit ? ' ' + unit : '');
+        const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
+        const format = (v) => {
+            const displayVal = shouldScale ? v * 100 : v;
+            return Number(displayVal).toFixed(decimals) + (unit ? ' ' + unit : '');
+        };
         const displayEl = displayId ? document.getElementById(displayId) : null;
         if (displayEl) {
             displayEl.textContent = isNaN(val) ? 'not set' : format(val);
@@ -46,7 +50,11 @@ document.addEventListener('DOMContentLoaded', () => {
             value: isNaN(val) ? 0 : val,
             orientation: 'horizontal'
         });
-        const format = (v) => Number(v).toFixed(decimals) + (unit ? ' ' + unit : '');
+        const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
+        const format = (v) => {
+            const displayVal = shouldScale ? v * 100 : v;
+            return Number(displayVal).toFixed(decimals) + (unit ? ' ' + unit : '');
+        };
         const displayEl = displayId ? document.getElementById(displayId) : null;
         if (displayEl) {
             displayEl.textContent = isNaN(val) ? 'not set' : format(val);


### PR DESCRIPTION
## Summary
- scale percentage values in `params_knobs.js` so values like sustain or mod amount show 0‑100% instead of 0‑1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a9b8dbdc8325880d61423456031f