### PR TITLE
Refine envelope cycling controls

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -183,10 +183,11 @@ class SynthParamEditorHandler(BaseHandler):
         "Envelope2_Decay": "Decay",
         "Envelope2_Sustain": "Sustain",
         "Envelope2_Release": "Release",
-        "CyclingEnvelope_Tilt": "Tilt",
+        "CyclingEnvelope_MidPoint": "Tilt",
         "CyclingEnvelope_Hold": "Hold",
         "CyclingEnvelope_Rate": "Rate",
         "CyclingEnvelope_Mode": "Mode",
+        "Global_Envelope2Mode": "Cycle",
 
         # LFO
         "Lfo_Shape": "Shape",
@@ -251,7 +252,7 @@ class SynthParamEditorHandler(BaseHandler):
         p_type = meta.get("type")
         label = label if label is not None else self.LABEL_OVERRIDES.get(name, name)
 
-        html = ['<div class="param-item">']
+        html = [f'<div class="param-item" data-name="{name}">']
         if not hide_label:
             html.append(f'<span class="param-label">{label}</span>')
 
@@ -424,30 +425,48 @@ class SynthParamEditorHandler(BaseHandler):
             sections["Oscillators"] = ordered
 
         if env_items:
-            env_rows = [
-                [
-                    "Envelope1_Attack",
-                    "Envelope1_Decay",
-                    "Envelope1_Sustain",
-                    "Envelope1_Release",
-                ],
-                [
-                    "Envelope2_Attack",
-                    "Envelope2_Decay",
-                    "Envelope2_Sustain",
-                    "Envelope2_Release",
-                ],
-                [
-                    "CyclingEnvelope_MidPoint",
-                    "CyclingEnvelope_Hold",
-                    "CyclingEnvelope_Rate",
-                ],
+            amp_adsr = [
+                env_items.pop("Envelope1_Attack", ""),
+                env_items.pop("Envelope1_Decay", ""),
+                env_items.pop("Envelope1_Sustain", ""),
+                env_items.pop("Envelope1_Release", ""),
             ]
+            env2_adsr = [
+                env_items.pop("Envelope2_Attack", ""),
+                env_items.pop("Envelope2_Decay", ""),
+                env_items.pop("Envelope2_Sustain", ""),
+                env_items.pop("Envelope2_Release", ""),
+            ]
+            cycle_toggle = env_items.pop("Global_Envelope2Mode", "")
+            cycle_extras = [
+                env_items.pop("CyclingEnvelope_MidPoint", ""),
+                env_items.pop("CyclingEnvelope_Hold", ""),
+                env_items.pop("CyclingEnvelope_Rate", ""),
+                env_items.pop("CyclingEnvelope_Mode", ""),
+            ]
+
             ordered = []
-            for row in env_rows:
-                row_html = "".join(env_items.pop(p, "") for p in row if p in env_items)
-                if row_html:
-                    ordered.append(f'<div class="param-row">{row_html}</div>')
+            row1 = "".join(amp_adsr)
+            if row1:
+                ordered.append(
+                    f'<div class="param-row"><span class="param-row-label">Amp envelope</span>{row1}</div>'
+                )
+            row2 = "".join(env2_adsr)
+            if row2:
+                ordered.append(
+                    f'<div class="param-row"><span class="param-row-label">Env 1</span>{row2}</div>'
+                )
+            row3_main = "".join(env2_adsr) + cycle_toggle
+            if row3_main.strip():
+                ordered.append(
+                    f'<div class="param-row env2-main"><span class="param-row-label">Env 2</span>{row3_main}</div>'
+                )
+            row3_extra = "".join(cycle_extras)
+            if row3_extra.strip():
+                ordered.append(
+                    f'<div class="param-row env2-cycling hidden">{row3_extra}</div>'
+                )
+
             ordered.extend(env_items.values())
             sections["Envelopes"] = ordered
 

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -75,4 +75,30 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     });
+
+    const env2Select = document.querySelector('.param-item[data-name="Global_Envelope2Mode"] select');
+    const env2Main = document.querySelector('.env2-main');
+    const env2Cycling = document.querySelector('.env2-cycling');
+    function updateCycling() {
+        if (!env2Select) return;
+        const cyc = env2Select.value === 'Cyc';
+        if (env2Main) {
+            if (cyc) {
+                env2Main.classList.add('hidden');
+            } else {
+                env2Main.classList.remove('hidden');
+            }
+        }
+        if (env2Cycling) {
+            if (cyc) {
+                env2Cycling.classList.remove('hidden');
+            } else {
+                env2Cycling.classList.add('hidden');
+            }
+        }
+    }
+    if (env2Select) {
+        env2Select.addEventListener('change', updateCycling);
+        updateCycling();
+    }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -544,6 +544,13 @@ select {
     gap: 0.5rem;
 }
 
+.param-row-label {
+    width: 80px;
+    display: flex;
+    align-items: center;
+    font-weight: bold;
+}
+
 .param-items {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- rename cycling envelope label overrides
- toggle Env2 cycling row when mode changes
- label the Cycle mode dropdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844a5a28ae8832596e145085f70237c