### PR TITLE
Show preset path in Drift editors

### DIFF
--- a/templates_jinja/drum_rack_inspector.html
+++ b/templates_jinja/drum_rack_inspector.html
@@ -14,7 +14,13 @@
     <input type="hidden" name="action" value="reset_preset">
     <button type="submit">Choose Another Preset</button>
   </form>
-  <p class="current-preset">Currently loaded preset: {{ selected_preset.split('/')[-1] }}</p>
+  {% set _display = selected_preset %}
+  {% if selected_preset.startswith('/data/UserData/UserLibrary/Track Presets') %}
+      {% set _display = '/' + selected_preset.split('/data/UserData/UserLibrary/Track Presets', 1)[1] %}
+  {% elif selected_preset.startswith('examples/Track Presets') %}
+      {% set _display = '/' + selected_preset.split('examples/Track Presets', 1)[1] %}
+  {% endif %}
+  <p class="current-preset">Currently loaded preset: {{ _display }}</p>
   <div class="samples-container">
     {{ samples_html | safe }}
   </div>

--- a/templates_jinja/synth_macros.html
+++ b/templates_jinja/synth_macros.html
@@ -23,7 +23,13 @@
     <input type="hidden" name="macro_index" id="macro-index-input" value="">
     <button type="submit">Choose Another Preset</button>
     <input type="hidden" name="preset_select" value="{{ selected_preset }}">
-    <p class="current-preset">Currently loaded preset: {{ selected_preset.split('/')[-1] }}</p>
+    {% set _display = selected_preset %}
+    {% if selected_preset.startswith('/data/UserData/UserLibrary/Track Presets') %}
+        {% set _display = '/' + selected_preset.split('/data/UserData/UserLibrary/Track Presets', 1)[1] %}
+    {% elif selected_preset.startswith('examples/Track Presets') %}
+        {% set _display = '/' + selected_preset.split('examples/Track Presets', 1)[1] %}
+    {% endif %}
+    <p class="current-preset">Currently loaded preset: {{ _display }}</p>
     <div class="macro-display">
         {{ macros_html | safe }}
     </div>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -51,7 +51,13 @@
     <input type="hidden" name="action" id="action-input" value="save_params">
     <input type="hidden" name="preset_select" value="{{ selected_preset }}">
     <input type="hidden" name="param_count" value="{{ param_count }}">
-    <p class="current-preset">Editing: {{ selected_preset.split('/')[-1] }}</p>
+    {% set _display = selected_preset %}
+    {% if selected_preset.startswith('/data/UserData/UserLibrary/Track Presets') %}
+        {% set _display = '/' + selected_preset.split('/data/UserData/UserLibrary/Track Presets', 1)[1] %}
+    {% elif selected_preset.startswith('examples/Track Presets') %}
+        {% set _display = '/' + selected_preset.split('examples/Track Presets', 1)[1] %}
+    {% endif %}
+    <p class="current-preset">Editing: {{ _display }}</p>
     {% set _basename = selected_preset.split('/')[-1] %}
     {% if _basename.endswith('.json') or _basename.endswith('.ablpreset') %}
         {% set _prefill = _basename.rsplit('.', 1)[0] %}


### PR DESCRIPTION
## Summary
- improve drift preset editor display to show preset path instead of just the file name
- apply same display change to synth macros and drum rack inspector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a66fd6d48325b0885cd8bc272169