### PR TITLE
Fix onset pipeline warm-up

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -194,7 +194,7 @@ def warm_up_modules():
     try:
         start = time.perf_counter()
         y_long = np.zeros(22050, dtype=float)
-        librosa.onset.onset_detect(y=y, sr=22050, units="time", delta=0.07)
+        librosa.onset.onset_detect(y=y_long, sr=22050, units="time", delta=0.07)
         y_harm, y_perc = librosa.effects.hpss(y_long)
         o_env = librosa.onset.onset_strength(
             y=y_perc,

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -136,7 +136,9 @@ def warm_up_modules():
     try:
         start = time.perf_counter()
         y = np.zeros(512, dtype=float)
-        librosa.onset.onset_detect(y=y, sr=22050, units="time", delta=0.07)
+        librosa.onset.onset_detect(
+            y=y, sr=22050, units="time", delta=0.07, n_fft=512
+        )
         logger.info(
             "Librosa onset_detect warm-up complete in %.3fs",
             time.perf_counter() - start,


### PR DESCRIPTION
## Summary
- use `y_long` when calling `librosa.onset.onset_detect` in the full onset pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844af2b75188325a3d8c25d9a19e08a