### PR TITLE
UI improvements for parameter editor

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -376,7 +376,10 @@ class SynthParamEditorHandler(BaseHandler):
             )
             html.append(f'<input type="hidden" name="param_{idx}_value" value="{value}">')
         elif p_type == "enum" and meta.get("options"):
-            html.append(f'<select class="param-select" name="param_{idx}_value">')
+            select_class = "param-select"
+            if name == "Filter_Type":
+                select_class += " filter-type-select"
+            html.append(f'<select class="{select_class}" name="param_{idx}_value">')
             short_map = {}
             if name in ("Oscillator1_Type", "Oscillator2_Type"):
                 short_map = self.OSC_WAVE_SHORT
@@ -796,7 +799,10 @@ class SynthParamEditorHandler(BaseHandler):
             if not items:
                 continue
             cls = sec.lower().replace(' ', '-').replace('+', '')
-            out_html += f'<div class="param-panel {cls}"><h3>{sec}</h3><div class="param-items">'
+            extra_cls = ' hidden' if sec == 'Extras' else ''
+            out_html += (
+                f'<div class="param-panel {cls}{extra_cls}"><h3>{sec}</h3><div class="param-items">'
+            )
             out_html += ''.join(items)
             out_html += '</div></div>'
         out_html += '</div>'

--- a/static/style.css
+++ b/static/style.css
@@ -632,6 +632,10 @@ select {
     padding: 0 1.5rem 0 0.5rem;
     text-align: center;
 }
+
+.filter-type-select {
+    width: 48px;
+}
   
 .param-item {
     margin-bottom: 0.75rem;
@@ -661,6 +665,11 @@ select {
 }
 
 .edit-macros-link {
+    text-align: center;
+    margin: 0 0 1rem;
+}
+
+.extras-toggle {
     text-align: center;
     margin: 0 0 1rem;
 }

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -40,6 +40,9 @@
     <div class="edit-macros-link">
         <a href="{{ host_prefix }}/synth-macros?preset={{ selected_preset | urlencode }}">Edit Macros</a>
     </div>
+    <div class="extras-toggle">
+        <button type="button" id="extras-toggle">Show Extras</button>
+    </div>
     <div class="param-list">
         {{ params_html | safe }}
     </div>
@@ -79,6 +82,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
     }
+  }
+
+  const extrasPanel = document.querySelector('.param-panel.extras');
+  const extrasToggle = document.getElementById('extras-toggle');
+  if (extrasPanel && extrasToggle) {
+    extrasToggle.addEventListener('click', () => {
+      extrasPanel.classList.toggle('hidden');
+      extrasToggle.textContent = extrasPanel.classList.contains('hidden') ? 'Show Extras' : 'Hide Extras';
+    });
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- make `Filter_Type` dropdown narrower
- hide the Extras panel by default and add toggle button
- provide styling for new controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455215b9708325a59f9bd666e0ef4e