### PR TITLE
UI tweaks for synth parameter editor

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -392,7 +392,14 @@ def synth_macros():
         form = SimpleForm(request.form.to_dict())
         result = synth_handler.handle_post(form)
     else:
-        result = synth_handler.handle_get()
+        if "preset" in request.args:
+            form = SimpleForm({
+                "action": "select_preset",
+                "preset_select": request.args.get("preset"),
+            })
+            result = synth_handler.handle_post(form)
+        else:
+            result = synth_handler.handle_get()
 
     message = result.get("message")
     message_type = result.get("message_type")

--- a/static/style.css
+++ b/static/style.css
@@ -642,6 +642,13 @@ select {
 .macro-number {
     margin-top: 0.25rem;
     font-size: 0.8rem;
+}
+
+.edit-macros-link {
+    text-align: center;
+    margin: 0 0 1rem;
+}
+
 /* Layout for preset editor controls */
 .preset-controls {
     display: flex;

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -32,9 +32,9 @@
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     </div>
     {{ macro_knobs_html | safe }}
-    <p style="margin-top:0.5em;">
+    <div class="edit-macros-link">
         <a href="{{ host_prefix }}/synth-macros?preset={{ selected_preset | urlencode }}">Edit Macros</a>
-    </p>
+    </div>
     <div class="param-list">
         {{ params_html | safe }}
     </div>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -19,14 +19,25 @@
     <input type="hidden" name="action" id="action-input" value="save_params">
     <input type="hidden" name="preset_select" value="{{ selected_preset }}">
     <input type="hidden" name="param_count" value="{{ param_count }}">
-    <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     <p class="current-preset">Editing: {{ selected_preset.split('/')[-1] }}</p>
+    {% set _basename = selected_preset.split('/')[-1] %}
+    {% if _basename.endswith('.json') or _basename.endswith('.ablpreset') %}
+        {% set _prefill = _basename.rsplit('.', 1)[0] %}
+    {% else %}
+        {% set _prefill = _basename %}
+    {% endif %}
+    <label>Preset Name: <input type="text" name="new_preset_name" value="{{ _prefill }}"></label>
+    <div class="preset-actions">
+        <button type="submit">Save Parameters</button>
+        <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
+    </div>
     {{ macro_knobs_html | safe }}
+    <p style="margin-top:0.5em;">
+        <a href="{{ host_prefix }}/synth-macros?preset={{ selected_preset | urlencode }}">Edit Macros</a>
+    </p>
     <div class="param-list">
         {{ params_html | safe }}
     </div>
-    <label>New Preset Name: <input type="text" name="new_preset_name"></label>
-    <button type="submit">Save Parameters</button>
 </form>
 
 {% endif %}


### PR DESCRIPTION
## Summary
- move preset name and save actions to the top of the parameter editor
- default the name field to the current preset
- add a link to launch the macro editor for the loaded preset
- allow `/synth-macros` to load presets via a `preset` query parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453235fba48325b7c60772150cc07e