### PR TITLE
Enhance macro editor layout

### DIFF
--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -255,7 +255,7 @@ class SynthPresetInspectorHandler(BaseHandler):
             except Exception:
                 value = 0.0
             display_val = round(value, 1)
-            html += f'<div class="macro-item macro-{macro["index"]}">'
+            html += f'<div class="macro-item">'
             html += '<div class="macro-top">'
             name_label = macro.get("name", f"Macro {macro['index']}")
             html += (

--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -247,9 +247,26 @@ class SynthPresetInspectorHandler(BaseHandler):
                     )
         
         html = '<div class="macros-container">'
-        
+
         for macro in macros:
-            html += f'<div class="macro-item">'
+            value = macro.get("value")
+            try:
+                value = float(value)
+            except Exception:
+                value = 0.0
+            display_val = round(value, 1)
+            html += f'<div class="macro-item macro-{macro["index"]}">'
+            html += '<div class="macro-top">'
+            name_label = macro.get("name", f"Macro {macro['index']}")
+            html += (
+                f'<div class="macro-knob macro-{macro["index"]}">'
+                f'<span class="macro-label">{name_label}</span>'
+                f'<input type="range" class="macro-dial input-knob" '
+                f'value="{display_val}" min="0" max="127" step="0.1" data-decimals="1" disabled>'
+                f'<span class="macro-number">{display_val}</span>'
+                f'</div>'
+            )
+            html += '<div>'
             html += f'<div class="macro-header">'
             html += f'<span>Macro {macro["index"]}:</span> '
             default_label = f"Macro {macro['index']}"
@@ -317,7 +334,7 @@ class SynthPresetInspectorHandler(BaseHandler):
             html += '</div>'  # Close parameter-controls
 
             html += '</div>'
-            
+
             # Display current mappings
             html += '<div class="current-mappings">'
             html += '<h4>Current Mappings:</h4>'
@@ -346,8 +363,10 @@ class SynthPresetInspectorHandler(BaseHandler):
             else:
                 html += '<p>No parameters mapped to this macro.</p>'
             
-            html += '</div>'
-            html += '</div>'
+            html += '</div>'  # close current-mappings
+            html += '</div>'  # close inner container
+            html += '</div>'  # close macro-top
+            html += '</div>'  # close macro-item
             
         html += '</div>'
         return html

--- a/static/style.css
+++ b/static/style.css
@@ -666,42 +666,42 @@ select {
 }
 
 /* Highlight parameters and macros by macro index */
-.param-item.macro-0, .macro-knob.macro-0 {
+.param-item.macro-0, .macro-knob.macro-0, .macro-item.macro-0 {
     border: 2px solid #191970;
     background-color: rgba(25, 25, 112, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-1, .macro-knob.macro-1 {
+.param-item.macro-1, .macro-knob.macro-1, .macro-item.macro-1 {
     border: 2px solid #006400;
     background-color: rgba(0, 100, 0, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-2, .macro-knob.macro-2 {
+.param-item.macro-2, .macro-knob.macro-2, .macro-item.macro-2 {
     border: 2px solid #ff0000;
     background-color: rgba(255, 0, 0, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-3, .macro-knob.macro-3 {
+.param-item.macro-3, .macro-knob.macro-3, .macro-item.macro-3 {
     border: 2px solid #ffd700;
     background-color: rgba(255, 215, 0, 0.1);
     border-radius: 4px;
 }
-.param-item.macro-4, .macro-knob.macro-4 {
+.param-item.macro-4, .macro-knob.macro-4, .macro-item.macro-4 {
     border: 2px solid #00ff00;
     background-color: rgba(0, 255, 0, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-5, .macro-knob.macro-5 {
+.param-item.macro-5, .macro-knob.macro-5, .macro-item.macro-5 {
     border: 2px solid #00ffff;
     background-color: rgba(0, 255, 255, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-6, .macro-knob.macro-6 {
+.param-item.macro-6, .macro-knob.macro-6, .macro-item.macro-6 {
     border: 2px solid #ff00ff;
     background-color: rgba(255, 0, 255, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-7, .macro-knob.macro-7 {
+.param-item.macro-7, .macro-knob.macro-7, .macro-item.macro-7 {
     border: 2px solid #ffb6c1;
     background-color: rgba(255, 182, 193, 0.1);
     border-radius: 4px;

--- a/static/style.css
+++ b/static/style.css
@@ -666,42 +666,42 @@ select {
 }
 
 /* Highlight parameters and macros by macro index */
-.param-item.macro-0, .macro-knob.macro-0, .macro-item.macro-0 {
+.param-item.macro-0, .macro-knob.macro-0 {
     border: 2px solid #191970;
     background-color: rgba(25, 25, 112, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-1, .macro-knob.macro-1, .macro-item.macro-1 {
+.param-item.macro-1, .macro-knob.macro-1 {
     border: 2px solid #006400;
     background-color: rgba(0, 100, 0, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-2, .macro-knob.macro-2, .macro-item.macro-2 {
+.param-item.macro-2, .macro-knob.macro-2 {
     border: 2px solid #ff0000;
     background-color: rgba(255, 0, 0, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-3, .macro-knob.macro-3, .macro-item.macro-3 {
+.param-item.macro-3, .macro-knob.macro-3 {
     border: 2px solid #ffd700;
     background-color: rgba(255, 215, 0, 0.1);
     border-radius: 4px;
 }
-.param-item.macro-4, .macro-knob.macro-4, .macro-item.macro-4 {
+.param-item.macro-4, .macro-knob.macro-4 {
     border: 2px solid #00ff00;
     background-color: rgba(0, 255, 0, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-5, .macro-knob.macro-5, .macro-item.macro-5 {
+.param-item.macro-5, .macro-knob.macro-5 {
     border: 2px solid #00ffff;
     background-color: rgba(0, 255, 255, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-6, .macro-knob.macro-6, .macro-item.macro-6 {
+.param-item.macro-6, .macro-knob.macro-6 {
     border: 2px solid #ff00ff;
     background-color: rgba(255, 0, 255, 0.05);
     border-radius: 4px;
 }
-.param-item.macro-7, .macro-knob.macro-7, .macro-item.macro-7 {
+.param-item.macro-7, .macro-knob.macro-7 {
     border: 2px solid #ffb6c1;
     background-color: rgba(255, 182, 193, 0.1);
     border-radius: 4px;

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -231,6 +231,7 @@
 {% endblock %}
 {% block scripts %}
 <script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
+<script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script>
 const driftSchema = {{ schema_json|safe }};
 (function() {

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -61,14 +61,23 @@
     
     .macros-container {
         margin-top: 20px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 15px;
     }
-    
+
     .macro-item {
-        margin-bottom: 20px;
+        flex: 1 1 300px;
         padding: 15px;
         border: 1px solid #ddd;
         border-radius: 5px;
         background-color: #f9f9f9;
+    }
+
+    .macro-top {
+        display: flex;
+        align-items: center;
+        gap: 10px;
     }
     
     .macro-header {


### PR DESCRIPTION
## Summary
- display macro tools in a flexible grid
- reuse macro highlight colors for macro editor items
- show read‑only macro value knobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684544a219688325a3d21bd8caf2cf2d