### PR TITLE
Show relative preset paths

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -59,9 +59,6 @@ MACRO_HIGHLIGHT_COLORS = {
 
 class SynthParamEditorHandler(BaseHandler):
     def handle_get(self):
-        base_dir = "/data/UserData/UserLibrary/Track Presets"
-        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
-            base_dir = "examples/Track Presets"
         browser_html = generate_dir_html(
             base_dir,
             "",
@@ -94,6 +91,10 @@ class SynthParamEditorHandler(BaseHandler):
         action = form.getvalue('action')
         if action == 'reset_preset':
             return self.handle_get()
+
+        base_dir = "/data/UserData/UserLibrary/Track Presets"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
+            base_dir = "examples/Track Presets"
 
         message = ''
         if action == 'new_preset':
@@ -225,9 +226,6 @@ class SynthParamEditorHandler(BaseHandler):
             params_html = self.generate_params_html(values['parameters'], mapped_params)
             param_count = len(values['parameters'])
 
-        base_dir = "/data/UserData/UserLibrary/Track Presets"
-        if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
-            base_dir = "examples/Track Presets"
         browser_html = generate_dir_html(
             base_dir,
             "",

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -77,6 +77,7 @@ class SynthParamEditorHandler(BaseHandler):
             'file_browser_html': browser_html,
             'params_html': '',
             'selected_preset': None,
+            'selected_preset_rel': None,
             'param_count': 0,
             'browser_root': base_dir,
             'browser_filter': 'drift',
@@ -195,7 +196,8 @@ class SynthParamEditorHandler(BaseHandler):
                 message += f" Library refresh failed: {refresh_message}"
         elif action in ['select_preset', 'new_preset']:
             if action == 'select_preset':
-                message = f"Selected preset: {os.path.basename(preset_path)}"
+                rel = os.path.relpath(preset_path, base_dir)
+                message = f"Selected preset: {rel}"
         else:
             return self.format_error_response("Unknown action")
 
@@ -234,12 +236,14 @@ class SynthParamEditorHandler(BaseHandler):
             'select_preset',
             filter_key='drift',
         )
+        rel_preset = os.path.relpath(preset_path, base_dir)
         return {
             'message': message,
             'message_type': 'success',
             'file_browser_html': browser_html,
             'params_html': params_html,
             'selected_preset': preset_path,
+            'selected_preset_rel': rel_preset,
             'param_count': param_count,
             'browser_root': base_dir,
             'browser_filter': 'drift',

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -51,7 +51,7 @@
     <input type="hidden" name="action" id="action-input" value="save_params">
     <input type="hidden" name="preset_select" value="{{ selected_preset }}">
     <input type="hidden" name="param_count" value="{{ param_count }}">
-    <p class="current-preset">Editing: {{ selected_preset.split('/')[-1] }}</p>
+    <p class="current-preset">Editing: {{ selected_preset_rel }}</p>
     {% set _basename = selected_preset.split('/')[-1] %}
     {% if _basename.endswith('.json') or _basename.endswith('.ablpreset') %}
         {% set _prefill = _basename.rsplit('.', 1)[0] %}


### PR DESCRIPTION
## Summary
- show relative preset path when selecting a preset
- expose `selected_preset_rel` to synth parameter page
- display `selected_preset_rel` in template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a1059ab08325b34e3ead6f13823a