### PR TITLE
Add renaming option to synth parameter editor

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -14,6 +14,7 @@ from core.synth_param_editor_handler import (
     update_parameter_values,
     update_macro_values,
 )
+from core.refresh_handler import refresh_library
 
 # Path to the preset used when creating a new preset. Prefer the version in the
 # user's library but fall back to the bundled example if it doesn't exist.
@@ -113,6 +114,11 @@ class SynthParamEditorHandler(BaseHandler):
             message = result['message'] + "; " + macro_result['message']
             if output_path:
                 message += f" Saved as {os.path.basename(output_path)}"
+            refresh_success, refresh_message = refresh_library()
+            if refresh_success:
+                message += " Library refreshed."
+            else:
+                message += f" Library refresh failed: {refresh_message}"
         elif action in ['select_preset', 'new_preset']:
             if action == 'new_preset':
                 message = "Loaded default preset"

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -59,6 +59,7 @@ class SynthParamEditorHandler(BaseHandler):
             'schema_json': json.dumps(schema),
             'default_preset_path': DEFAULT_PRESET,
             'macro_knobs_html': '',
+            'rename_checked': False,
         }
 
     def handle_post(self, form):
@@ -75,6 +76,7 @@ class SynthParamEditorHandler(BaseHandler):
             return self.format_error_response("No preset selected")
 
         message = ''
+        rename_flag = False
         if action == 'save_params':
             try:
                 count = int(form.getvalue('param_count', '0'))
@@ -86,9 +88,10 @@ class SynthParamEditorHandler(BaseHandler):
                 value = form.getvalue(f'param_{i}_value')
                 if name is not None and value is not None:
                     updates[name] = value
+            rename_flag = form.getvalue('rename') in ('on', 'true', '1')
             new_name = form.getvalue('new_preset_name')
             output_path = None
-            if new_name:
+            if rename_flag and new_name:
                 directory = os.path.dirname(preset_path)
                 if not new_name.endswith('.ablpreset'):
                     new_name += '.ablpreset'
@@ -153,6 +156,7 @@ class SynthParamEditorHandler(BaseHandler):
             'schema_json': json.dumps(load_drift_schema()),
             'default_preset_path': DEFAULT_PRESET,
             'macro_knobs_html': macro_knobs_html,
+            'rename_checked': rename_flag if action == 'save_params' else False,
         }
 
     SECTION_ORDER = [

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -448,6 +448,7 @@ def synth_params():
     param_count = result.get("param_count", 0)
     default_preset_path = result.get("default_preset_path")
     macro_knobs_html = result.get("macro_knobs_html", "")
+    rename_checked = result.get("rename_checked", False)
     preset_selected = bool(selected_preset)
     return render_template(
         "synth_params.html",
@@ -463,6 +464,7 @@ def synth_params():
         param_count=param_count,
         default_preset_path=default_preset_path,
         macro_knobs_html=macro_knobs_html,
+        rename_checked=rename_checked,
         active_tab="synth-params",
     )
 

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -30,7 +30,7 @@
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
         </label>
-        <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Rename</label>
+        <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>
     <div class="preset-actions">
         <button type="submit">Save Parameters</button>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -26,8 +26,12 @@
     {% else %}
         {% set _prefill = _basename %}
     {% endif %}
-    <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Rename</label>
-    <label>Preset Name: <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}></label>
+    <div class="preset-controls">
+        <label>Preset Name:
+            <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+        </label>
+        <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Rename</label>
+    </div>
     <div class="preset-actions">
         <button type="submit">Save Parameters</button>
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -26,7 +26,8 @@
     {% else %}
         {% set _prefill = _basename %}
     {% endif %}
-    <label>Preset Name: <input type="text" name="new_preset_name" value="{{ _prefill }}"></label>
+    <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Rename</label>
+    <label>Preset Name: <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}></label>
     <div class="preset-actions">
         <button type="submit">Save Parameters</button>
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
@@ -46,5 +47,32 @@
 <script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const cb = document.getElementById('rename-checkbox');
+  const nameInput = document.getElementById('new-preset-name');
+  if (cb && nameInput) {
+    cb.addEventListener('change', () => {
+      nameInput.disabled = !cb.checked;
+    });
+    const form = document.getElementById('param-form');
+    const orig = nameInput.dataset.originalName;
+    if (form && orig) {
+      form.addEventListener('submit', (e) => {
+        if (!cb.checked) return;
+        let newName = nameInput.value.trim();
+        if (!newName.endsWith('.ablpreset') && !newName.endsWith('.json')) {
+          newName += '.ablpreset';
+        }
+        if (newName === orig) {
+          if (!confirm('This will overwrite the existing preset. Continue?')) {
+            e.preventDefault();
+          }
+        }
+      });
+    }
+  }
+});
+</script>
 {% endblock %}
 

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -143,6 +143,9 @@ def test_synth_params_post(client, monkeypatch):
     assert b'done' in resp.data
     assert b'Editing:' in resp.data
     assert b'<div>p</div>' in resp.data
+    assert b'name="rename"' in resp.data
+    assert b'name="new_preset_name"' in resp.data
+    assert b'disabled' in resp.data
 
 def test_synth_params_new_preset(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
@@ -162,6 +165,8 @@ def test_synth_params_new_preset(client, monkeypatch):
     assert resp.status_code == 200
     assert b'loaded' in resp.data
     assert b'Editing:' in resp.data
+    assert b'name="rename"' in resp.data
+    assert b'name="new_preset_name"' in resp.data
 
 def test_drum_rack_inspector_get(client, monkeypatch):
     def fake_get():


### PR DESCRIPTION
## Summary
- update synth parameters page with rename checkbox and warning script
- support rename flag in synth parameter handler and route
- update tests for new form controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845375976048325b6e8efe6cd7b6483