### PR TITLE
Display macro knobs on synth parameter page

### DIFF
--- a/core/synth_param_editor_handler.py
+++ b/core/synth_param_editor_handler.py
@@ -104,3 +104,77 @@ def update_parameter_values(preset_path, param_updates, output_path=None):
         logger.error("Parameter update failed: %s", exc)
         return {"success": False, "message": f"Error updating parameters: {exc}"}
 
+
+def update_macro_values(preset_path, macro_updates, output_path=None):
+    """Update macro values in a preset.
+
+    Args:
+        preset_path: Path to the source preset.
+        macro_updates: Mapping of macro index to new value (as strings).
+        output_path: Optional path for the modified preset. If omitted, the
+            source preset is overwritten.
+
+    Returns:
+        dict with keys:
+            - success: bool
+            - message: status or error message
+            - path: path to written preset
+    """
+    try:
+        with open(preset_path, "r") as f:
+            preset_data = json.load(f)
+
+        def cast_value(val_str, original):
+            if isinstance(original, bool):
+                try:
+                    return bool(int(val_str))
+                except ValueError:
+                    return original
+            if isinstance(original, int) and not isinstance(original, bool):
+                try:
+                    return int(float(val_str))
+                except ValueError:
+                    return original
+            if isinstance(original, float):
+                try:
+                    return float(val_str)
+                except ValueError:
+                    return original
+            return val_str
+
+        updated = 0
+
+        def update_macros(obj):
+            nonlocal updated
+            if isinstance(obj, dict):
+                for key, val in obj.items():
+                    if key.startswith("Macro") and key[5:].isdigit():
+                        idx = int(key[5:])
+                        if idx in macro_updates:
+                            new_val = macro_updates[idx]
+                            if isinstance(val, dict) and "value" in val:
+                                val["value"] = cast_value(new_val, val["value"])
+                            else:
+                                obj[key] = cast_value(new_val, val)
+                            updated += 1
+                    update_macros(val)
+            elif isinstance(obj, list):
+                for item in obj:
+                    update_macros(item)
+
+        update_macros(preset_data)
+
+        dest = output_path or preset_path
+        with open(dest, "w") as f:
+            json.dump(preset_data, f, indent=2)
+            f.write("\n")
+
+        return {
+            "success": True,
+            "message": f"Updated {updated} macro values",
+            "path": dest,
+        }
+    except Exception as exc:
+        logger.error("Macro value update failed: %s", exc)
+        return {"success": False, "message": f"Error updating macro values: {exc}"}
+

--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -207,25 +207,31 @@ def extract_macro_information(preset_path):
         # Initialize macros dictionary
         macros = {}
         
-        # Find all macros and their custom names
+        # Find all macros, their custom names, and values
         def find_macros(data, path=""):
             if isinstance(data, dict):
                 for key, value in data.items():
                     if key.startswith("Macro") and key[5:].isdigit():
                         macro_index = int(key[5:])
-                        
+
                         # Initialize macro if not exists
                         if macro_index not in macros:
                             macros[macro_index] = {
                                 "index": macro_index,
                                 "name": f"Macro {macro_index}",  # Default name
-                                "parameters": []
+                                "parameters": [],
+                                "value": None,
                             }
-                        
+
                         # Check if it has a custom name
-                        if isinstance(value, dict) and "customName" in value:
-                            macros[macro_index]["name"] = value["customName"]
-                    
+                        if isinstance(value, dict):
+                            if "customName" in value:
+                                macros[macro_index]["name"] = value["customName"]
+                            if "value" in value:
+                                macros[macro_index]["value"] = value["value"]
+                        else:
+                            macros[macro_index]["value"] = value
+
                     # Recursively search in nested dictionaries
                     new_path = f"{path}.{key}" if path else key
                     find_macros(value, new_path)

--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -293,6 +293,17 @@ def extract_macro_information(preset_path):
         # Then find all parameters with macroMapping
         find_macro_mappings(preset_data)
         
+        # If a macro lacks a custom name, derive one from its mapped parameters
+        for idx, info in macros.items():
+            if info.get("name") == f"Macro {idx}" and info.get("parameters"):
+                names = []
+                for p in info["parameters"]:
+                    n = p.get("name")
+                    if n and n not in names:
+                        names.append(n)
+                if names:
+                    info["name"] = ", ".join(names)
+
         # Convert dictionary to sorted list
         macros_list = [macros[i] for i in sorted(macros.keys())]
         

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -440,6 +440,7 @@ def synth_params():
     selected_preset = result.get("selected_preset")
     param_count = result.get("param_count", 0)
     default_preset_path = result.get("default_preset_path")
+    macro_knobs_html = result.get("macro_knobs_html", "")
     preset_selected = bool(selected_preset)
     return render_template(
         "synth_params.html",
@@ -454,6 +455,7 @@ def synth_params():
         selected_preset=selected_preset,
         param_count=param_count,
         default_preset_path=default_preset_path,
+        macro_knobs_html=macro_knobs_html,
         active_tab="synth-params",
     )
 

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.querySelectorAll('input.param-dial').forEach(setupControl);
     document.querySelectorAll('input.param-slider').forEach(setupControl);
+    document.querySelectorAll('input.macro-dial').forEach(setupControl);
 
     document.querySelectorAll('input.param-toggle').forEach(el => {
         const target = el.dataset.target;

--- a/static/style.css
+++ b/static/style.css
@@ -621,3 +621,26 @@ select {
     margin-bottom: 0.75rem;
   }
 
+.macro-knob-row {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    margin: 0.5rem 0 1rem 0;
+}
+
+.macro-knob {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.macro-label {
+    font-size: 0.8rem;
+    margin-bottom: 0.25rem;
+}
+
+.macro-number {
+    margin-top: 0.25rem;
+    font-size: 0.8rem;
+}
+

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -21,6 +21,7 @@
     <input type="hidden" name="param_count" value="{{ param_count }}">
     <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     <p class="current-preset">Editing: {{ selected_preset.split('/')[-1] }}</p>
+    {{ macro_knobs_html | safe }}
     <div class="param-list">
         {{ params_html | safe }}
     </div>

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -133,6 +133,20 @@ def test_update_parameter_values(tmp_path):
     assert abs(val - 0.5) < 1e-6
 
 
+def test_update_macro_values(tmp_path):
+    src = Path("examples/Track Presets/Drift/Analog Shape - Core.json")
+    dest = tmp_path / "out.ablpreset"
+    from core.synth_param_editor_handler import update_macro_values
+    result = update_macro_values(str(src), {0: "64.5"}, str(dest))
+    assert result["success"], result.get("message")
+    with open(dest, "rb") as f:
+        data = f.read()
+    assert data.endswith(b"\n")
+    preset = json.loads(data)
+    # Macro0 occurs in multiple places; ensure top-level updated
+    assert abs(preset["parameters"]["Macro0"] - 64.5) < 1e-6
+
+
 def test_save_preset_no_changes(tmp_path):
     """Saving a preset without modifying parameters should produce identical output."""
     src = Path("examples/Track Presets/Drift/Analog Shape - Core.json")

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -168,3 +168,14 @@ def test_save_preset_no_changes(tmp_path):
     with open(dest, "rb") as f:
         written = f.read()
     assert written == original
+
+
+def test_macro_names_fall_back_to_parameters():
+    src = Path("examples/Track Presets/Drift/Analog Shape - Core.json")
+    from core.synth_preset_inspector_handler import extract_macro_information
+    info = extract_macro_information(str(src))
+    assert info["success"], info.get("message")
+    names = {m["index"]: m["name"] for m in info["macros"]}
+    assert names[0] == "Filter Cutoff"
+    assert names[2] == "Oscillator1_Type"
+    assert names[3] == "Oscillator2_Type"


### PR DESCRIPTION
## Summary
- include macro values when extracting macro info
- render macro knob row on the synth parameter page
- propagate macro knob HTML from handler to template
- style macro knob row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684529806b5883258a1aa0017c76ec01