### PR TITLE
Add --dev option for update-on-move

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -129,6 +129,10 @@ def log_request_time(response):
 
 def warm_up_modules():
     """Warm-up heavy modules to avoid first-call latency."""
+    if os.environ.get("SKIP_MODULE_WARMUP"):
+        logger.info("SKIP_MODULE_WARMUP set; skipping module warm-up")
+        return
+
     overall_start = time.perf_counter()
     # Warm-up librosa onset detection
     try:

--- a/utility-scripts/restart-webserver.sh
+++ b/utility-scripts/restart-webserver.sh
@@ -21,7 +21,13 @@ fi
 
 echo "Restarting the webserver on ${REMOTE_HOST}..."
 
-ssh -T "${REMOTE_USER}@${REMOTE_HOST}" bash <<'EOF'
+if [ -n "${SKIP_MODULE_WARMUP:-}" ]; then
+  SSH_CMD="SKIP_MODULE_WARMUP=${SKIP_MODULE_WARMUP} bash -s"
+else
+  SSH_CMD="bash -s"
+fi
+
+ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "$SSH_CMD" <<'EOF'
 set -euo pipefail
 
 # Load port configuration on the remote machine


### PR DESCRIPTION
## Summary
- allow skipping module warmup via `SKIP_MODULE_WARMUP` env var in `move-webserver.py`
- pass `SKIP_MODULE_WARMUP` through restart script
- add `--dev` flag to `update-on-move.sh` to skip pip install, skip warm-up and tail logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684510d1a6b88325827519fed7eb8c5b