### PR TITLE
Fix drift browser cache

### DIFF
--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -8,17 +8,24 @@ _CACHE_PREFIX = "file_browser:"
 
 
 def _list_directory(base_dir: str, rel_path: str) -> Tuple[list[str], list[str]]:
-    """List subdirectories and files for the given path with caching."""
+    """List subdirectories and files for the given path with caching.
+
+    Cached entries are automatically invalidated if the directory's
+    modification time or entry count changes.
+    """
     abs_path = os.path.join(base_dir, rel_path)
     key = f"{_CACHE_PREFIX}{abs_path}"
     cached = get_cache(key)
-    if cached is not None:
-        return cached["dirs"], cached["files"]
-
     try:
+        mtime = os.stat(abs_path).st_mtime_ns
         entries = os.listdir(abs_path)
     except FileNotFoundError:
         return [], []
+
+    if cached is not None and cached.get("mtime") == mtime and cached.get("count") == len(entries):
+        return cached["dirs"], cached["files"]
+
+
     dirs: list[str] = []
     files: list[str] = []
     for name in sorted(entries):
@@ -27,23 +34,34 @@ def _list_directory(base_dir: str, rel_path: str) -> Tuple[list[str], list[str]]
             dirs.append(name)
         elif os.path.isfile(full):
             files.append(name)
-    set_cache(key, {"dirs": dirs, "files": files})
+
+    set_cache(key, {"dirs": dirs, "files": files, "mtime": mtime, "count": len(entries)})
     return dirs, files
 
 
 def _check_json_file(file_path: str, kind: str) -> bool:
-    """Check JSON file for a specific ``kind`` with caching."""
+    """Check JSON file for a specific ``kind`` with caching.
+
+    Cached results are revalidated if the file's modification time changes.
+    """
     key = f"{_CACHE_PREFIX}{kind}:{file_path}"
     cached = get_cache(key)
-    if cached is not None and "result" in cached:
-        return cached["result"]
+    try:
+        mtime = os.stat(file_path).st_mtime_ns
+    except FileNotFoundError:
+        return False
+
+    if cached is not None and cached.get("mtime") == mtime:
+        return cached.get("result", False)
+
     try:
         with open(file_path, "r") as f:
             data = json.load(f)
         result = _has_kind(data, kind)
     except Exception:
         result = False
-    set_cache(key, {"result": result})
+
+    set_cache(key, {"result": result, "mtime": mtime})
     return result
 
 

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -11,13 +11,20 @@ from core.synth_preset_inspector_handler import (
 )
 from core.synth_param_editor_handler import update_parameter_values
 
-# Path to the example preset used when creating a new preset
+# Path to the preset used when creating a new preset. Prefer the version in the
+# user's library but fall back to the bundled example if it doesn't exist.
 DEFAULT_PRESET = os.path.join(
-    "examples",
-    "Track Presets",
+    "/data/UserData/UserLibrary/Track Presets",
     "Drift",
-    "Analog Shape.ablpreset",
+    "Analog Shape - Core.json",
 )
+if not os.path.exists(DEFAULT_PRESET):
+    DEFAULT_PRESET = os.path.join(
+        "examples",
+        "Track Presets",
+        "Drift",
+        "Analog Shape - Core.json",
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -78,6 +78,18 @@ def test_generate_dir_html(tmp_path):
     assert 'a.wav' in html
     assert 'b.txt' not in html
 
+    # Adding a new file should invalidate the cache automatically
+    (tmp_path / "new.wav").write_text("x")
+    html2 = generate_dir_html(
+        str(tmp_path),
+        "",
+        "/upload",
+        "file",
+        "select",
+        filter_key="wav",
+    )
+    assert 'new.wav' in html2
+
 
 def test_time_stretch_wav(tmp_path, monkeypatch):
     sr = 22050
@@ -103,7 +115,7 @@ def test_get_rubberband_binary_exists():
 
 
 def test_update_parameter_values(tmp_path):
-    src = Path("examples/Track Presets/Drift/Analog Shape.ablpreset")
+    src = Path("examples/Track Presets/Drift/Analog Shape - Core.json")
     dest = tmp_path / "out.ablpreset"
     result = update_parameter_values(str(src), {"Oscillator1_Shape": "0.5"}, str(dest))
     assert result["success"], result.get("message")
@@ -123,7 +135,7 @@ def test_update_parameter_values(tmp_path):
 
 def test_save_preset_no_changes(tmp_path):
     """Saving a preset without modifying parameters should produce identical output."""
-    src = Path("examples/Track Presets/Drift/Analog Shape.ablpreset")
+    src = Path("examples/Track Presets/Drift/Analog Shape - Core.json")
 
     # Extract existing parameter values
     from core.synth_preset_inspector_handler import extract_parameter_values

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -107,6 +107,8 @@ def test_synth_macros_post(client, monkeypatch):
     assert b'View All Parameters' in resp.data
 
 def test_synth_params_get(client, monkeypatch):
+    from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
+
     def fake_get():
         return {
             'message': 'pick',
@@ -116,7 +118,7 @@ def test_synth_params_get(client, monkeypatch):
             'selected_preset': None,
             'param_count': 0,
             'browser_root': '/tmp',
-            'default_preset_path': '/examples/Analog Shape.ablpreset',
+            'default_preset_path': DEFAULT_PRESET,
         }
     monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_get', fake_get)
     resp = client.get('/synth-params')
@@ -143,15 +145,17 @@ def test_synth_params_post(client, monkeypatch):
     assert b'<div>p</div>' in resp.data
 
 def test_synth_params_new_preset(client, monkeypatch):
+    from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
+
     def fake_post(form):
         return {
             'message': 'loaded',
             'message_type': 'success',
             'params_html': '<div>x</div>',
             'browser_root': '/tmp',
-            'selected_preset': '/examples/Analog Shape.ablpreset',
+            'selected_preset': DEFAULT_PRESET,
             'param_count': 2,
-            'default_preset_path': '/examples/Analog Shape.ablpreset',
+            'default_preset_path': DEFAULT_PRESET,
         }
     monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
     resp = client.post('/synth-params', data={'action': 'new_preset'})


### PR DESCRIPTION
## Summary
- refresh file browser listings when directory contents change
- update default drift preset path to new JSON file
- adjust tests for updated example preset name
- default preset now points to user library if available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68451772ad74832584c7af62113c2276