### PR TITLE
Fix macro placeholder

### DIFF
--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -252,7 +252,13 @@ class SynthPresetInspectorHandler(BaseHandler):
             html += f'<div class="macro-item">'
             html += f'<div class="macro-header">'
             html += f'<span>Macro {macro["index"]}:</span> '
-            html += f'<input type="text" name="macro_{macro["index"]}_name" value="{macro["name"]}" class="macro-name-input">'
+            default_label = f"Macro {macro['index']}"
+            macro_value = macro["name"] if macro["name"] != default_label else ""
+            placeholder = " placeholder=\"Default name chosen by Move..\"" if not macro_value else ""
+            html += (
+                f'<input type="text" name="macro_{macro["index"]}_name" '
+                f'value="{macro_value}"{placeholder} class="macro-name-input">'
+            )
             # Add the "Save Name" button
             html += f'<button type="submit" class="save-name-btn" '
             html += f'onclick="document.getElementById(\'action-input\').value=\'save_name\'; '

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -435,7 +435,14 @@ def synth_params():
         form = SimpleForm(request.form.to_dict())
         result = synth_param_handler.handle_post(form)
     else:
-        result = synth_param_handler.handle_get()
+        if "preset" in request.args:
+            form = SimpleForm({
+                "action": "select_preset",
+                "preset_select": request.args.get("preset"),
+            })
+            result = synth_param_handler.handle_post(form)
+        else:
+            result = synth_param_handler.handle_get()
 
     message = result.get("message")
     message_type = result.get("message_type")

--- a/static/style.css
+++ b/static/style.css
@@ -649,6 +649,11 @@ select {
     margin: 0 0 1rem;
 }
 
+.return-params-link {
+    text-align: center;
+    margin: 1rem 0;
+}
+
 /* Layout for preset editor controls */
 .preset-controls {
     display: flex;

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -29,6 +29,9 @@
             {{ all_params_html | safe }}
         </div>
     </details>
+    <div class="return-params-link">
+        <a href="{{ host_prefix }}/synth-params?preset={{ selected_preset | urlencode }}">Return to Parameter Editor</a>
+    </div>
 </form>
 {% endif %}
 

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -105,6 +105,7 @@ def test_synth_macros_post(client, monkeypatch):
     assert b'<p>done</p>' in resp.data
     assert b'Currently loaded preset:' in resp.data
     assert b'View All Parameters' in resp.data
+    assert b'Return to Parameter Editor' in resp.data
 
 def test_synth_params_get(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
@@ -146,6 +147,27 @@ def test_synth_params_post(client, monkeypatch):
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
     assert b'disabled' in resp.data
+
+def test_synth_params_get_with_preset(client, monkeypatch):
+    def fake_post(form):
+        assert form.getvalue('action') == 'select_preset'
+        assert form.getvalue('preset_select') == 'x'
+        return {
+            'message': 'loaded',
+            'message_type': 'success',
+            'params_html': '<div>p</div>',
+            'browser_root': '/tmp',
+            'selected_preset': 'x',
+            'param_count': 1,
+            'default_preset_path': 'x',
+            'macro_knobs_html': '',
+            'rename_checked': False,
+        }
+    monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
+    resp = client.get('/synth-params?preset=x')
+    assert resp.status_code == 200
+    assert b'loaded' in resp.data
+    assert b'Editing:' in resp.data
 
 def test_synth_params_new_preset(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET


### PR DESCRIPTION
## Summary
- adjust macro name input in SynthPresetInspectorHandler to show a placeholder if the name is default
- allow jumping back to the parameter editor via a link on the macro editor
- support preset selection via query parameter when loading the parameter editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68453d18d7308325a5e7ea6b24e039d7