### PR TITLE
Improve Drift global layout

### DIFF
--- a/examples/Track Presets/Drift/Analog Shape.ablpreset
+++ b/examples/Track Presets/Drift/Analog Shape.ablpreset
@@ -1,0 +1,303 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "instrumentRack",
+  "name": "Analog Shape",
+  "lockId": 1001,
+  "lockSeal": 1625930243,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": 0.0,
+    "Macro1": 0.0,
+    "Macro2": 0.0,
+    "Macro3": 0.0,
+    "Macro4": 0.0,
+    "Macro5": 0.0,
+    "Macro6": 0.0,
+    "Macro7": 0.0
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "instrumentRack",
+          "name": "Drift",
+          "lockId": 1001,
+          "lockSeal": 278284,
+          "parameters": {
+            "Enabled": true,
+            "Macro0": {
+              "value": 127.0,
+              "customName": "Filter Cutoff"
+            },
+            "Macro1": {
+              "value": 127.0,
+              "customName": "Shape"
+            },
+            "Macro2": 0.0,
+            "Macro3": 0.0,
+            "Macro4": {
+              "value": 0.0,
+              "customName": "Attack"
+            },
+            "Macro5": {
+              "value": 65.29655456542969,
+              "customName": "DSR"
+            },
+            "Macro6": {
+              "value": 127.0,
+              "customName": "Shape Decay"
+            },
+            "Macro7": 69.64323425292969
+          },
+          "chains": [
+            {
+              "name": "",
+              "color": 0,
+              "devices": [
+                {
+                  "presetUri": null,
+                  "kind": "drift",
+                  "name": "",
+                  "parameters": {
+                    "CyclingEnvelope_Hold": 0.0,
+                    "CyclingEnvelope_MidPoint": 0.5,
+                    "CyclingEnvelope_Mode": "Freq",
+                    "CyclingEnvelope_Rate": 4.999998569488525,
+                    "CyclingEnvelope_Ratio": 1.0,
+                    "CyclingEnvelope_SyncedRate": 15,
+                    "CyclingEnvelope_Time": 1.0000001192092896,
+                    "Enabled": true,
+                    "Envelope1_Attack": {
+                      "value": 0.0009999996982514858,
+                      "macroMapping": {
+                        "macroIndex": 4,
+                        "rangeMin": 0.0010000000474974513,
+                        "rangeMax": 6.0
+                      }
+                    },
+                    "Envelope1_Decay": {
+                      "value": 0.6000000238418579,
+                      "macroMapping": {
+                        "macroIndex": 5,
+                        "rangeMin": 0.15000000596046448,
+                        "rangeMax": 5.5
+                      }
+                    },
+                    "Envelope1_Release": {
+                      "value": 0.5999999642372131,
+                      "macroMapping": {
+                        "macroIndex": 5,
+                        "rangeMin": 0.019999999552965164,
+                        "rangeMax": 6.0
+                      }
+                    },
+                    "Envelope1_Sustain": {
+                      "value": 0.699999988079071,
+                      "macroMapping": {
+                        "macroIndex": 5,
+                        "rangeMin": 0.0,
+                        "rangeMax": 1.0
+                      }
+                    },
+                    "Envelope2_Attack": 0.0009999996982514858,
+                    "Envelope2_Decay": {
+                      "value": 0.6000000238418579,
+                      "macroMapping": {
+                        "macroIndex": 6,
+                        "rangeMin": 0.004999999888241291,
+                        "rangeMax": 60.0
+                      }
+                    },
+                    "Envelope2_Release": {
+                      "value": 0.5999999642372131,
+                      "macroMapping": {
+                        "macroIndex": 6,
+                        "rangeMin": 0.009999999776482582,
+                        "rangeMax": 60.0
+                      }
+                    },
+                    "Envelope2_Sustain": 0.0,
+                    "Filter_Frequency": {
+                      "value": 19999.99609375,
+                      "macroMapping": {
+                        "macroIndex": 0,
+                        "rangeMin": 20.0,
+                        "rangeMax": 19999.99609375
+                      }
+                    },
+                    "Filter_HiPassFrequency": 10.0,
+                    "Filter_ModAmount1": 0.0,
+                    "Filter_ModAmount2": 0.15000000596046448,
+                    "Filter_ModSource1": "Env 2 / Cyc",
+                    "Filter_ModSource2": "Pressure",
+                    "Filter_NoiseThrough": true,
+                    "Filter_OscillatorThrough1": true,
+                    "Filter_OscillatorThrough2": true,
+                    "Filter_Resonance": 0.20000000298023224,
+                    "Filter_Tracking": 0.0,
+                    "Filter_Type": "I",
+                    "Global_DriftDepth": 0.07199999690055847,
+                    "Global_Envelope2Mode": "Env",
+                    "Global_Glide": 0.0,
+                    "Global_HiQuality": false,
+                    "Global_Legato": false,
+                    "Global_MonoVoiceDepth": 0.0,
+                    "Global_NotePitchBend": true,
+                    "Global_PitchBendRange": 2,
+                    "Global_PolyVoiceDepth": 0.0,
+                    "Global_ResetOscillatorPhase": false,
+                    "Global_SerialNumber": 2429554,
+                    "Global_StereoVoiceDepth": 0.10000000149011612,
+                    "Global_Transpose": 0,
+                    "Global_UnisonVoiceDepth": 0.05000000074505806,
+                    "Global_VoiceCount": "8",
+                    "Global_VoiceMode": "Poly",
+                    "Global_VolVelMod": 0.5,
+                    "Global_Volume": 0.2818392217159271,
+                    "Lfo_Amount": 1.0,
+                    "Lfo_ModAmount": 0.0,
+                    "Lfo_ModSource": "Modwheel",
+                    "Lfo_Mode": "Freq",
+                    "Lfo_Rate": 0.4000000059604645,
+                    "Lfo_Ratio": 1.0,
+                    "Lfo_Retrigger": false,
+                    "Lfo_Shape": "Sine",
+                    "Lfo_SyncedRate": 15,
+                    "Lfo_Time": 1.0000001192092896,
+                    "Mixer_NoiseLevel": 0.0,
+                    "Mixer_NoiseOn": true,
+                    "Mixer_OscillatorGain1": 0.9999999403953552,
+                    "Mixer_OscillatorGain2": {
+                      "value": 0.5000000596046448,
+                      "macroMapping": {
+                        "macroIndex": 7,
+                        "rangeMin": 0.0,
+                        "rangeMax": 1.9952679872512817
+                      }
+                    },
+                    "Mixer_OscillatorOn1": true,
+                    "Mixer_OscillatorOn2": true,
+                    "ModulationMatrix_Amount1": 0.800000011920929,
+                    "ModulationMatrix_Amount2": 0.0,
+                    "ModulationMatrix_Amount3": 0.0,
+                    "ModulationMatrix_Source1": "Modwheel",
+                    "ModulationMatrix_Source2": "Velocity",
+                    "ModulationMatrix_Source3": "Pressure",
+                    "ModulationMatrix_Target1": "HP Frequency",
+                    "ModulationMatrix_Target2": "None",
+                    "ModulationMatrix_Target3": "None",
+                    "Oscillator1_Shape": {
+                      "value": 0.0,
+                      "macroMapping": {
+                        "macroIndex": 1,
+                        "rangeMin": 1.0,
+                        "rangeMax": 0.0
+                      }
+                    },
+                    "Oscillator1_ShapeMod": {
+                      "value": 0.0,
+                      "macroMapping": {
+                        "macroIndex": 1,
+                        "rangeMin": -1.0,
+                        "rangeMax": 1.0
+                      }
+                    },
+                    "Oscillator1_ShapeModSource": "Env 2 / Cyc",
+                    "Oscillator1_Transpose": 0,
+                    "Oscillator1_Type": {
+                      "value": "Saw",
+                      "macroMapping": {
+                        "macroIndex": 2
+                      }
+                    },
+                    "Oscillator2_Detune": 0.0,
+                    "Oscillator2_Transpose": -1,
+                    "Oscillator2_Type": {
+                      "value": "Sine",
+                      "macroMapping": {
+                        "macroIndex": 3
+                      }
+                    },
+                    "PitchModulation_Amount1": 0.0,
+                    "PitchModulation_Amount2": 0.0,
+                    "PitchModulation_Source1": "Env 2 / Cyc",
+                    "PitchModulation_Source2": "LFO"
+                  },
+                  "deviceData": {}
+                }
+              ],
+              "mixer": {
+                "pan": 0.0,
+                "solo-cue": false,
+                "speakerOn": true,
+                "volume": 0.0,
+                "sends": []
+              }
+            }
+          ]
+        },
+        {
+          "presetUri": null,
+          "kind": "delay",
+          "name": "Delay",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": true,
+            "DelayLine_SyncR": true,
+            "DelayLine_SyncedSixteenthL": "1",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0010000000474974513,
+            "DelayLine_TimeR": 0.0010747963096946478,
+            "DryWet": 0.0,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.30000001192092896,
+            "Filter_Bandwidth": 4.650000095367432,
+            "Filter_Frequency": 999.9998779296875,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.0,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.5019679069519043
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": 0.9999999403953552,
+            "HighpassOn": false,
+            "LowShelfGain": 0.9999999403953552,
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -351,6 +351,7 @@ class SynthParamEditorHandler(BaseHandler):
                 "Global_ResetOscillatorPhase",
                 "Global_StereoVoiceDepth",
                 "Global_UnisonVoiceDepth",
+                "Global_SerialNumber",
             }:
                 return "Extras"
             return "Global"

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -134,6 +134,7 @@ class SynthParamEditorHandler(BaseHandler):
         "LFO",
         "Modulation",
         "Global",
+        "Extras",
         "Other",
     ]
 
@@ -254,6 +255,12 @@ class SynthParamEditorHandler(BaseHandler):
         "PitchModulation_Amount2",
         "Filter_ModAmount1",
         "Filter_ModAmount2",
+        # Global sliders
+        "Global_DriftDepth",
+        "Global_Glide",
+        "Global_VolVelMod",
+        "Global_Transpose",
+        "Global_PitchBendRange",
     }
 
     def _build_param_item(self, idx, name, value, meta, label=None,
@@ -292,6 +299,12 @@ class SynthParamEditorHandler(BaseHandler):
                 f'data-target="param_{idx}_value" data-value="{bool_val}"></div>'
             )
             html.append(f'<input type="hidden" name="param_{idx}_value" value="{bool_val}">')
+        elif name == "Global_SerialNumber":
+            min_attr = f' min="{meta.get("min")}"' if meta.get("min") is not None else ''
+            max_attr = f' max="{meta.get("max")}"' if meta.get("max") is not None else ''
+            html.append(
+                f'<input type="number" class="param-input" name="param_{idx}_value" value="{value}"{min_attr}{max_attr}>'
+            )
         else:
             min_attr = f' data-min="{meta.get("min")}"' if meta.get("min") is not None else ''
             max_attr = f' data-max="{meta.get("max")}"' if meta.get("max") is not None else ''
@@ -331,6 +344,15 @@ class SynthParamEditorHandler(BaseHandler):
         if name.startswith("ModulationMatrix_"):
             return "Modulation"
         if name.startswith("Global_"):
+            if name in {
+                "Global_HiQuality",
+                "Global_MonoVoiceDepth",
+                "Global_PolyVoiceDepth",
+                "Global_ResetOscillatorPhase",
+                "Global_StereoVoiceDepth",
+                "Global_UnisonVoiceDepth",
+            }:
+                return "Extras"
             return "Global"
         return "Other"
 
@@ -346,6 +368,7 @@ class SynthParamEditorHandler(BaseHandler):
         env_items: dict[str, str] = {}
         mixer_items: dict[str, str] = {}
         global_items: dict[str, str] = {}
+        extras_items: dict[str, str] = {}
         cycling_mode_val = None
 
         for i, item in enumerate(params):
@@ -394,6 +417,8 @@ class SynthParamEditorHandler(BaseHandler):
                 mixer_items[name] = html
             elif section == "Global":
                 global_items[name] = html
+            elif section == "Extras":
+                extras_items[name] = html
             else:
                 sections[section].append(html)
 
@@ -560,6 +585,9 @@ class SynthParamEditorHandler(BaseHandler):
                 )
             ordered.extend(global_items.values())
             sections["Global"] = ordered
+
+        if extras_items:
+            sections["Extras"] = list(extras_items.values())
 
         out_html = '<div class="drift-param-panels">'
         for sec in self.SECTION_ORDER:

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -345,6 +345,7 @@ class SynthParamEditorHandler(BaseHandler):
         osc_items: dict[str, str] = {}
         env_items: dict[str, str] = {}
         mixer_items: dict[str, str] = {}
+        global_items: dict[str, str] = {}
         cycling_mode_val = None
 
         for i, item in enumerate(params):
@@ -391,6 +392,8 @@ class SynthParamEditorHandler(BaseHandler):
                 env_items[name] = html
             elif section == "Mixer":
                 mixer_items[name] = html
+            elif section == "Global":
+                global_items[name] = html
             else:
                 sections[section].append(html)
 
@@ -532,6 +535,31 @@ class SynthParamEditorHandler(BaseHandler):
 
             ordered.extend(env_items.values())
             sections["Envelopes"] = ordered
+
+        if global_items:
+            col1_order = [
+                "Global_VoiceMode",
+                "Global_VoiceCount",
+                "Global_DriftDepth",
+                "Global_Legato",
+                "Global_Glide",
+            ]
+            col2_order = [
+                "Global_Volume",
+                "Global_VolVelMod",
+                "Global_Transpose",
+                "Global_NotePitchBend",
+                "Global_PitchBendRange",
+            ]
+            col1_html = "".join(global_items.pop(n, "") for n in col1_order)
+            col2_html = "".join(global_items.pop(n, "") for n in col2_order)
+            ordered = []
+            if col1_html or col2_html:
+                ordered.append(
+                    f'<div class="param-columns"><div class="param-column">{col1_html}</div><div class="param-column">{col2_html}</div></div>'
+                )
+            ordered.extend(global_items.values())
+            sections["Global"] = ordered
 
         out_html = '<div class="drift-param-panels">'
         for sec in self.SECTION_ORDER:

--- a/static/style.css
+++ b/static/style.css
@@ -599,6 +599,12 @@ select {
     display: inline-block;
     text-align: right;
 }
+
+.param-input {
+    margin: 0.25rem;
+    width: 80px;
+    text-align: center;
+}
   
 .param-item {
     margin-bottom: 0.75rem;

--- a/static/style.css
+++ b/static/style.css
@@ -555,6 +555,17 @@ select {
     gap: 0.5rem;
 }
 
+.param-columns {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.param-column {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
 /* Ensure hidden rows stay hidden despite flex layout */
 
 .param-row.hidden,


### PR DESCRIPTION
## Summary
- arrange drift global parameters in two columns
- add example Drift preset for tests
- support new column layout via CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451890ccac8325b0c2a2e323e588e7