### PR TITLE
Add macro highlighting in parameter editor

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -661,12 +661,44 @@ select {
 }
 
 /* Highlight parameters and macros by macro index */
-.param-item.macro-0, .macro-knob.macro-0 { border: 2px solid #191970; }
-.param-item.macro-1, .macro-knob.macro-1 { border: 2px solid #006400; }
-.param-item.macro-2, .macro-knob.macro-2 { border: 2px solid #ff0000; }
-.param-item.macro-3, .macro-knob.macro-3 { border: 2px solid #ffd700; }
-.param-item.macro-4, .macro-knob.macro-4 { border: 2px solid #00ff00; }
-.param-item.macro-5, .macro-knob.macro-5 { border: 2px solid #00ffff; }
-.param-item.macro-6, .macro-knob.macro-6 { border: 2px solid #ff00ff; }
-.param-item.macro-7, .macro-knob.macro-7 { border: 2px solid #ffb6c1; }
+.param-item.macro-0, .macro-knob.macro-0 {
+    border: 2px solid #191970;
+    background-color: rgba(25, 25, 112, 0.05);
+    border-radius: 4px;
+}
+.param-item.macro-1, .macro-knob.macro-1 {
+    border: 2px solid #006400;
+    background-color: rgba(0, 100, 0, 0.05);
+    border-radius: 4px;
+}
+.param-item.macro-2, .macro-knob.macro-2 {
+    border: 2px solid #ff0000;
+    background-color: rgba(255, 0, 0, 0.05);
+    border-radius: 4px;
+}
+.param-item.macro-3, .macro-knob.macro-3 {
+    border: 2px solid #ffd700;
+    background-color: rgba(255, 215, 0, 0.1);
+    border-radius: 4px;
+}
+.param-item.macro-4, .macro-knob.macro-4 {
+    border: 2px solid #00ff00;
+    background-color: rgba(0, 255, 0, 0.05);
+    border-radius: 4px;
+}
+.param-item.macro-5, .macro-knob.macro-5 {
+    border: 2px solid #00ffff;
+    background-color: rgba(0, 255, 255, 0.05);
+    border-radius: 4px;
+}
+.param-item.macro-6, .macro-knob.macro-6 {
+    border: 2px solid #ff00ff;
+    background-color: rgba(255, 0, 255, 0.05);
+    border-radius: 4px;
+}
+.param-item.macro-7, .macro-knob.macro-7 {
+    border: 2px solid #ffb6c1;
+    background-color: rgba(255, 182, 193, 0.1);
+    border-radius: 4px;
+}
 

--- a/static/style.css
+++ b/static/style.css
@@ -660,3 +660,13 @@ select {
     margin-bottom: 0;
 }
 
+/* Highlight parameters and macros by macro index */
+.param-item.macro-0, .macro-knob.macro-0 { border: 2px solid #191970; }
+.param-item.macro-1, .macro-knob.macro-1 { border: 2px solid #006400; }
+.param-item.macro-2, .macro-knob.macro-2 { border: 2px solid #ff0000; }
+.param-item.macro-3, .macro-knob.macro-3 { border: 2px solid #ffd700; }
+.param-item.macro-4, .macro-knob.macro-4 { border: 2px solid #00ff00; }
+.param-item.macro-5, .macro-knob.macro-5 { border: 2px solid #00ffff; }
+.param-item.macro-6, .macro-knob.macro-6 { border: 2px solid #ff00ff; }
+.param-item.macro-7, .macro-knob.macro-7 { border: 2px solid #ffb6c1; }
+

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -12,6 +12,10 @@
     {{ file_browser_html | safe }}
 </div>
 {% else %}
+    <div class="return-params-link">
+        <a href="{{ host_prefix }}/synth-params?preset={{ selected_preset | urlencode }}">Return to Parameter Editor</a>
+    </div>
+    
 <form method="post" action="{{ host_prefix }}/synth-macros" id="preset-form">
     <input type="hidden" name="action" id="action-input" value="reset_preset">
     <input type="hidden" name="param_path" id="param-path-input" value="">


### PR DESCRIPTION
## Summary
- highlight macros and parameters with matching colors
- update style sheet for macro highlight classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453f507a4c8325b69d42811acaaf96