### PR TITLE
Improve synth preset editor layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -621,3 +621,14 @@ select {
     margin-bottom: 0.75rem;
   }
 
+/* Layout for preset editor controls */
+.preset-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+.preset-controls label {
+    margin-bottom: 0;
+}
+

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -15,18 +15,20 @@
     {{ file_browser_html | safe }}
 </div>
 {% else %}
-<form method="post" action="{{ host_prefix }}/synth-params" id="param-form">
-    <input type="hidden" name="action" id="action-input" value="save_params">
-    <input type="hidden" name="preset_select" value="{{ selected_preset }}">
-    <input type="hidden" name="param_count" value="{{ param_count }}">
-    <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
-    <p class="current-preset">Editing: {{ selected_preset.split('/')[-1] }}</p>
-    <div class="param-list">
-        {{ params_html | safe }}
-    </div>
-    <label>New Preset Name: <input type="text" name="new_preset_name"></label>
-    <button type="submit">Save Parameters</button>
-</form>
+    <form method="post" action="{{ host_prefix }}/synth-params" id="param-form">
+        <input type="hidden" name="action" id="action-input" value="save_params">
+        <input type="hidden" name="preset_select" value="{{ selected_preset }}">
+        <input type="hidden" name="param_count" value="{{ param_count }}">
+        <div class="preset-controls">
+            <label class="preset-name">Preset Name: <input type="text" name="new_preset_name" value="{{ selected_preset.split('/')[-1] }}"></label>
+            <button type="submit">Save Preset</button>
+            <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
+        </div>
+        <p class="current-preset">Editing: {{ selected_preset.split('/')[-1] }}</p>
+        <div class="param-list">
+            {{ params_html | safe }}
+        </div>
+    </form>
 {% endif %}
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- update synth preset editor layout and inputs
- add preset-controls styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452c4d709883259182462912590a25