### PR TITLE
Integrate macro editor into synth parameter page

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -9,6 +9,9 @@ from core.synth_preset_inspector_handler import (
     extract_parameter_values,
     load_drift_schema,
     extract_macro_information,
+    update_preset_macro_names,
+    update_preset_parameter_mappings,
+    delete_parameter_mapping,
 )
 from core.synth_param_editor_handler import (
     update_parameter_values,
@@ -73,6 +76,9 @@ class SynthParamEditorHandler(BaseHandler):
             'default_preset_path': DEFAULT_PRESET,
             'macro_knobs_html': '',
             'rename_checked': False,
+            'macros_json': '[]',
+            'available_params_json': '[]',
+            'param_paths_json': '{}',
         }
 
     def handle_post(self, form):
@@ -123,6 +129,41 @@ class SynthParamEditorHandler(BaseHandler):
             if not macro_result['success']:
                 return self.format_error_response(macro_result['message'])
 
+            macros_data_str = form.getvalue('macros_data')
+            if macros_data_str:
+                try:
+                    macros_data = json.loads(macros_data_str)
+                except Exception:
+                    macros_data = []
+            else:
+                macros_data = []
+
+            # Update macro names
+            name_updates = {m.get('index'): m.get('name') for m in macros_data}
+            name_result = update_preset_macro_names(preset_path, name_updates)
+            if not name_result['success']:
+                return self.format_error_response(name_result['message'])
+
+            # Determine existing mappings to remove
+            existing_info = extract_macro_information(preset_path)
+            existing_mapped = existing_info.get('mapped_parameters', {}) if existing_info['success'] else {}
+
+            processed = set()
+            for m in macros_data:
+                idx = m.get('index')
+                for p in m.get('parameters', []):
+                    pname = p.get('name')
+                    param_updates = {idx: {'parameter': pname, 'parameter_path': p.get('path')}}
+                    upd = update_preset_parameter_mappings(preset_path, param_updates)
+                    if not upd['success']:
+                        return self.format_error_response(upd['message'])
+                    processed.add(pname)
+                    existing_mapped.pop(pname, None)
+
+            # Remove mappings not present anymore
+            for pname, info in existing_mapped.items():
+                delete_parameter_mapping(preset_path, info['path'])
+
             message = result['message'] + "; " + macro_result['message']
             if output_path:
                 message += f" Saved as {os.path.basename(output_path)}"
@@ -146,10 +187,19 @@ class SynthParamEditorHandler(BaseHandler):
         macro_knobs_html = ''
         macro_info = extract_macro_information(preset_path)
         mapped_params = {}
+        macros_json = '[]'
+        available_params_json = '[]'
+        param_paths_json = '{}'
         if macro_info['success']:
             macro_knobs_html = self.generate_macro_knobs_html(macro_info['macros'])
             mapped_params = macro_info.get('mapped_parameters', {})
+            macros_json = json.dumps(macro_info['macros'])
 
+        param_info = extract_available_parameters(preset_path)
+        if param_info['success']:
+            available_params_json = json.dumps(param_info['parameters'])
+            param_paths_json = json.dumps(param_info.get('parameter_paths', {}))
+        
         if values['success']:
             params_html = self.generate_params_html(values['parameters'], mapped_params)
             param_count = len(values['parameters'])
@@ -178,6 +228,9 @@ class SynthParamEditorHandler(BaseHandler):
             'default_preset_path': DEFAULT_PRESET,
             'macro_knobs_html': macro_knobs_html,
             'rename_checked': rename_flag if action == 'save_params' else False,
+            'macros_json': macros_json,
+            'available_params_json': available_params_json,
+            'param_paths_json': param_paths_json,
         }
 
     SECTION_ORDER = [
@@ -865,13 +918,13 @@ class SynthParamEditorHandler(BaseHandler):
                 classes.append(f"macro-{i}")
             cls_str = " ".join(classes)
             html.append(
-                f'<div class="{cls_str}">' 
-                f'<span class="macro-label">{name}</span>'
+                f'<div class="{cls_str}" data-index="{i}">'
+                f'<span class="macro-label" data-index="{i}">{name}</span>'
                 f'<input id="macro_{i}_dial" type="range" class="macro-dial input-knob" '
                 f'data-target="macro_{i}_value" data-display="macro_{i}_disp" '
                 f'value="{display_val}" min="0" max="127" step="0.1" data-decimals="1">'
                 f'<span id="macro_{i}_disp" class="macro-number"></span>'
-                f'<input type="hidden" name="macro_{i}_value" value="{display_val}">' 
+                f'<input type="hidden" name="macro_{i}_value" value="{display_val}">'
                 f'</div>'
             )
         html.append('</div>')

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -12,6 +12,7 @@ from core.synth_preset_inspector_handler import (
     update_preset_macro_names,
     update_preset_parameter_mappings,
     delete_parameter_mapping,
+    extract_available_parameters,
 )
 from core.synth_param_editor_handler import (
     update_parameter_values,

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -456,6 +456,9 @@ def synth_params():
     default_preset_path = result.get("default_preset_path")
     macro_knobs_html = result.get("macro_knobs_html", "")
     rename_checked = result.get("rename_checked", False)
+    macros_json = result.get("macros_json", "[]")
+    available_params_json = result.get("available_params_json", "[]")
+    param_paths_json = result.get("param_paths_json", "{}")
     preset_selected = bool(selected_preset)
     return render_template(
         "synth_params.html",
@@ -472,6 +475,9 @@ def synth_params():
         default_preset_path=default_preset_path,
         macro_knobs_html=macro_knobs_html,
         rename_checked=rename_checked,
+        macros_json=macros_json,
+        available_params_json=available_params_json,
+        param_paths_json=param_paths_json,
         active_tab="synth-params",
     )
 

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -1,0 +1,98 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const macrosInput = document.getElementById('macros-data-input');
+  if (!macrosInput) return;
+  const paramPaths = JSON.parse(document.getElementById('param-paths-input').value || '{}');
+  const availableParams = JSON.parse(document.getElementById('available-params-input').value || '[]');
+  let macros = [];
+  try { macros = JSON.parse(macrosInput.value || '[]'); } catch (e) {}
+
+  const overlay = document.getElementById('sidebar-overlay');
+  const sidebar = document.getElementById('macro-sidebar');
+  const titleEl = document.getElementById('macro-sidebar-title');
+  const nameInput = document.getElementById('macro-name-input');
+  const listDiv = document.querySelector('.macro-params-list');
+  const closeBtn = document.getElementById('macro-sidebar-close');
+
+  let currentIndex = null;
+
+  function saveState() {
+    macrosInput.value = JSON.stringify(macros);
+  }
+
+  function updateHighlights() {
+    document.querySelectorAll('.param-item').forEach(item => {
+      const name = item.dataset.name;
+      item.classList.remove(...Array.from({length:8},(_,i)=>'macro-'+i));
+      for (const m of macros) {
+        if (m.parameters.some(p => p.name === name)) {
+          item.classList.add('macro-'+m.index);
+        }
+      }
+    });
+    document.querySelectorAll('.macro-knob').forEach(knob => {
+      const idx = parseInt(knob.dataset.index,10);
+      knob.classList.toggle('macro-'+idx, (macros.find(m=>m.index===idx)?.parameters.length||0)>0);
+    });
+  }
+
+  function openSidebar(idx) {
+    currentIndex = idx;
+    const macro = macros.find(m=>m.index===idx) || {index: idx, name: `Macro ${idx}`, parameters: []};
+    if (!macros.find(m=>m.index===idx)) macros.push(macro);
+    titleEl.textContent = `Macro ${idx}`;
+    nameInput.value = macro.name.startsWith('Macro ') ? '' : macro.name;
+    listDiv.innerHTML = '';
+    availableParams.forEach(p => {
+      const div = document.createElement('div');
+      div.className = 'map-item';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = macro.parameters.some(mp=>mp.name===p);
+      cb.addEventListener('change', () => {
+        if (cb.checked) {
+          if (!macro.parameters.some(mp=>mp.name===p)) {
+            macro.parameters.push({name:p, path:paramPaths[p]});
+          }
+        } else {
+          macro.parameters = macro.parameters.filter(mp=>mp.name!==p);
+        }
+        updateHighlights();
+        saveState();
+      });
+      const label = document.createElement('label');
+      label.textContent = p;
+      div.appendChild(cb);
+      div.appendChild(label);
+      listDiv.appendChild(div);
+    });
+    overlay.classList.remove('hidden');
+    sidebar.classList.remove('hidden');
+  }
+
+  function closeSidebar() {
+    if (currentIndex !== null) {
+      const macro = macros.find(m=>m.index===currentIndex);
+      if (macro) {
+        const name = nameInput.value.trim();
+        macro.name = name || `Macro ${currentIndex}`;
+      }
+      saveState();
+      updateHighlights();
+    }
+    overlay.classList.add('hidden');
+    sidebar.classList.add('hidden');
+    currentIndex = null;
+  }
+
+  closeBtn.addEventListener('click', closeSidebar);
+  overlay.addEventListener('click', closeSidebar);
+
+  document.querySelectorAll('.macro-label').forEach(lbl => {
+    lbl.addEventListener('click', () => {
+      const idx = parseInt(lbl.dataset.index, 10);
+      openSidebar(idx);
+    });
+  });
+
+  updateHighlights();
+});

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -15,6 +15,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const addBtn = document.getElementById('macro-add-param');
   const closeBtn = document.getElementById('macro-sidebar-close');
 
+  function updateAddBtn() {
+    addBtn.disabled = !selectEl.value;
+  }
+
   nameInput.addEventListener('input', () => {
     if (currentIndex !== null) {
       const macro = macros.find(m => m.index === currentIndex);
@@ -36,6 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function saveState() {
     macrosInput.value = JSON.stringify(macros);
+    macrosInput.dispatchEvent(new Event('change'));
   }
 
   function updateKnobLabels() {
@@ -84,6 +89,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     selectEl.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Choose a parameter...';
+    selectEl.appendChild(placeholder);
     const taken = allAssigned();
     availableParams.forEach(p => {
       if (!taken.includes(p)) {
@@ -93,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
         selectEl.appendChild(opt);
       }
     });
+    updateAddBtn();
   }
 
   function openSidebar(idx) {
@@ -105,6 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
     titleEl.textContent = `Macro ${idx}`;
     nameInput.value = macro.name.startsWith('Macro ') ? '' : macro.name;
     rebuildLists(macro);
+    updateAddBtn();
     overlay.classList.remove('hidden');
     sidebar.classList.remove('hidden');
     nameInput.focus();
@@ -128,6 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   closeBtn.addEventListener('click', closeSidebar);
   overlay.addEventListener('click', closeSidebar);
+  selectEl.addEventListener('change', updateAddBtn);
   addBtn.addEventListener('click', () => {
     if (currentIndex === null) return;
     const macro = macros.find(m => m.index === currentIndex);
@@ -137,6 +149,7 @@ document.addEventListener('DOMContentLoaded', () => {
       rebuildLists(macro);
       updateHighlights();
       saveState();
+      updateAddBtn();
     }
   });
 
@@ -148,4 +161,5 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   updateHighlights();
+  updateAddBtn();
 });

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -15,6 +15,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const addBtn = document.getElementById('macro-add-param');
   const closeBtn = document.getElementById('macro-sidebar-close');
 
+  nameInput.addEventListener('input', () => {
+    if (currentIndex !== null) {
+      const macro = macros.find(m => m.index === currentIndex);
+      if (macro) {
+        macro.name = nameInput.value.trim() || `Macro ${currentIndex}`;
+        const label = document.querySelector(`.macro-label[data-index="${currentIndex}"]`);
+        if (label) label.textContent = macro.name;
+      }
+    }
+  });
+
   function allAssigned() {
     const arr = [];
     macros.forEach(m => m.parameters.forEach(p => arr.push(p.name)));
@@ -25,6 +36,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function saveState() {
     macrosInput.value = JSON.stringify(macros);
+  }
+
+  function updateKnobLabels() {
+    macros.forEach(m => {
+      const label = document.querySelector(`.macro-label[data-index="${m.index}"]`);
+      if (label) label.textContent = m.name;
+    });
   }
 
   function updateHighlights() {
@@ -41,6 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const idx = parseInt(knob.dataset.index,10);
       knob.classList.toggle('macro-'+idx, (macros.find(m=>m.index===idx)?.parameters.length||0)>0);
     });
+    updateKnobLabels();
   }
 
   function rebuildLists(macro) {
@@ -88,6 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
     rebuildLists(macro);
     overlay.classList.remove('hidden');
     sidebar.classList.remove('hidden');
+    nameInput.focus();
   }
 
   function closeSidebar() {
@@ -99,6 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       saveState();
       updateHighlights();
+      updateKnobLabels();
     }
     overlay.classList.add('hidden');
     sidebar.classList.add('hidden');

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -15,6 +15,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const addBtn = document.getElementById('macro-add-param');
   const closeBtn = document.getElementById('macro-sidebar-close');
 
+  function allAssigned() {
+    const arr = [];
+    macros.forEach(m => m.parameters.forEach(p => arr.push(p.name)));
+    return arr;
+  }
+
   let currentIndex = null;
 
   function saveState() {
@@ -59,8 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     selectEl.innerHTML = '';
+    const taken = allAssigned();
     availableParams.forEach(p => {
-      if (!macro.parameters.some(mp => mp.name === p)) {
+      if (!taken.includes(p)) {
         const opt = document.createElement('option');
         opt.value = p;
         opt.textContent = p;
@@ -112,10 +119,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  document.querySelectorAll('.macro-label').forEach(lbl => {
-    lbl.addEventListener('click', () => {
-      const idx = parseInt(lbl.dataset.index, 10);
-      openSidebar(idx);
+  document.querySelectorAll('.macro-label, .macro-knob').forEach(el => {
+    el.addEventListener('click', () => {
+      const idx = parseInt(el.dataset.index, 10);
+      if (!isNaN(idx)) openSidebar(idx);
     });
   });
 

--- a/static/style.css
+++ b/static/style.css
@@ -684,11 +684,13 @@ select {
     display: flex;
     flex-direction: column;
     align-items: center;
+    cursor: pointer;
 }
 
 .macro-label {
     font-size: 0.8rem;
     margin-bottom: 0.25rem;
+    cursor: pointer;
 }
 
 .macro-number {

--- a/static/style.css
+++ b/static/style.css
@@ -817,12 +817,18 @@ select {
 .sidebar-overlay.hidden, .macro-sidebar.hidden {
     display: none;
 }
-.macro-params-list {
+.macro-assigned-list {
     margin-top: 1rem;
 }
-.map-item {
+.assign-item {
     display: flex;
+    justify-content: space-between;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.25rem;
+}
+.macro-add-section {
+    margin-top: 0.5rem;
+    display: flex;
+    gap: 0.25rem;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -791,3 +791,38 @@ select {
     position: relative;
     z-index: 1;
 }
+
+/* Macro sidebar */
+.macro-sidebar {
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: 300px;
+    height: 100%;
+    background: #fff;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.3);
+    padding: 1rem;
+    overflow-y: auto;
+    z-index: 1001;
+}
+.sidebar-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    z-index: 1000;
+}
+.sidebar-overlay.hidden, .macro-sidebar.hidden {
+    display: none;
+}
+.macro-params-list {
+    margin-top: 1rem;
+}
+.map-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -33,7 +33,7 @@
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>
     <div class="preset-actions">
-        <button type="submit">Save Parameters</button>
+        <button type="submit" id="save-params-btn" disabled>Save Parameters</button>
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     </div>
     {{ macro_knobs_html | safe }}
@@ -71,9 +71,18 @@
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');
   const nameInput = document.getElementById('new-preset-name');
+  const saveBtn = document.getElementById('save-params-btn');
+  const macrosInput = document.getElementById('macros-data-input');
+  let changed = false;
+
   if (cb && nameInput) {
     cb.addEventListener('change', () => {
       nameInput.disabled = !cb.checked;
+      if (cb.checked) {
+        saveBtn.disabled = false;
+      } else if (!changed) {
+        saveBtn.disabled = true;
+      }
     });
     const form = document.getElementById('param-form');
     const orig = nameInput.dataset.originalName;
@@ -91,6 +100,22 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
     }
+  }
+
+  function markChanged() {
+    changed = true;
+    saveBtn.disabled = false;
+  }
+
+  document.querySelectorAll('.param-list input[type="hidden"]').forEach(el => {
+    el.addEventListener('change', markChanged);
+  });
+  if (macrosInput) {
+    macrosInput.addEventListener('change', markChanged);
+  }
+
+  if (!cb.checked) {
+    saveBtn.disabled = true;
   }
 
 });

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -37,9 +37,16 @@
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     </div>
     {{ macro_knobs_html | safe }}
-    <div class="edit-macros-link">
-        <a href="{{ host_prefix }}/synth-macros?preset={{ selected_preset | urlencode }}">Edit Macros</a>
+    <input type="hidden" name="macros_data" id="macros-data-input" value='{{ macros_json|safe }}'>
+    <input type="hidden" id="available-params-input" value='{{ available_params_json|safe }}'>
+    <input type="hidden" id="param-paths-input" value='{{ param_paths_json|safe }}'>
+    <div id="macro-sidebar" class="macro-sidebar hidden">
+        <h3 id="macro-sidebar-title"></h3>
+        <label>Custom Name: <input type="text" id="macro-name-input"></label>
+        <div class="macro-params-list"></div>
+        <button type="button" id="macro-sidebar-close">Close</button>
     </div>
+    <div id="sidebar-overlay" class="sidebar-overlay hidden"></div>
     <div class="param-list">
         {{ params_html | safe }}
     </div>
@@ -55,6 +62,7 @@
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>
 <script src="{{ host_prefix }}/static/rect-slider.js"></script>
+<script src="{{ host_prefix }}/static/macro_sidebar.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -37,9 +37,9 @@
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     </div>
     {{ macro_knobs_html | safe }}
-    <input type="hidden" name="macros_data" id="macros-data-input" value='{{ macros_json|safe }}'>
-    <input type="hidden" id="available-params-input" value='{{ available_params_json|safe }}'>
-    <input type="hidden" id="param-paths-input" value='{{ param_paths_json|safe }}'>
+    <input type="hidden" name="macros_data" id="macros-data-input" value='{{ macros_json }}'>
+    <input type="hidden" id="available-params-input" value='{{ available_params_json }}'>
+    <input type="hidden" id="param-paths-input" value='{{ param_paths_json }}'>
     <div id="macro-sidebar" class="macro-sidebar hidden">
         <h3 id="macro-sidebar-title"></h3>
         <label>Custom Name: <input type="text" id="macro-name-input"></label>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -43,7 +43,11 @@
     <div id="macro-sidebar" class="macro-sidebar hidden">
         <h3 id="macro-sidebar-title"></h3>
         <label>Custom Name: <input type="text" id="macro-name-input"></label>
-        <div class="macro-params-list"></div>
+        <div class="macro-assigned-list"></div>
+        <div class="macro-add-section">
+            <select id="macro-param-select"></select>
+            <button type="button" id="macro-add-param">Add</button>
+        </div>
         <button type="button" id="macro-sidebar-close">Close</button>
     </div>
     <div id="sidebar-overlay" class="sidebar-overlay hidden"></div>


### PR DESCRIPTION
## Summary
- add macro sidebar inputs and script
- support macro data when saving params
- style sidebar in CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684585260c408325bd7f6fe48ba923cb