### PR TITLE
Add Drift UI experiment page

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -467,6 +467,10 @@ def chord():
 def synth_knobs():
     return render_template("synth_knobs.html", active_tab="synth-knobs")
 
+@app.route("/drift-ui", methods=["GET"])
+def drift_ui():
+    return render_template("drift_ui.html", active_tab="drift-ui")
+
 
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -754,3 +754,41 @@ select {
     background: #ff5050;
     color: #20232a;
 }
+
+.drift-ui .icon {
+    margin: 0 4px;
+    font-size: 12px;
+}
+
+.drift-ui .envelope-graph {
+    width: 176px;
+    height: 104px;
+    border: 1px solid #555;
+    margin-left: auto;
+}
+
+.drift-ui .pitch-mod {
+    align-items: flex-start;
+}
+.drift-ui .pitch-mod-controls {
+    display: flex;
+}
+.drift-ui .param-pair {
+    text-align: center;
+    margin-right: 8px;
+}
+
+.drift-ui .routing-icon {
+    position: absolute;
+    top: 136px;
+    left: 328px;
+    width: 20px;
+    height: 20px;
+    border: 1px solid #ffc300;
+    color: #ffc300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    background: #20232a;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -705,6 +705,15 @@ select {
     align-items: center;
     margin-bottom: 24px;
 }
+.drift-ui .mix-knob {
+    text-align: center;
+    margin: 0 8px;
+}
+.drift-ui .mix-knob .param-number {
+    display: block;
+    margin-top: 4px;
+    font-weight: bold;
+}
 .drift-ui .badge {
     width: 32px;
     height: 48px;
@@ -716,6 +725,12 @@ select {
 }
 .drift-ui .badge.yellow {
     background: #ffc300;
+}
+.drift-ui .badge.blue {
+    background: #00eaff;
+}
+.drift-ui .badge.red {
+    background: #ff5050;
 }
 .drift-ui .mix-knob .knob-dial {
     margin-bottom: 4px;
@@ -729,5 +744,13 @@ select {
 }
 .drift-ui .arrow.yellow {
     background: #ffc300;
+    color: #20232a;
+}
+.drift-ui .arrow.blue {
+    background: #00eaff;
+    color: #20232a;
+}
+.drift-ui .arrow.red {
+    background: #ff5050;
     color: #20232a;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -621,3 +621,113 @@ select {
     margin-bottom: 0.75rem;
   }
 
+
+/* Drift UI Experiment */
+.drift-ui {
+    width: 512px;
+    height: 352px;
+    display: flex;
+    background: #20232a;
+    color: #b3b3b3;
+    font-size: 11px;
+    position: relative;
+}
+.drift-ui .panel {
+    padding: 16px;
+    box-sizing: border-box;
+}
+.drift-ui .oscillators {
+    width: 272px;
+    border-right: 1px solid #3a3a3a;
+}
+.drift-ui .osc-mix {
+    width: 240px;
+    background: #ececec;
+    color: #20232a;
+}
+.drift-ui .row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 16px;
+}
+.drift-ui .row-label {
+    width: 40px;
+}
+.drift-ui .knob {
+    margin: 0 8px;
+    text-align: center;
+}
+.drift-ui .knob-dial {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    border: 6px solid #666;
+    position: relative;
+}
+.drift-ui .knob.blue .knob-dial {
+    border-color: #00eaff;
+}
+.drift-ui .knob-label {
+    display: block;
+    margin-bottom: 4px;
+}
+.drift-ui .knob-value {
+    display: block;
+    margin-top: 4px;
+    color: #ffc300;
+    font-weight: bold;
+}
+.drift-ui .knob.blue .knob-value {
+    color: #00eaff;
+}
+.drift-ui .separator {
+    height: 1px;
+    background: #3a3a3a;
+    margin: 8px 0;
+}
+.drift-ui .mod-source {
+    margin-left: auto;
+    text-align: center;
+    border: 1px solid #555;
+    padding: 4px;
+    width: 64px;
+    font-weight: bold;
+    color: #ffc300;
+}
+.drift-ui .mix-header {
+    background: #ccc;
+    padding: 4px;
+    font-weight: bold;
+    margin-bottom: 16px;
+}
+.drift-ui .mix-row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 24px;
+}
+.drift-ui .badge {
+    width: 32px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #20232a;
+    font-weight: bold;
+}
+.drift-ui .badge.yellow {
+    background: #ffc300;
+}
+.drift-ui .mix-knob .knob-dial {
+    margin-bottom: 4px;
+}
+.drift-ui .arrow {
+    width: 24px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.drift-ui .arrow.yellow {
+    background: #ffc300;
+    color: #20232a;
+}

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -16,6 +16,7 @@
         <a href="{{ host_prefix }}/synth-macros" class="{% if active_tab == 'synth-macros' %}active{% endif %}">Macros</a>
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Params</a>
         <a href="{{ host_prefix }}/synth-knobs" class="{% if active_tab == 'synth-knobs' %}active{% endif %}">Knobs</a>
+        <a href="{{ host_prefix }}/drift-ui" class="{% if active_tab == 'drift-ui' %}active{% endif %}">Drift UI</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
     </nav>

--- a/templates_jinja/drift_ui.html
+++ b/templates_jinja/drift_ui.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Drift UI Experiment</h2>
+<div class="drift-ui">
+  <div class="oscillators panel">
+    <div class="row osc1">
+      <span class="row-label">Osc 1</span>
+      <div class="knob oct">
+        <span class="knob-label">Oct</span>
+        <div class="knob-dial"></div>
+        <span class="knob-value">1</span>
+      </div>
+      <div class="knob shape">
+        <span class="knob-label">Shape</span>
+        <div class="knob-dial"></div>
+        <span class="knob-value">0.00</span>
+      </div>
+      <div class="mod-source">
+        <span class="mod-label">LFO</span>
+        <span class="mod-value">50 %</span>
+      </div>
+    </div>
+    <div class="separator"></div>
+    <div class="row osc2">
+      <span class="row-label">Osc 2</span>
+      <div class="knob oct blue">
+        <span class="knob-label">Oct</span>
+        <div class="knob-dial"></div>
+        <span class="knob-value">0</span>
+      </div>
+      <div class="knob detune blue">
+        <span class="knob-label">Detune</span>
+        <div class="knob-dial"></div>
+        <span class="knob-value">0.00</span>
+      </div>
+    </div>
+  </div>
+  <div class="osc-mix panel">
+    <div class="mix-header">Osc Mix</div>
+    <div class="mix-row">
+      <div class="badge yellow">1</div>
+      <div class="mix-knob yellow">
+        <div class="knob-dial"></div>
+        <span class="mix-value">-11 dB</span>
+      </div>
+      <div class="arrow yellow">&#8250;</div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}{% endblock %}

--- a/templates_jinja/drift_ui.html
+++ b/templates_jinja/drift_ui.html
@@ -1,51 +1,128 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Drift UI Experiment</h2>
+<p><em>Interactive mockup for oscillator and mix controls.</em></p>
+<form id="drift-ui-form">
 <div class="drift-ui">
   <div class="oscillators panel">
+    <!-- Oscillator 1 controls -->
     <div class="row osc1">
       <span class="row-label">Osc 1</span>
       <div class="knob oct">
-        <span class="knob-label">Oct</span>
-        <div class="knob-dial"></div>
-        <span class="knob-value">1</span>
+        <span class="param-label">Oct</span>
+        <div id="osc1-oct" class="param-dial" data-target="Oscillator1_Transpose" data-min="-2" data-max="2" data-value="0" data-display="osc1-oct-val"></div>
+        <span id="osc1-oct-val" class="param-number"></span>
+        <input type="hidden" name="Oscillator1_Transpose" value="0">
       </div>
       <div class="knob shape">
-        <span class="knob-label">Shape</span>
-        <div class="knob-dial"></div>
-        <span class="knob-value">0.00</span>
+        <span class="param-label">Shape</span>
+        <div id="osc1-shape" class="param-dial" data-target="Oscillator1_Shape" data-min="0" data-max="1" data-value="0" data-display="osc1-shape-val"></div>
+        <span id="osc1-shape-val" class="param-number"></span>
+        <input type="hidden" name="Oscillator1_Shape" value="0">
       </div>
       <div class="mod-source">
-        <span class="mod-label">LFO</span>
-        <span class="mod-value">50 %</span>
+        <label for="osc1-mod-source" class="mod-label">Mod</label>
+        <select id="osc1-mod-source" name="Oscillator1_ShapeModSource">
+          <option value="None">None</option>
+          <option value="Env 2">Env 2</option>
+          <option value="LFO">LFO</option>
+        </select>
+        <div class="param-dial" data-target="Oscillator1_ShapeMod" data-min="0" data-max="1" data-value="0" data-display="osc1-mod-val"></div>
+        <span id="osc1-mod-val" class="param-number"></span>
+        <input type="hidden" name="Oscillator1_ShapeMod" value="0">
       </div>
     </div>
     <div class="separator"></div>
+    <!-- Oscillator 2 controls -->
     <div class="row osc2">
       <span class="row-label">Osc 2</span>
       <div class="knob oct blue">
-        <span class="knob-label">Oct</span>
-        <div class="knob-dial"></div>
-        <span class="knob-value">0</span>
+        <span class="param-label">Oct</span>
+        <div id="osc2-oct" class="param-dial" data-target="Oscillator2_Transpose" data-min="-2" data-max="2" data-value="0" data-display="osc2-oct-val"></div>
+        <span id="osc2-oct-val" class="param-number"></span>
+        <input type="hidden" name="Oscillator2_Transpose" value="0">
       </div>
       <div class="knob detune blue">
-        <span class="knob-label">Detune</span>
-        <div class="knob-dial"></div>
-        <span class="knob-value">0.00</span>
+        <span class="param-label">Detune</span>
+        <div id="osc2-detune" class="param-dial" data-target="Oscillator2_Detune" data-min="-50" data-max="50" data-value="0" data-display="osc2-detune-val"></div>
+        <span id="osc2-detune-val" class="param-number"></span>
+        <input type="hidden" name="Oscillator2_Detune" value="0">
+      </div>
+    </div>
+    <div class="separator"></div>
+    <!-- Pitch modulation controls -->
+    <div class="row pitch-mod">
+      <span class="row-label">Pitch Mod</span>
+      <div class="param-pair">
+        <select name="PitchModulation_Source1">
+          <option value="None">None</option>
+          <option value="Env 2">Env 2</option>
+          <option value="LFO">LFO</option>
+        </select>
+        <div class="param-dial" data-target="PitchModulation_Amount1" data-min="0" data-max="1" data-value="0" data-display="pm1-val"></div>
+        <span id="pm1-val" class="param-number"></span>
+        <input type="hidden" name="PitchModulation_Amount1" value="0">
+      </div>
+      <div class="param-pair">
+        <select name="PitchModulation_Source2">
+          <option value="None">None</option>
+          <option value="Env 2">Env 2</option>
+          <option value="LFO">LFO</option>
+        </select>
+        <div class="param-dial" data-target="PitchModulation_Amount2" data-min="0" data-max="1" data-value="0" data-display="pm2-val"></div>
+        <span id="pm2-val" class="param-number"></span>
+        <input type="hidden" name="PitchModulation_Amount2" value="0">
+      </div>
+    </div>
+    <div class="separator"></div>
+    <!-- Noise level control -->
+    <div class="row noise">
+      <span class="row-label">Noise</span>
+      <div class="knob">
+        <span class="param-label">Level</span>
+        <div id="noise-level" class="param-dial" data-target="Mixer_NoiseLevel" data-min="-60" data-max="0" data-value="-6" data-display="noise-val"></div>
+        <span id="noise-val" class="param-number"></span>
+        <input type="hidden" name="Mixer_NoiseLevel" value="-6">
       </div>
     </div>
   </div>
   <div class="osc-mix panel">
     <div class="mix-header">Osc Mix</div>
+    <!-- Oscillator 1 mix -->
     <div class="mix-row">
       <div class="badge yellow">1</div>
-      <div class="mix-knob yellow">
-        <div class="knob-dial"></div>
-        <span class="mix-value">-11 dB</span>
+      <div class="mix-knob">
+        <div class="param-dial" data-target="Mixer_OscillatorGain1" data-min="-60" data-max="0" data-value="-11" data-display="mix-osc1"></div>
+        <span id="mix-osc1" class="param-number"></span>
+        <input type="hidden" name="Mixer_OscillatorGain1" value="-11">
       </div>
       <div class="arrow yellow">&#8250;</div>
     </div>
+    <!-- Oscillator 2 mix -->
+    <div class="mix-row">
+      <div class="badge blue">2</div>
+      <div class="mix-knob">
+        <div class="param-dial" data-target="Mixer_OscillatorGain2" data-min="-60" data-max="0" data-value="-11" data-display="mix-osc2"></div>
+        <span id="mix-osc2" class="param-number"></span>
+        <input type="hidden" name="Mixer_OscillatorGain2" value="-11">
+      </div>
+      <div class="arrow blue">&#8250;</div>
+    </div>
+    <!-- Noise mix -->
+    <div class="mix-row">
+      <div class="badge red">N</div>
+      <div class="mix-knob">
+        <div class="param-dial" data-target="Mixer_NoiseLevel" data-min="-60" data-max="0" data-value="-6" data-display="mix-noise"></div>
+        <span id="mix-noise" class="param-number"></span>
+        <input type="hidden" name="Mixer_NoiseLevel" value="-6">
+      </div>
+      <div class="arrow red">&#8250;</div>
+    </div>
   </div>
 </div>
+</form>
 {% endblock %}
-{% block scripts %}{% endblock %}
+{% block scripts %}
+<script src="https://unpkg.com/nexusui@latest/dist/NexusUI.js"></script>
+<script src="{{ host_prefix }}/static/params_knobs.js"></script>
+{% endblock %}

--- a/templates_jinja/drift_ui.html
+++ b/templates_jinja/drift_ui.html
@@ -8,6 +8,8 @@
     <!-- Oscillator 1 controls -->
     <div class="row osc1">
       <span class="row-label">Osc 1</span>
+      <span class="icon chevron-up">&#9650;</span>
+      <span class="icon chevron-down">&#9660;</span>
       <div class="knob oct">
         <span class="param-label">Oct</span>
         <div id="osc1-oct" class="param-dial" data-target="Oscillator1_Transpose" data-min="-2" data-max="2" data-value="0" data-display="osc1-oct-val"></div>
@@ -36,6 +38,8 @@
     <!-- Oscillator 2 controls -->
     <div class="row osc2">
       <span class="row-label">Osc 2</span>
+      <span class="icon sine">&#8764;</span>
+      <span class="icon chevron-down">&#9660;</span>
       <div class="knob oct blue">
         <span class="param-label">Oct</span>
         <div id="osc2-oct" class="param-dial" data-target="Oscillator2_Transpose" data-min="-2" data-max="2" data-value="0" data-display="osc2-oct-val"></div>
@@ -53,41 +57,34 @@
     <!-- Pitch modulation controls -->
     <div class="row pitch-mod">
       <span class="row-label">Pitch Mod</span>
-      <div class="param-pair">
-        <select name="PitchModulation_Source1">
-          <option value="None">None</option>
-          <option value="Env 2">Env 2</option>
-          <option value="LFO">LFO</option>
-        </select>
-        <div class="param-dial" data-target="PitchModulation_Amount1" data-min="0" data-max="1" data-value="0" data-display="pm1-val"></div>
-        <span id="pm1-val" class="param-number"></span>
-        <input type="hidden" name="PitchModulation_Amount1" value="0">
+      <div class="pitch-mod-controls">
+        <div class="param-pair">
+          <select name="PitchModulation_Source1">
+            <option value="None">None</option>
+            <option value="Env 2">Env 2</option>
+            <option value="LFO">LFO</option>
+          </select>
+          <div class="param-dial" data-target="PitchModulation_Amount1" data-min="0" data-max="1" data-value="0" data-display="pm1-val"></div>
+          <span id="pm1-val" class="param-number"></span>
+          <input type="hidden" name="PitchModulation_Amount1" value="0">
+        </div>
+        <div class="param-pair">
+          <select name="PitchModulation_Source2">
+            <option value="None">None</option>
+            <option value="Env 2">Env 2</option>
+            <option value="LFO">LFO</option>
+          </select>
+          <div class="param-dial" data-target="PitchModulation_Amount2" data-min="0" data-max="1" data-value="0" data-display="pm2-val"></div>
+          <span id="pm2-val" class="param-number"></span>
+          <input type="hidden" name="PitchModulation_Amount2" value="0">
+        </div>
       </div>
-      <div class="param-pair">
-        <select name="PitchModulation_Source2">
-          <option value="None">None</option>
-          <option value="Env 2">Env 2</option>
-          <option value="LFO">LFO</option>
-        </select>
-        <div class="param-dial" data-target="PitchModulation_Amount2" data-min="0" data-max="1" data-value="0" data-display="pm2-val"></div>
-        <span id="pm2-val" class="param-number"></span>
-        <input type="hidden" name="PitchModulation_Amount2" value="0">
-      </div>
-    </div>
-    <div class="separator"></div>
-    <!-- Noise level control -->
-    <div class="row noise">
-      <span class="row-label">Noise</span>
-      <div class="knob">
-        <span class="param-label">Level</span>
-        <div id="noise-level" class="param-dial" data-target="Mixer_NoiseLevel" data-min="-60" data-max="0" data-value="-6" data-display="noise-val"></div>
-        <span id="noise-val" class="param-number"></span>
-        <input type="hidden" name="Mixer_NoiseLevel" value="-6">
-      </div>
+      <div class="envelope-graph"></div>
     </div>
   </div>
   <div class="osc-mix panel">
     <div class="mix-header">Osc Mix</div>
+    <div class="routing-icon">R</div>
     <!-- Oscillator 1 mix -->
     <div class="mix-row">
       <div class="badge yellow">1</div>


### PR DESCRIPTION
## Summary
- add a simple experimental "Drift UI" page showing an Oscillator layout
- style the page with new `.drift-ui` rules in `style.css`
- add navigation link and Flask route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684520dbd8a4832594d49f861617bc95