### PR TITLE
Disable macro-controlled parameter interaction

### DIFF
--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -46,15 +46,32 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateHighlights() {
+    const mapped = {};
+    macros.forEach(m => m.parameters.forEach(p => { mapped[p.name] = m.index; }));
+
     document.querySelectorAll('.param-item').forEach(item => {
       const name = item.dataset.name;
-      item.classList.remove(...Array.from({length:8},(_,i)=>'macro-'+i));
-      for (const m of macros) {
-        if (m.parameters.some(p => p.name === name)) {
-          item.classList.add('macro-'+m.index);
-        }
+      const idx = mapped[name];
+      item.classList.remove('param-mapped', ...Array.from({length:8},(_,i)=>'macro-'+i));
+      const isMapped = idx !== undefined;
+      if (isMapped) {
+        item.classList.add('param-mapped');
+        item.classList.add('macro-' + idx);
       }
+      item.querySelectorAll('input:not([type=hidden]):not(.macro-dial), select').forEach(inp => {
+        inp.disabled = isMapped;
+      });
+      item.querySelectorAll('.rect-slider').forEach(sl => {
+        if (isMapped) {
+          sl.classList.add('disabled');
+          sl.dataset.disabled = 'true';
+        } else {
+          sl.classList.remove('disabled');
+          delete sl.dataset.disabled;
+        }
+      });
     });
+
     document.querySelectorAll('.macro-knob').forEach(knob => {
       const idx = parseInt(knob.dataset.index,10);
       knob.classList.toggle('macro-'+idx, (macros.find(m=>m.index===idx)?.parameters.length||0)>0);

--- a/static/rect-slider.js
+++ b/static/rect-slider.js
@@ -68,6 +68,7 @@ function initSlider(el){
     }
   }
   function start(ev){
+    if(el.classList.contains('disabled') || el.dataset.disabled==='true') return;
     ev.preventDefault();
     const startY=ev.touches?ev.touches[0].clientY:ev.clientY;
     const startVal=value;

--- a/static/style.css
+++ b/static/style.css
@@ -761,6 +761,11 @@ select {
     border-radius: 4px;
 }
 
+/* Parameters controlled by macros */
+.param-item.param-mapped {
+    opacity: 0.6;
+}
+
 
 /* Rectangular slider component */
 .rect-slider-container {
@@ -775,6 +780,10 @@ select {
     font-size: 0.8rem;
     text-align: center;
     line-height: 24px;
+}
+.rect-slider-container.disabled {
+    pointer-events: none;
+    opacity: 0.6;
 }
 .rect-slider-fill {
     position: absolute;


### PR DESCRIPTION
## Summary
- disable param UI when parameter is mapped to a macro
- prevent rectangular slider interaction when disabled
- style mapped parameters as disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459de81a04832590f83aaa650c189d