### PR TITLE
Adjust knob size on drift parameter page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -614,6 +614,7 @@ select {
     min-width: 60px;
     display: inline-block;
     text-align: right;
+    font-size: 0.8rem;
 }
 
 .param-input {

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -50,7 +50,7 @@
 {% block scripts %}
 <script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 <script>
-  window.inputKnobsOptions = { knobDiameter: 48 };
+  window.inputKnobsOptions = { knobDiameter: 32 };
 </script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>


### PR DESCRIPTION
## Summary
- make drift parameter knobs 32px in diameter
- unify knob value font size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68454dcdfbd88325a58620364fe23ece