### PR TITLE
Allow unmapped macros

### DIFF
--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -293,16 +293,19 @@ def extract_macro_information(preset_path):
         # Then find all parameters with macroMapping
         find_macro_mappings(preset_data)
         
-        # If a macro lacks a custom name, derive one from its mapped parameters
-        for idx, info in macros.items():
-            if info.get("name") == f"Macro {idx}" and info.get("parameters"):
-                names = []
-                for p in info["parameters"]:
-                    n = p.get("name")
-                    if n and n not in names:
-                        names.append(n)
-                if names:
-                    info["name"] = ", ".join(names)
+
+        # Leave unnamed macros untouched. The Move system will assign names
+        # when the preset is loaded, so we simply preserve the default
+        # "Macro N" labels here even if parameters are mapped.
+
+        # Ensure all 8 macros are present even if unused
+        for i in range(8):
+            if i not in macros:
+                macros[i] = {
+                    "index": i,
+                    "name": f"Macro {i}",
+                    "parameters": [],
+                }
 
         # Convert dictionary to sorted list
         macros_list = [macros[i] for i in sorted(macros.keys())]

--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -367,17 +367,22 @@ def update_preset_macro_names(preset_path, macro_updates):
                                 
                                 # For device parameters (not top-level), we can add customName
                                 # If it's already an object with customName
+                                new_name = macro_updates[macro_index]
+
                                 if isinstance(params[key], dict) and "value" in params[key]:
-                                    params[key]["customName"] = macro_updates[macro_index]
+                                    if new_name:
+                                        params[key]["customName"] = new_name
+                                    else:
+                                        params[key].pop("customName", None)
                                     updated_count += 1
-                                # If it's a direct value, convert to object with value and customName
                                 else:
-                                    original_value = params[key]
-                                    params[key] = {
-                                        "value": original_value,
-                                        "customName": macro_updates[macro_index]
-                                    }
-                                    updated_count += 1
+                                    if new_name:
+                                        original_value = params[key]
+                                        params[key] = {
+                                            "value": original_value,
+                                            "customName": new_name
+                                        }
+                                        updated_count += 1
                 
                 # Recursively search in nested structures
                 for key, value in data.items():

--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -62,19 +62,19 @@ class SynthPresetInspectorHandler(BaseHandler):
             if action == 'save_name':
                 macro_index = int(form.getvalue('macro_index'))
                 new_name = form.getvalue(f'macro_{macro_index}_name')
-                
-                if new_name:  # Only update if a name was provided
-                    # Create a single macro update
-                    macro_updates = {macro_index: new_name}
-                    
-                    # Update the preset file with the new macro name
-                    update_result = update_preset_macro_names(preset_path, macro_updates)
-                    if not update_result['success']:
-                        return self.format_error_response(update_result['message'])
-                    
+
+                # Allow blank names to remove customName
+                macro_updates = {macro_index: new_name}
+
+                # Update the preset file with the new macro name (or removal)
+                update_result = update_preset_macro_names(preset_path, macro_updates)
+                if not update_result['success']:
+                    return self.format_error_response(update_result['message'])
+
+                if new_name:
                     message = f"Saved name for Macro {macro_index}: {new_name}"
                 else:
-                    return self.format_error_response("No name provided for the macro")
+                    message = f"Removed custom name for Macro {macro_index}"
             
             # If this is a save names action for all macros, update all macro names
             elif action == 'save_names':
@@ -86,14 +86,11 @@ class SynthPresetInspectorHandler(BaseHandler):
                     if match:
                         macro_index = int(match.group(1))
                         new_name = form.getvalue(field_name)
-                        if new_name:  # Only update if a name was provided
-                            macro_updates[macro_index] = new_name
-                
-                # Update the preset file with the new macro names
-                if macro_updates:
-                    update_result = update_preset_macro_names(preset_path, macro_updates)
-                    if not update_result['success']:
-                        return self.format_error_response(update_result['message'])
+                        macro_updates[macro_index] = new_name
+
+                update_result = update_preset_macro_names(preset_path, macro_updates)
+                if not update_result['success']:
+                    return self.format_error_response(update_result['message'])
                 
                 message = f"Saved macro names for preset: {preset_path.split('/')[-1]}"
             

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -209,3 +209,30 @@ def test_extract_macro_info_adds_missing_macros(tmp_path):
     assert len(info["macros"]) == 8
     # All macros should use default names
     assert all(m["name"] == f"Macro {m['index']}" for m in info["macros"])
+
+
+def test_remove_macro_name(tmp_path):
+    preset_src = Path("examples/Track Presets/Drift/Analog Shape - Core.json")
+    preset_copy = tmp_path / "copy.ablpreset"
+    preset_copy.write_text(preset_src.read_text())
+
+    from core.synth_preset_inspector_handler import (
+        extract_macro_information,
+        update_preset_macro_names,
+    )
+
+    # Remove the name for Macro0
+    result = update_preset_macro_names(str(preset_copy), {0: ""})
+    assert result["success"], result.get("message")
+
+    info = extract_macro_information(str(preset_copy))
+    assert info["success"], info.get("message")
+
+    names = {m["index"]: m["name"] for m in info["macros"]}
+    assert names[0] == "Macro 0"
+    assert names[1] == "Shape"
+
+    with open(preset_copy) as f:
+        data = json.load(f)
+    assert "customName" not in data["chains"][0]["devices"][0]["parameters"]["Macro0"]
+


### PR DESCRIPTION
## Summary
- ensure macros keep default names when custom name is missing
- adjust tests for new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684534362fc083259e820f99a5ebd6cf