### PR TITLE
Fix quantization for synth parameter editor

### DIFF
--- a/core/synth_param_editor_handler.py
+++ b/core/synth_param_editor_handler.py
@@ -65,12 +65,7 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
             # Determine numeric vs string
             if isinstance(target, dict) and "value" in target:
                 orig_val = target["value"]
-                if isinstance(orig_val, int):
-                    try:
-                        target["value"] = int(round(float(val)))
-                    except ValueError:
-                        continue
-                elif isinstance(orig_val, float):
+                if isinstance(orig_val, (int, float)):
                     try:
                         target["value"] = float(val)
                     except ValueError:
@@ -79,12 +74,7 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
                     target["value"] = val
             else:
                 orig_val = target
-                if isinstance(orig_val, int):
-                    try:
-                        parent[key] = int(round(float(val)))
-                    except ValueError:
-                        continue
-                elif isinstance(orig_val, float):
+                if isinstance(orig_val, (int, float)):
                     try:
                         parent[key] = float(val)
                     except ValueError:

--- a/core/synth_param_editor_handler.py
+++ b/core/synth_param_editor_handler.py
@@ -65,7 +65,12 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
             # Determine numeric vs string
             if isinstance(target, dict) and "value" in target:
                 orig_val = target["value"]
-                if isinstance(orig_val, (int, float)):
+                if isinstance(orig_val, int):
+                    try:
+                        target["value"] = int(round(float(val)))
+                    except ValueError:
+                        continue
+                elif isinstance(orig_val, float):
                     try:
                         target["value"] = float(val)
                     except ValueError:
@@ -74,7 +79,12 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
                     target["value"] = val
             else:
                 orig_val = target
-                if isinstance(orig_val, (int, float)):
+                if isinstance(orig_val, int):
+                    try:
+                        parent[key] = int(round(float(val)))
+                    except ValueError:
+                        continue
+                elif isinstance(orig_val, float):
                     try:
                         parent[key] = float(val)
                     except ValueError:

--- a/examples/Track Presets/Drift/Analog Drift 1-parsed.ablpreset
+++ b/examples/Track Presets/Drift/Analog Drift 1-parsed.ablpreset
@@ -1,0 +1,290 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "instrumentRack",
+  "name": "Analog Drift",
+  "lockId": 1001,
+  "lockSeal": -1741001056,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": 0.0,
+    "Macro1": 0.0,
+    "Macro2": 0.0,
+    "Macro3": 0.0,
+    "Macro4": 0.0,
+    "Macro5": 0.0,
+    "Macro6": 0.0,
+    "Macro7": 0.0
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "instrumentRack",
+          "name": "Drift",
+          "lockId": 1001,
+          "lockSeal": 278284,
+          "parameters": {
+            "Enabled": true,
+            "Macro0": {
+              "value": 0.0,
+              "customName": "Filter Cutoff"
+            },
+            "Macro1": 9.144000053405762,
+            "Macro2": 79.0,
+            "Macro3": 0.0,
+            "Macro4": {
+              "value": 0.0,
+              "customName": "Attack"
+            },
+            "Macro5": {
+              "value": 65.29655456542969,
+              "customName": "DSR"
+            },
+            "Macro6": 93.45697784423828,
+            "Macro7": 69.64323425292969
+          },
+          "chains": [
+            {
+              "name": "",
+              "color": 0,
+              "devices": [
+                {
+                  "presetUri": null,
+                  "kind": "drift",
+                  "name": "",
+                  "parameters": {
+                    "CyclingEnvelope_Hold": 0.0,
+                    "CyclingEnvelope_MidPoint": 0.5,
+                    "CyclingEnvelope_Mode": "Freq",
+                    "CyclingEnvelope_Rate": 4.999998569488525,
+                    "CyclingEnvelope_Ratio": 1.0,
+                    "CyclingEnvelope_SyncedRate": 15.0,
+                    "CyclingEnvelope_Time": 1.0000001192092896,
+                    "Enabled": true,
+                    "Envelope1_Attack": {
+                      "value": 0.0009999996982514858,
+                      "macroMapping": {
+                        "macroIndex": 4,
+                        "rangeMin": 0.0010000000474974513,
+                        "rangeMax": 6.0
+                      }
+                    },
+                    "Envelope1_Decay": {
+                      "value": 0.6000000238418579,
+                      "macroMapping": {
+                        "macroIndex": 5,
+                        "rangeMin": 0.15000000596046448,
+                        "rangeMax": 5.5
+                      }
+                    },
+                    "Envelope1_Release": {
+                      "value": 0.5999999642372131,
+                      "macroMapping": {
+                        "macroIndex": 5,
+                        "rangeMin": 0.019999999552965164,
+                        "rangeMax": 6.0
+                      }
+                    },
+                    "Envelope1_Sustain": {
+                      "value": 0.699999988079071,
+                      "macroMapping": {
+                        "macroIndex": 5,
+                        "rangeMin": 0.0,
+                        "rangeMax": 1.0
+                      }
+                    },
+                    "Envelope2_Attack": 0.0009999996982514858,
+                    "Envelope2_Decay": 0.6000000238418579,
+                    "Envelope2_Release": 0.5999999046325684,
+                    "Envelope2_Sustain": 0.20000000298023224,
+                    "Filter_Frequency": {
+                      "value": 19999.99609375,
+                      "macroMapping": {
+                        "macroIndex": 0,
+                        "rangeMin": 20.0,
+                        "rangeMax": 19999.99609375
+                      }
+                    },
+                    "Filter_HiPassFrequency": 10.0,
+                    "Filter_ModAmount1": 0.0,
+                    "Filter_ModAmount2": 0.15000000596046448,
+                    "Filter_ModSource1": "Env 2 / Cyc",
+                    "Filter_ModSource2": "Pressure",
+                    "Filter_NoiseThrough": 1.0,
+                    "Filter_OscillatorThrough1": 1.0,
+                    "Filter_OscillatorThrough2": 1.0,
+                    "Filter_Resonance": 0.20000000298023224,
+                    "Filter_Tracking": 0.0,
+                    "Filter_Type": "I",
+                    "Global_DriftDepth": {
+                      "value": 0.07249999791383743,
+                      "macroMapping": {
+                        "macroIndex": 1,
+                        "rangeMin": 0.0,
+                        "rangeMax": 1.0
+                      }
+                    },
+                    "Global_Envelope2Mode": "Env",
+                    "Global_Glide": 0.0,
+                    "Global_HiQuality": 0.0,
+                    "Global_Legato": 0.0,
+                    "Global_MonoVoiceDepth": 0.0,
+                    "Global_NotePitchBend": 1.0,
+                    "Global_PitchBendRange": 2.0,
+                    "Global_PolyVoiceDepth": 0.0,
+                    "Global_ResetOscillatorPhase": 0.0,
+                    "Global_SerialNumber": 2429554.0,
+                    "Global_StereoVoiceDepth": 0.10000000149011612,
+                    "Global_Transpose": 0.0,
+                    "Global_UnisonVoiceDepth": 0.05000000074505806,
+                    "Global_VoiceCount": "8",
+                    "Global_VoiceMode": "Poly",
+                    "Global_VolVelMod": 0.5,
+                    "Global_Volume": 0.2818392217159271,
+                    "Lfo_Amount": 1.0,
+                    "Lfo_ModAmount": 0.0,
+                    "Lfo_ModSource": "Modwheel",
+                    "Lfo_Mode": "Freq",
+                    "Lfo_Rate": 0.4000000059604645,
+                    "Lfo_Ratio": 1.0,
+                    "Lfo_Retrigger": 0.0,
+                    "Lfo_Shape": "Sine",
+                    "Lfo_SyncedRate": 15.0,
+                    "Lfo_Time": 1.0000001192092896,
+                    "Mixer_NoiseLevel": 0.0,
+                    "Mixer_NoiseOn": 1.0,
+                    "Mixer_OscillatorGain1": {
+                      "value": 0.5000000596046448,
+                      "macroMapping": {
+                        "macroIndex": 6,
+                        "rangeMin": 0.0,
+                        "rangeMax": 1.9952679872512817
+                      }
+                    },
+                    "Mixer_OscillatorGain2": {
+                      "value": 0.5000000596046448,
+                      "macroMapping": {
+                        "macroIndex": 7,
+                        "rangeMin": 0.0,
+                        "rangeMax": 1.9952679872512817
+                      }
+                    },
+                    "Mixer_OscillatorOn1": 1.0,
+                    "Mixer_OscillatorOn2": 1.0,
+                    "ModulationMatrix_Amount1": 0.800000011920929,
+                    "ModulationMatrix_Amount2": 0.0,
+                    "ModulationMatrix_Amount3": 0.0,
+                    "ModulationMatrix_Source1": "Modwheel",
+                    "ModulationMatrix_Source2": "Velocity",
+                    "ModulationMatrix_Source3": "Pressure",
+                    "ModulationMatrix_Target1": "HP Frequency",
+                    "ModulationMatrix_Target2": "None",
+                    "ModulationMatrix_Target3": "None",
+                    "Oscillator1_Shape": 0.0,
+                    "Oscillator1_ShapeMod": 0.04999995231628418,
+                    "Oscillator1_ShapeModSource": "Slide",
+                    "Oscillator1_Transpose": 0.0,
+                    "Oscillator1_Type": {
+                      "value": "Saw",
+                      "macroMapping": {
+                        "macroIndex": 2
+                      }
+                    },
+                    "Oscillator2_Detune": 0.0,
+                    "Oscillator2_Transpose": -1.0,
+                    "Oscillator2_Type": {
+                      "value": "Sine",
+                      "macroMapping": {
+                        "macroIndex": 3
+                      }
+                    },
+                    "PitchModulation_Amount1": 0.0,
+                    "PitchModulation_Amount2": 0.0,
+                    "PitchModulation_Source1": "Env 2 / Cyc",
+                    "PitchModulation_Source2": "LFO"
+                  },
+                  "deviceData": {}
+                }
+              ],
+              "mixer": {
+                "pan": 0.0,
+                "solo-cue": false,
+                "speakerOn": true,
+                "volume": 0.0,
+                "sends": []
+              }
+            }
+          ]
+        },
+        {
+          "presetUri": null,
+          "kind": "delay",
+          "name": "Delay",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": true,
+            "DelayLine_SyncR": true,
+            "DelayLine_SyncedSixteenthL": "1",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0010000000474974513,
+            "DelayLine_TimeR": 0.0010747963096946478,
+            "DryWet": 0.0,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.30000001192092896,
+            "Filter_Bandwidth": 4.650000095367432,
+            "Filter_Frequency": 999.9998779296875,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.0,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.501967191696167
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "chorus",
+          "name": "",
+          "parameters": {
+            "Amount": 0.5,
+            "DryWet": 0.0,
+            "Enabled": true,
+            "Feedback": 0.0,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 50.00000762939453,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 0.9999999403953552,
+            "Rate": 0.9000000357627869,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.05000000074505806,
+            "Width": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
             max: isNaN(max) ? 1 : max,
             value: isNaN(val) ? 0 : val,
         });
+        const step = Math.pow(10, -decimals);
+        dial.step = step;
         const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
         const format = (v) => {
             const displayVal = shouldScale ? v * 100 : v;
@@ -52,6 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
             value: isNaN(val) ? 0 : val,
             orientation: 'horizontal'
         });
+        const step = Math.pow(10, -decimals);
+        slider.step = step;
         const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
         const format = (v) => {
             const displayVal = shouldScale ? v * 100 : v;

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -26,8 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const input = document.querySelector(`input[name="${target}"]`);
         if (input) {
             dial.on('change', v => {
-                input.value = v;
-                if (displayEl) displayEl.textContent = format(v);
+                const m = Math.pow(10, decimals);
+                const q = Math.round(v * m) / m;
+                input.value = q;
+                if (displayEl) displayEl.textContent = format(q);
             });
         }
     });
@@ -62,8 +64,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const input = document.querySelector(`input[name="${target}"]`);
         if (input) {
             slider.on('change', v => {
-                input.value = v;
-                if (displayEl) displayEl.textContent = format(v);
+                const m = Math.pow(10, decimals);
+                const q = Math.round(v * m) / m;
+                input.value = q;
+                if (displayEl) displayEl.textContent = format(q);
             });
         }
     });


### PR DESCRIPTION
## Summary
- quantize dial and slider values based on decimal precision
- keep integer parameters as integers when writing presets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450400a5c0832591bc4293985f491a