### PR TITLE
Fix macro knob click behavior

### DIFF
--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -153,9 +153,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  document.querySelectorAll('.macro-label, .macro-knob').forEach(el => {
-    el.addEventListener('click', () => {
-      const idx = parseInt(el.dataset.index, 10);
+  // Only open the sidebar when the macro name is clicked so that
+  // the knob itself can be used without interference.
+  document.querySelectorAll('.macro-label').forEach(label => {
+    label.addEventListener('click', () => {
+      const idx = parseInt(label.dataset.index, 10);
       if (!isNaN(idx)) openSidebar(idx);
     });
   });


### PR DESCRIPTION
## Summary
- only open macro edit sidebar when the macro label is clicked so knob interaction isn't blocked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459ef5a5188325ab279a22bf9eaf94