### PR TITLE
Allow naming new Drift preset

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -2,6 +2,7 @@
 import os
 import json
 import logging
+import shutil
 
 from handlers.base_handler import BaseHandler
 from core.file_browser import generate_dir_html
@@ -30,6 +31,12 @@ if not os.path.exists(DEFAULT_PRESET):
         "Drift",
         "Analog Shape - Core.json",
     )
+
+# Directory where new presets are saved
+NEW_PRESET_DIR = os.path.join(
+    "/data/UserData/UserLibrary/Track Presets",
+    "Drift",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,15 +87,28 @@ class SynthParamEditorHandler(BaseHandler):
         if action == 'reset_preset':
             return self.handle_get()
 
+        message = ''
         if action == 'new_preset':
-            preset_path = DEFAULT_PRESET
+            new_name = form.getvalue('new_preset_name')
+            if not new_name:
+                return self.format_error_response("Preset name required")
+            os.makedirs(NEW_PRESET_DIR, exist_ok=True)
+            if not new_name.endswith('.ablpreset') and not new_name.endswith('.json'):
+                new_name += '.ablpreset'
+            preset_path = os.path.join(NEW_PRESET_DIR, new_name)
+            if os.path.exists(preset_path):
+                return self.format_error_response("Preset already exists")
+            try:
+                shutil.copy(DEFAULT_PRESET, preset_path)
+            except Exception as exc:
+                return self.format_error_response(f"Could not create preset: {exc}")
+            message = f"Created new preset {os.path.basename(preset_path)}"
         else:
             preset_path = form.getvalue('preset_select')
 
         if not preset_path:
             return self.format_error_response("No preset selected")
 
-        message = ''
         rename_flag = False
         if action == 'save_params':
             try:
@@ -132,9 +152,7 @@ class SynthParamEditorHandler(BaseHandler):
             else:
                 message += f" Library refresh failed: {refresh_message}"
         elif action in ['select_preset', 'new_preset']:
-            if action == 'new_preset':
-                message = "Loaded default preset"
-            else:
+            if action == 'select_preset':
                 message = f"Selected preset: {os.path.basename(preset_path)}"
         else:
             return self.format_error_response("Unknown action")

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -1,0 +1,14 @@
+function initNewPresetModal() {
+  const modal = document.getElementById('newPresetModal');
+  const openBtn = document.getElementById('create-new-btn');
+  if (!modal || !openBtn) return;
+  const closeBtn = modal.querySelector('.modal-close');
+  openBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    modal.classList.remove('hidden');
+  });
+  if (closeBtn) closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
+  window.addEventListener('click', (e) => { if (e.target === modal) modal.classList.add('hidden'); });
+}
+
+document.addEventListener('DOMContentLoaded', initNewPresetModal);

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -6,11 +6,43 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 {% if not preset_selected %}
-<form method="post" action="{{ host_prefix }}/synth-params" style="margin-bottom:1em;">
-    <input type="hidden" name="action" value="new_preset">
-    <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
-    <button type="submit">Create New Drift Preset</button>
-</form>
+<button id="create-new-btn" style="margin-bottom:1em;">Create New Drift Preset</button>
+<style>
+  .modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  .modal.hidden { display: none; }
+  .modal-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    position: relative;
+    z-index: 1001;
+  }
+  .modal-close { position: absolute; top: 10px; right: 10px; cursor: pointer; }
+</style>
+<div id="newPresetModal" class="modal hidden">
+  <div class="modal-content">
+    <span class="modal-close">&times;</span>
+    <form method="post" action="{{ host_prefix }}/synth-params" id="newPresetForm">
+      <input type="hidden" name="action" value="new_preset">
+      <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
+      <label>Preset Name:
+        <input type="text" name="new_preset_name" required>
+      </label>
+      <button type="submit">Create</button>
+    </form>
+  </div>
+</div>
 <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/synth-params" data-field="preset_select" data-value="select_preset" data-filter="drift">
     {{ file_browser_html | safe }}
 </div>
@@ -53,6 +85,7 @@
 <script>
   window.inputKnobsOptions = { knobDiameter: 32 };
 </script>
+<script type="module" src="{{ host_prefix }}/static/synth_params.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>
 <script src="{{ host_prefix }}/static/rect-slider.js"></script>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -127,6 +127,8 @@ def test_synth_params_get(client, monkeypatch):
     assert b'pick' in resp.data
     assert b'Editing:' not in resp.data
     assert b'Create New Drift Preset' in resp.data
+    assert b'name="new_preset_name"' in resp.data
+    assert b'id="newPresetModal"' in resp.data
 
 def test_synth_params_post(client, monkeypatch):
     def fake_post(form):
@@ -183,7 +185,7 @@ def test_synth_params_new_preset(client, monkeypatch):
             'default_preset_path': DEFAULT_PRESET,
         }
     monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
-    resp = client.post('/synth-params', data={'action': 'new_preset'})
+    resp = client.post('/synth-params', data={'action': 'new_preset', 'new_preset_name': 'Test'})
     assert resp.status_code == 200
     assert b'loaded' in resp.data
     assert b'Editing:' in resp.data


### PR DESCRIPTION
## Summary
- prompt for name in modal when creating a Drift preset
- save new preset to UserLibrary/Track Presets
- add front-end script for modal behavior
- update route test for modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684595c124a083259839266a6db87c3c