### PR TITLE
Update Drift envelope units and range

### DIFF
--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -20,6 +20,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     unitLabel = 'kHz';
                 }
                 return displayVal.toFixed(1) + ' ' + unitLabel;
+            } else if (unit === 's') {
+                if (displayVal < 1) {
+                    return (displayVal * 1000).toFixed(0) + ' ms';
+                }
+                return Number(displayVal).toFixed(displayDecimals) + ' s';
             }
             return Number(displayVal).toFixed(displayDecimals) + (unit ? ' ' + unitLabel : '');
         };

--- a/static/rect-slider.js
+++ b/static/rect-slider.js
@@ -32,6 +32,11 @@ function initSlider(el){
         unitLabel='kHz';
       }
       return displayVal.toFixed(1)+` ${unitLabel}`;
+    }else if(unit==='s'){
+      if(displayVal<1){
+        return (displayVal*1000).toFixed(0)+` ms`;
+      }
+      return Number(displayVal).toFixed(displayDecimals)+` s`;
     }
     return Number(displayVal).toFixed(displayDecimals)+(unit?` ${unitLabel}`:'');
   }

--- a/static/schemas/drift_schema.json
+++ b/static/schemas/drift_schema.json
@@ -28,6 +28,7 @@
     "min": 0.17,
     "max": 1700.0,
     "options": [],
+    "unit": "Hz",
     "decimals": 1
   },
   "CyclingEnvelope_Ratio": {
@@ -45,32 +46,34 @@
   "CyclingEnvelope_Time": {
     "type": "number",
     "min": 0.1,
-    "max": 1.147904,
-    "options": []
+    "max": 60.0,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope1_Attack": {
     "type": "number",
     "min": 0.0,
-    "max": 2.0,
+    "max": 60.0,
     "options": [],
-    "unit": "ms",
-    "decimals": 2
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope1_Decay": {
     "type": "number",
-    "min": 0.0,
-    "max": 45.086365,
+    "min": 0.005,
+    "max": 60.0,
     "options": [],
-    "unit": "ms",
-    "decimals": 0
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope1_Release": {
     "type": "number",
-    "min": 0.0,
-    "max": 4.201648,
+    "min": 0.01,
+    "max": 60.0,
     "options": [],
-    "unit": "ms",
-    "decimals": 2
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope1_Sustain": {
     "type": "number",
@@ -78,31 +81,31 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Envelope2_Attack": {
     "type": "number",
     "min": 0.0,
-    "max": 35.476055,
+    "max": 60.0,
     "options": [],
-    "unit": "ms",
-    "decimals": 2
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope2_Decay": {
     "type": "number",
-    "min": 0.0,
+    "min": 0.005,
     "max": 60.0,
     "options": [],
-    "unit": "ms",
-    "decimals": 0
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope2_Release": {
     "type": "number",
-    "min": 0.0,
+    "min": 0.01,
     "max": 60.0,
     "options": [],
-    "unit": "ms",
-    "decimals": 2
+    "unit": "s",
+    "decimals": 3
   },
   "Envelope2_Sustain": {
     "type": "number",
@@ -110,7 +113,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Filter_Frequency": {
     "type": "number",


### PR DESCRIPTION
## Summary
- update drift parameter schema with seconds-based ranges
- improve sustain precision
- support `s` unit display in JS controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684578082a6883258c8df77e8af7e087