### PR TITLE
Improve Drift filter controls

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -576,16 +576,21 @@ class SynthParamEditorHandler(BaseHandler):
                 sections[section].append(html)
 
         if filter_items:
-            filter_rows = [
-                ["Filter_Frequency", "Filter_Type"],
-                ["Filter_Tracking"],
-                ["Filter_Resonance", "Filter_HiPassFrequency"],
-            ]
             ordered = []
-            for row in filter_rows:
-                row_html = "".join(filter_items.pop(p, "") for p in row if p in filter_items)
-                if row_html:
-                    ordered.append(f'<div class="param-row">{row_html}</div>')
+
+            freq = filter_items.pop("Filter_Frequency", "")
+            f_type = filter_items.pop("Filter_Type", "")
+            tracking = filter_items.pop("Filter_Tracking", "")
+            pair = ""
+            if f_type or tracking:
+                pair = f'<div class="param-pair">{f_type}{tracking}</div>'
+            row1_html = f"{freq}{pair}"
+            if row1_html.strip():
+                ordered.append(f'<div class="param-row">{row1_html}</div>')
+
+            row2_html = "".join(filter_items.pop(p, "") for p in ["Filter_Resonance", "Filter_HiPassFrequency"] if p in filter_items)
+            if row2_html:
+                ordered.append(f'<div class="param-row">{row2_html}</div>')
 
             src1 = filter_items.pop("Filter_ModSource1", "")
             amt1 = filter_items.pop("Filter_ModAmount1", "")

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -350,6 +350,7 @@ class SynthParamEditorHandler(BaseHandler):
         "ModulationMatrix_Amount2",
         "ModulationMatrix_Amount3",
         "Lfo_ModAmount",
+        "Filter_Tracking",
 
     }
 
@@ -576,7 +577,8 @@ class SynthParamEditorHandler(BaseHandler):
 
         if filter_items:
             filter_rows = [
-                ["Filter_Frequency", "Filter_Type", "Filter_Tracking"],
+                ["Filter_Frequency", "Filter_Type"],
+                ["Filter_Tracking"],
                 ["Filter_Resonance", "Filter_HiPassFrequency"],
             ]
             ordered = []

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -11,8 +11,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const max = parseFloat(el.max);
         const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
         const format = (v) => {
-            const displayVal = shouldScale ? v * 100 : v;
-            return Number(displayVal).toFixed(displayDecimals) + (unit ? ' ' + unit : '');
+            let displayVal = shouldScale ? v * 100 : v;
+            let unitLabel = unit;
+            if (unit === 'Hz') {
+                displayVal = Number(displayVal);
+                if (displayVal >= 1000) {
+                    displayVal = displayVal / 1000;
+                    unitLabel = 'kHz';
+                }
+                return displayVal.toFixed(1) + ' ' + unitLabel;
+            }
+            return Number(displayVal).toFixed(displayDecimals) + (unit ? ' ' + unitLabel : '');
         };
         if (displayEl) {
             displayEl.textContent = isNaN(el.value) ? 'not set' : format(parseFloat(el.value));

--- a/static/rect-slider.js
+++ b/static/rect-slider.js
@@ -23,8 +23,17 @@ function initSlider(el){
   label.className='rect-slider-label';
   el.appendChild(label);
   function format(v){
-    const displayVal=shouldScale?v*100:v;
-    return Number(displayVal).toFixed(displayDecimals)+(unit?` ${unit}`:'');
+    let displayVal=shouldScale?v*100:v;
+    let unitLabel=unit;
+    if(unit==='Hz'){
+      displayVal=Number(displayVal);
+      if(displayVal>=1000){
+        displayVal=displayVal/1000;
+        unitLabel='kHz';
+      }
+      return displayVal.toFixed(1)+` ${unitLabel}`;
+    }
+    return Number(displayVal).toFixed(displayDecimals)+(unit?` ${unitLabel}`:'');
   }
   function update(){
     label.textContent=format(value);


### PR DESCRIPTION
## Summary
- tweak dial/slider display for Hz values to switch to kHz after 1000
- make Filter_Tracking a slider and move it below Filter Type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684574b27fd88325a1e12c68578e091f