### PR TITLE
Simplify envelope layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -441,7 +441,7 @@ class SynthParamEditorHandler(BaseHandler):
                 env_items.pop("Envelope1_Sustain", ""),
                 env_items.pop("Envelope1_Release", ""),
             ]
-            env1_adsr = [
+            env2_adsr = [
                 env_items.pop("Envelope2_Attack", ""),
                 env_items.pop("Envelope2_Decay", ""),
                 env_items.pop("Envelope2_Sustain", ""),
@@ -461,20 +461,15 @@ class SynthParamEditorHandler(BaseHandler):
                 ordered.append(
                     f'<div class="param-row"><span class="param-row-label">Amp envelope</span>{row1}</div>'
                 )
-            row2 = "".join(env1_adsr)
-            if row2:
+            row2 = "".join(env2_adsr) + cycle_toggle
+            if row2.strip():
                 ordered.append(
-                    f'<div class="param-row"><span class="param-row-label">Env 1</span>{row2}</div>'
+                    f'<div class="param-row env2-main env2-adsr"><span class="param-row-label">Env 2</span>{row2}</div>'
                 )
-            row3_main = row2 + cycle_toggle
-            if row3_main.strip():
+            row2_extra = "".join(cycle_extras)
+            if row2_extra.strip():
                 ordered.append(
-                    f'<div class="param-row env2-main"><span class="param-row-label">Env 2</span>{row3_main}</div>'
-                )
-            row3_extra = "".join(cycle_extras)
-            if row3_extra.strip():
-                ordered.append(
-                    f'<div class="param-row env2-cycling hidden">{row3_extra}</div>'
+                    f'<div class="param-row env2-cycling hidden"><span class="param-row-label">Env 2</span>{row2_extra}</div>'
                 )
 
             ordered.extend(env_items.values())

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -357,6 +357,17 @@ class SynthParamEditorHandler(BaseHandler):
 
             hide = name in self.UNLABELED_PARAMS
             slider = name in self.SLIDER_PARAMS
+
+            extra = ""
+            if name == "CyclingEnvelope_Rate":
+                extra = "cycle-rate freq-rate"
+            elif name == "CyclingEnvelope_Ratio":
+                extra = "cycle-rate ratio-rate"
+            elif name == "CyclingEnvelope_Time":
+                extra = "cycle-rate time-rate"
+            elif name == "CyclingEnvelope_SyncedRate":
+                extra = "cycle-rate sync-rate"
+
             html = self._build_param_item(
                 i,
                 name,
@@ -365,6 +376,7 @@ class SynthParamEditorHandler(BaseHandler):
                 label=self.LABEL_OVERRIDES.get(name, name),
                 hide_label=hide,
                 slider=slider,
+                extra_classes=extra,
             )
 
             if name == "CyclingEnvelope_Mode":

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -301,7 +301,7 @@ class SynthParamEditorHandler(BaseHandler):
 
     def _get_section(self, name):
         if name == "Global_Envelope2Mode":
-            return "Filter"
+            return "Envelopes"
         if name.startswith(("Oscillator1_", "Oscillator2_", "PitchModulation_")):
             return "Oscillators"
         if name.startswith("Mixer_") or name.startswith("Filter_OscillatorThrough") or name.startswith("Filter_NoiseThrough"):
@@ -364,7 +364,7 @@ class SynthParamEditorHandler(BaseHandler):
 
         if filter_items:
             filter_rows = [
-                ["Filter_Frequency", "Filter_Type", "Filter_Tracking", "Global_Envelope2Mode"],
+                ["Filter_Frequency", "Filter_Type", "Filter_Tracking"],
                 ["Filter_Resonance", "Filter_HiPassFrequency"],
             ]
             ordered = []
@@ -444,12 +444,13 @@ class SynthParamEditorHandler(BaseHandler):
                 env_items.pop("Envelope1_Sustain", ""),
                 env_items.pop("Envelope1_Release", ""),
             ]
-            env_adsr = [
+            env2_adsr = [
                 env_items.pop("Envelope2_Attack", ""),
                 env_items.pop("Envelope2_Decay", ""),
                 env_items.pop("Envelope2_Sustain", ""),
                 env_items.pop("Envelope2_Release", ""),
             ]
+            cycle_toggle = env_items.pop("Global_Envelope2Mode", "")
             cycle_extras = [
                 env_items.pop("CyclingEnvelope_MidPoint", ""),
                 env_items.pop("CyclingEnvelope_Hold", ""),
@@ -463,15 +464,10 @@ class SynthParamEditorHandler(BaseHandler):
                 ordered.append(
                     f'<div class="param-row"><span class="param-row-label">Amp envelope</span>{row1}</div>'
                 )
-            row2 = "".join(env_adsr)
-            if row2:
+            row2_main = "".join(env2_adsr) + cycle_toggle
+            if row2_main.strip():
                 ordered.append(
-                    f'<div class="param-row"><span class="param-row-label">Env 1</span>{row2}</div>'
-                )
-            row3 = "".join(env_adsr)
-            if row3.strip():
-                ordered.append(
-                    f'<div class="param-row env2-main env2-adsr"><span class="param-row-label">Env 2</span>{row3}</div>'
+                    f'<div class="param-row env2-main env2-adsr"><span class="param-row-label">Env 2</span>{row2_main}</div>'
                 )
             row3_extra = "".join(cycle_extras)
             if row3_extra.strip():

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -221,6 +221,7 @@ class SynthParamEditorHandler(BaseHandler):
         "Global_Glide": "Glide",
         "Global_DriftDepth": "Drift",
         "Global_Volume": "Volume",
+        "Global_Envelope2Mode": "Env/Cyc",
         "Global_VolVelMod": "Vel > Vol",
         "Global_Transpose": "Transpose",
         "Global_NotePitchBend": "Note PB",
@@ -299,6 +300,8 @@ class SynthParamEditorHandler(BaseHandler):
         return ''.join(html)
 
     def _get_section(self, name):
+        if name == "Global_Envelope2Mode":
+            return "Filter"
         if name.startswith(("Oscillator1_", "Oscillator2_", "PitchModulation_")):
             return "Oscillators"
         if name.startswith("Mixer_") or name.startswith("Filter_OscillatorThrough") or name.startswith("Filter_NoiseThrough"):
@@ -361,7 +364,7 @@ class SynthParamEditorHandler(BaseHandler):
 
         if filter_items:
             filter_rows = [
-                ["Filter_Frequency", "Filter_Type", "Filter_Tracking"],
+                ["Filter_Frequency", "Filter_Type", "Filter_Tracking", "Global_Envelope2Mode"],
                 ["Filter_Resonance", "Filter_HiPassFrequency"],
             ]
             ordered = []
@@ -441,13 +444,12 @@ class SynthParamEditorHandler(BaseHandler):
                 env_items.pop("Envelope1_Sustain", ""),
                 env_items.pop("Envelope1_Release", ""),
             ]
-            env2_adsr = [
+            env_adsr = [
                 env_items.pop("Envelope2_Attack", ""),
                 env_items.pop("Envelope2_Decay", ""),
                 env_items.pop("Envelope2_Sustain", ""),
                 env_items.pop("Envelope2_Release", ""),
             ]
-            cycle_toggle = env_items.pop("Global_Envelope2Mode", "")
             cycle_extras = [
                 env_items.pop("CyclingEnvelope_MidPoint", ""),
                 env_items.pop("CyclingEnvelope_Hold", ""),
@@ -461,15 +463,20 @@ class SynthParamEditorHandler(BaseHandler):
                 ordered.append(
                     f'<div class="param-row"><span class="param-row-label">Amp envelope</span>{row1}</div>'
                 )
-            row2 = "".join(env2_adsr) + cycle_toggle
-            if row2.strip():
+            row2 = "".join(env_adsr)
+            if row2:
                 ordered.append(
-                    f'<div class="param-row env2-main env2-adsr"><span class="param-row-label">Env 2</span>{row2}</div>'
+                    f'<div class="param-row"><span class="param-row-label">Env 1</span>{row2}</div>'
                 )
-            row2_extra = "".join(cycle_extras)
-            if row2_extra.strip():
+            row3 = "".join(env_adsr)
+            if row3.strip():
                 ordered.append(
-                    f'<div class="param-row env2-cycling hidden"><span class="param-row-label">Env 2</span>{row2_extra}</div>'
+                    f'<div class="param-row env2-main env2-adsr"><span class="param-row-label">Env 2</span>{row3}</div>'
+                )
+            row3_extra = "".join(cycle_extras)
+            if row3_extra.strip():
+                ordered.append(
+                    f'<div class="param-row env2-cycling hidden"><span class="param-row-label">Env 2</span>{row3_extra}</div>'
                 )
 
             ordered.extend(env_items.values())

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -241,6 +241,7 @@ class SynthParamEditorHandler(BaseHandler):
         "Filter_ModSource2",
         "Filter_ModAmount1",
         "Filter_ModAmount2",
+        "Global_Envelope2Mode",
     }
 
     # Parameters that use a horizontal slider instead of a dial
@@ -262,7 +263,16 @@ class SynthParamEditorHandler(BaseHandler):
         if not hide_label:
             html.append(f'<span class="param-label">{label}</span>')
 
-        if p_type == "enum" and meta.get("options"):
+        if name == "Global_Envelope2Mode":
+            true_val = "Cyc"
+            false_val = "Env"
+            html.append(
+                f'<div id="param_{idx}_toggle" class="param-toggle" '
+                f'data-target="param_{idx}_value" data-value="{value}" '
+                f'data-true-value="{true_val}" data-false-value="{false_val}"></div>'
+            )
+            html.append(f'<input type="hidden" name="param_{idx}_value" value="{value}">')
+        elif p_type == "enum" and meta.get("options"):
             html.append(f'<select name="param_{idx}_value">')
             for opt in meta["options"]:
                 sel = " selected" if str(value) == str(opt) else ""
@@ -464,10 +474,14 @@ class SynthParamEditorHandler(BaseHandler):
                 ordered.append(
                     f'<div class="param-row"><span class="param-row-label">Amp envelope</span>{row1}</div>'
                 )
-            row2_main = "".join(env2_adsr) + cycle_toggle
+            if cycle_toggle:
+                ordered.append(
+                    f'<div class="param-row env2-mode"><span class="param-row-label">Env/Cyc</span>{cycle_toggle}</div>'
+                )
+            row2_main = "".join(env2_adsr)
             if row2_main.strip():
                 ordered.append(
-                    f'<div class="param-row env2-main env2-adsr"><span class="param-row-label">Env 2</span>{row2_main}</div>'
+                    f'<div class="param-row env2-adsr"><span class="param-row-label">Env 2</span>{row2_main}</div>'
                 )
             row3_extra = "".join(cycle_extras)
             if row3_extra.strip():

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -104,4 +104,22 @@ document.addEventListener('DOMContentLoaded', () => {
         env2Input.addEventListener('change', updateCycling);
         updateCycling();
     }
+
+    const modeSelect = document.querySelector('.param-item[data-name="CyclingEnvelope_Mode"] select');
+    const rateItem = document.querySelector('.param-item[data-name="CyclingEnvelope_Rate"]');
+    const ratioItem = document.querySelector('.param-item[data-name="CyclingEnvelope_Ratio"]');
+    const timeItem = document.querySelector('.param-item[data-name="CyclingEnvelope_Time"]');
+    const syncItem = document.querySelector('.param-item[data-name="CyclingEnvelope_SyncedRate"]');
+    function updateCycleRateDisplay() {
+        if (!modeSelect) return;
+        const mode = modeSelect.value;
+        if (rateItem) rateItem.classList.toggle('hidden', mode !== 'Freq');
+        if (ratioItem) ratioItem.classList.toggle('hidden', mode !== 'Ratio');
+        if (timeItem) timeItem.classList.toggle('hidden', mode !== 'Time');
+        if (syncItem) syncItem.classList.toggle('hidden', mode !== 'Sync');
+    }
+    if (modeSelect) {
+        modeSelect.addEventListener('change', updateCycleRateDisplay);
+        updateCycleRateDisplay();
+    }
 });

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -85,17 +85,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const env2Select = document.querySelector('.param-item[data-name="Global_Envelope2Mode"] select');
-    const cyclingRows = document.querySelectorAll('.env2-cycling');
+    const cyclingRow = document.querySelector('.env2-cycling');
+    const adsrRow = document.querySelector('.env2-adsr');
     function updateCycling() {
         if (!env2Select) return;
         const show = env2Select.value === 'Cyc';
-        cyclingRows.forEach(r => {
-            if (show) {
-                r.classList.remove('hidden');
-            } else {
-                r.classList.add('hidden');
-            }
-        });
+        if (cyclingRow) {
+            cyclingRow.classList.toggle('hidden', !show);
+        }
+        if (adsrRow) {
+            adsrRow.classList.toggle('hidden', show);
+        }
     }
     if (env2Select) {
         env2Select.addEventListener('change', updateCycling);

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -70,26 +70,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const toggles = document.querySelectorAll('.param-toggle');
     toggles.forEach(el => {
-        const val = parseFloat(el.dataset.value);
+        const val = el.dataset.value;
         const target = el.dataset.target;
+        const trueVal = el.dataset.trueValue ?? '1';
+        const falseVal = el.dataset.falseValue ?? '0';
         const toggle = new Nexus.Toggle(el, {
             size: [30,15],
-            state: val > 0,
+            state: val === trueVal,
         });
         const input = document.querySelector(`input[name="${target}"]`);
         if (input) {
             toggle.on('change', v => {
-                input.value = v ? 1 : 0;
+                input.value = v ? trueVal : falseVal;
+                input.dispatchEvent(new Event('change'));
             });
         }
     });
 
-    const env2Select = document.querySelector('.param-item[data-name="Global_Envelope2Mode"] select');
+    const env2Input = document.querySelector('.param-item[data-name="Global_Envelope2Mode"] input[type="hidden"]');
     const cyclingRow = document.querySelector('.env2-cycling');
     const adsrRow = document.querySelector('.env2-adsr');
     function updateCycling() {
-        if (!env2Select) return;
-        const show = env2Select.value === 'Cyc';
+        if (!env2Input) return;
+        const show = env2Input.value === 'Cyc';
         if (cyclingRow) {
             cyclingRow.classList.toggle('hidden', !show);
         }
@@ -97,8 +100,8 @@ document.addEventListener('DOMContentLoaded', () => {
             adsrRow.classList.toggle('hidden', show);
         }
     }
-    if (env2Select) {
-        env2Select.addEventListener('change', updateCycling);
+    if (env2Input) {
+        env2Input.addEventListener('change', updateCycling);
         updateCycling();
     }
 });

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -106,17 +106,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const modeSelect = document.querySelector('.param-item[data-name="CyclingEnvelope_Mode"] select');
-    const rateItem = document.querySelector('.param-item[data-name="CyclingEnvelope_Rate"]');
-    const ratioItem = document.querySelector('.param-item[data-name="CyclingEnvelope_Ratio"]');
-    const timeItem = document.querySelector('.param-item[data-name="CyclingEnvelope_Time"]');
-    const syncItem = document.querySelector('.param-item[data-name="CyclingEnvelope_SyncedRate"]');
+    const cycleRateMap = {
+        Freq: document.querySelector('.cycle-rate.freq-rate'),
+        Ratio: document.querySelector('.cycle-rate.ratio-rate'),
+        Time: document.querySelector('.cycle-rate.time-rate'),
+        Sync: document.querySelector('.cycle-rate.sync-rate'),
+    };
     function updateCycleRateDisplay() {
         if (!modeSelect) return;
         const mode = modeSelect.value;
-        if (rateItem) rateItem.classList.toggle('hidden', mode !== 'Freq');
-        if (ratioItem) ratioItem.classList.toggle('hidden', mode !== 'Ratio');
-        if (timeItem) timeItem.classList.toggle('hidden', mode !== 'Time');
-        if (syncItem) syncItem.classList.toggle('hidden', mode !== 'Sync');
+        Object.entries(cycleRateMap).forEach(([key, el]) => {
+            if (el) el.classList.toggle('hidden', key !== mode);
+        });
     }
     if (modeSelect) {
         modeSelect.addEventListener('change', updateCycleRateDisplay);

--- a/static/style.css
+++ b/static/style.css
@@ -555,6 +555,11 @@ select {
     gap: 0.5rem;
 }
 
+/* Ensure hidden rows stay hidden despite flex layout */
+.param-row.hidden {
+    display: none;
+}
+
 .param-row-label {
     width: 80px;
     display: flex;


### PR DESCRIPTION
## Summary
- generate ADSR rows for Amp envelope and Env 2 only
- switch Env 2 row to cycling controls when cycling is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844abbe5700832586eb5b80f13c9495