### PR TITLE
Fix knob step size handling

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -362,6 +362,16 @@ class SynthParamEditorHandler(BaseHandler):
             step_attr = ''
             if meta.get("decimals") is not None:
                 step_attr = f' step="{10 ** (-meta["decimals"])}"'
+            else:
+                min_val = meta.get("min")
+                max_val = meta.get("max")
+                if (
+                    min_val is not None
+                    and max_val is not None
+                    and max_val <= 1
+                    and min_val >= -1
+                ):
+                    step_attr = ' step="0.01"'
             unit_attr = f' data-unit="{meta.get("unit")}"' if meta.get("unit") else ''
             disp_id = f'param_{idx}_display'
             klass = "param-dial input-knob"

--- a/static/schemas/drift_schema.json
+++ b/static/schemas/drift_schema.json
@@ -305,7 +305,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Global_VoiceCount": {
     "type": "enum",


### PR DESCRIPTION
## Summary
- tweak synth parameter editor to default to 0.01 step for parameters whose range is within ±1
- adjust `Global_UnisonVoiceDepth` schema precision to show fine control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452b5f526c8325b99b8a1ca0bb949e