### PR TITLE
Fix hand cursor on macro knobs

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -691,7 +691,7 @@ select {
     display: flex;
     flex-direction: column;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
 }
 
 .macro-label {


### PR DESCRIPTION
## Summary
- fix UI so the macro knob's cursor is the default arrow instead of a pointer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a499853883259dbe114fd6cdaff7