### PR TITLE
Fix LFO rate units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /uploads
 /midi-env
 *server.log
+.venv/

--- a/static/schemas/drift_schema.json
+++ b/static/schemas/drift_schema.json
@@ -390,13 +390,16 @@
     "type": "number",
     "min": 0.17,
     "max": 1700.0,
-    "options": []
+    "options": [],
+    "unit": "Hz",
+    "decimals": 1
   },
   "Lfo_Ratio": {
     "type": "number",
     "min": 0.25,
     "max": 16.0,
-    "options": []
+    "options": [],
+    "decimals": 2
   },
   "Lfo_Retrigger": {
     "type": "boolean",
@@ -429,7 +432,9 @@
     "type": "number",
     "min": 0.1,
     "max": 60.0,
-    "options": []
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Mixer_NoiseLevel": {
     "type": "number",


### PR DESCRIPTION
## Summary
- set proper units and precision for Drift LFO rate parameters
- ignore local virtualenvs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_68457b983ad88325ba7f3eacea05fe21