### PR TITLE
Scale Drift oscillator gain display in dB

### DIFF
--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -29,6 +29,18 @@ document.addEventListener('DOMContentLoaded', () => {
                     return (displayVal * 1000).toFixed(0) + ' ms';
                 }
                 return Number(displayVal).toFixed(getDisplayDecimals(v)) + ' s';
+            } else if (
+                unit === 'dB' &&
+                !isNaN(min) &&
+                !isNaN(max) &&
+                min === 0 &&
+                max === 2
+            ) {
+                if (v <= 0) return '-inf dB';
+                if (v <= 1) {
+                    return (v * 64 - 64).toFixed(1) + ' dB';
+                }
+                return ((v - 1) * 6).toFixed(1) + ' dB';
             }
             return Number(displayVal).toFixed(getDisplayDecimals(v)) + (unit ? ' ' + unitLabel : '');
         };


### PR DESCRIPTION
## Summary
- adjust param knob formatting for Drift oscillator gain
- show oscillator gain dB values and handle zero as -inf

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684594687b588325860adcd0b3635e40