### PR TITLE
Add macro range editing to parameter editor

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -174,7 +174,14 @@ class SynthParamEditorHandler(BaseHandler):
                 idx = m.get('index')
                 for p in m.get('parameters', []):
                     pname = p.get('name')
-                    param_updates = {idx: {'parameter': pname, 'parameter_path': p.get('path')}}
+                    param_updates = {
+                        idx: {
+                            'parameter': pname,
+                            'parameter_path': p.get('path'),
+                            'rangeMin': p.get('rangeMin'),
+                            'rangeMax': p.get('rangeMax'),
+                        }
+                    }
                     upd = update_preset_parameter_mappings(preset_path, param_updates)
                     if not upd['success']:
                         return self.format_error_response(upd['message'])

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -69,6 +69,37 @@ document.addEventListener('DOMContentLoaded', () => {
       div.className = 'assign-item';
       const span = document.createElement('span');
       span.textContent = p.name;
+      const rangeDiv = document.createElement('div');
+      rangeDiv.className = 'range-inputs';
+      const minInput = document.createElement('input');
+      minInput.type = 'number';
+      minInput.step = '0.01';
+      minInput.placeholder = 'min';
+      if (p.rangeMin !== undefined) {
+        const n = parseFloat(p.rangeMin);
+        if (!isNaN(n)) minInput.value = n.toFixed(2);
+      }
+      minInput.addEventListener('change', () => {
+        p.rangeMin = minInput.value === '' ? undefined : parseFloat(minInput.value);
+        saveState();
+      });
+      const dash = document.createElement('span');
+      dash.textContent = '-';
+      const maxInput = document.createElement('input');
+      maxInput.type = 'number';
+      maxInput.step = '0.01';
+      maxInput.placeholder = 'max';
+      if (p.rangeMax !== undefined) {
+        const n = parseFloat(p.rangeMax);
+        if (!isNaN(n)) maxInput.value = n.toFixed(2);
+      }
+      maxInput.addEventListener('change', () => {
+        p.rangeMax = maxInput.value === '' ? undefined : parseFloat(maxInput.value);
+        saveState();
+      });
+      rangeDiv.appendChild(minInput);
+      rangeDiv.appendChild(dash);
+      rangeDiv.appendChild(maxInput);
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.textContent = 'Remove';
@@ -79,6 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
         saveState();
       });
       div.appendChild(span);
+      div.appendChild(rangeDiv);
       div.appendChild(btn);
       assignedDiv.appendChild(div);
     });
@@ -133,7 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const macro = macros.find(m => m.index === currentIndex);
     const val = selectEl.value;
     if (val && !macro.parameters.some(p => p.name === val)) {
-      macro.parameters.push({ name: val, path: paramPaths[val] });
+      macro.parameters.push({ name: val, path: paramPaths[val], rangeMin: undefined, rangeMax: undefined });
       rebuildLists(macro);
       updateHighlights();
       saveState();

--- a/static/style.css
+++ b/static/style.css
@@ -829,6 +829,14 @@ select {
     gap: 0.5rem;
     margin-bottom: 0.25rem;
 }
+.range-inputs {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+.range-inputs input[type="number"] {
+    width: 60px;
+}
 .macro-add-section {
     margin-top: 0.5rem;
     display: flex;


### PR DESCRIPTION
## Summary
- show min/max range editors in macro sidebar
- persist range values when assigning parameters
- include rangeMin/rangeMax when saving mappings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459e23a0a88325af9ba3dcf5d49fcc