### PR TITLE
Improve macro range display

### DIFF
--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -357,7 +357,12 @@ class SynthPresetInspectorHandler(BaseHandler):
                         opts = ", ".join(map(str, info["options"]))
                         param_info += f' [Options: {opts}]'
                     elif "rangeMin" in param and "rangeMax" in param:
-                        param_info += f' (Range: {param["rangeMin"]} - {param["rangeMax"]})'
+                        try:
+                            rmin = float(param["rangeMin"])
+                            rmax = float(param["rangeMax"])
+                            param_info += f' (Range: {rmin:.2f} - {rmax:.2f})'
+                        except (ValueError, TypeError):
+                            param_info += f' (Range: {param["rangeMin"]} - {param["rangeMax"]})'
                     
                     # Add delete button with onclick handler to set action and parameter info
                     html += f'<li class="parameter-item">'

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -264,8 +264,8 @@ const driftSchema = {{ schema_json|safe }};
     } else {
       minInput.disabled = false;
       maxInput.disabled = false;
-      minInput.placeholder = info.min !== null ? info.min : '';
-      maxInput.placeholder = info.max !== null ? info.max : '';
+      minInput.placeholder = info.min !== null ? info.min.toFixed(2) : '';
+      maxInput.placeholder = info.max !== null ? info.max.toFixed(2) : '';
       if (minWrap) minWrap.style.display = 'inline-block';
       if (maxWrap) maxWrap.style.display = 'inline-block';
     }


### PR DESCRIPTION
## Summary
- round placeholder min/max values in macro editor
- show mapped range values rounded to 2 decimals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684597b025788325afaaa76b3c0be947