### PR TITLE
Fix parameter type conversion

### DIFF
--- a/core/synth_param_editor_handler.py
+++ b/core/synth_param_editor_handler.py
@@ -53,6 +53,25 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
                         return None, None
             return current, parts[-1]
 
+        def cast_value(val_str, original):
+            """Cast the string ``val_str`` to the same type as ``original``."""
+            if isinstance(original, bool):
+                try:
+                    return bool(int(val_str))
+                except ValueError:
+                    return original
+            if isinstance(original, int) and not isinstance(original, bool):
+                try:
+                    return int(float(val_str))
+                except ValueError:
+                    return original
+            if isinstance(original, float):
+                try:
+                    return float(val_str)
+                except ValueError:
+                    return original
+            return val_str
+
         updated = 0
         for name, val in param_updates.items():
             path = paths.get(name)
@@ -62,25 +81,13 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
             if parent is None or key not in parent:
                 continue
             target = parent[key]
-            # Determine numeric vs string
+
             if isinstance(target, dict) and "value" in target:
                 orig_val = target["value"]
-                if isinstance(orig_val, (int, float)):
-                    try:
-                        target["value"] = float(val)
-                    except ValueError:
-                        continue
-                else:
-                    target["value"] = val
+                target["value"] = cast_value(val, orig_val)
             else:
                 orig_val = target
-                if isinstance(orig_val, (int, float)):
-                    try:
-                        parent[key] = float(val)
-                    except ValueError:
-                        continue
-                else:
-                    parent[key] = val
+                parent[key] = cast_value(val, orig_val)
             updated += 1
 
         dest = output_path or preset_path

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -119,3 +119,26 @@ def test_update_parameter_values(tmp_path):
         ["parameters"]["Oscillator1_Shape"]["value"]
     )
     assert abs(val - 0.5) < 1e-6
+
+
+def test_save_preset_no_changes(tmp_path):
+    """Saving a preset without modifying parameters should produce identical output."""
+    src = Path("examples/Track Presets/Drift/Analog Shape.ablpreset")
+
+    # Extract existing parameter values
+    from core.synth_preset_inspector_handler import extract_parameter_values
+
+    info = extract_parameter_values(str(src))
+    assert info["success"], info.get("message")
+    # Convert values to strings as the web editor would submit
+    updates = {p["name"]: str(p["value"]) for p in info["parameters"]}
+
+    dest = tmp_path / "saved.ablpreset"
+    result = update_parameter_values(str(src), updates, str(dest))
+    assert result["success"], result.get("message")
+
+    with open(src, "rb") as f:
+        original = f.read()
+    with open(dest, "rb") as f:
+        written = f.read()
+    assert written == original


### PR DESCRIPTION
## Summary
- ensure boolean and integer values keep their types when editing synth presets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450be1fa808325969cbd282bede88c