### PR TITLE
Use placeholder for unnamed macros

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -219,7 +219,13 @@ class SynthParamEditorHandler(BaseHandler):
         if macro_info['success']:
             macro_knobs_html = self.generate_macro_knobs_html(macro_info['macros'])
             mapped_params = macro_info.get('mapped_parameters', {})
-            macros_json = json.dumps(macro_info['macros'])
+            macros_for_json = []
+            for m in macro_info['macros']:
+                mc = dict(m)
+                if mc.get('name') == f"Macro {mc.get('index')}":
+                    mc['name'] = ""
+                macros_for_json.append(mc)
+            macros_json = json.dumps(macros_for_json)
 
         param_info = extract_available_parameters(preset_path)
         if param_info['success']:
@@ -933,7 +939,7 @@ class SynthParamEditorHandler(BaseHandler):
         for i in range(8):
             info = by_index.get(i, {"name": f"Macro {i}", "value": 0.0})
             name = info.get("name", f"Macro {i}")
-            if name == f"Macro {i}":
+            if not name or name == f"Macro {i}":
                 name = f"Knob {i + 1}"
             val = info.get("value", 0.0)
             try:

--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -280,7 +280,7 @@ class SynthPresetInspectorHandler(BaseHandler):
             html += f'<span>Knob {macro["index"] + 1}:</span> '
             default_label = f"Macro {macro['index']}"
             macro_value = macro["name"] if macro["name"] != default_label else ""
-            placeholder = " placeholder=\"Default name chosen by Move..\"" if not macro_value else ""
+            placeholder = " placeholder=\"No name specified\"" if not macro_value else ""
             html += (
                 f'<input type="text" name="macro_{macro["index"]}_name" '
                 f'value="{macro_value}"{placeholder} class="macro-name-input">'

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -5,6 +5,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const availableParams = JSON.parse(document.getElementById('available-params-input').value || '[]');
   let macros = [];
   try { macros = JSON.parse(macrosInput.value || '[]'); } catch (e) {}
+  macros.forEach(m => {
+    if (/^Macro\s\d+$/.test(m.name)) m.name = '';
+  });
+  macrosInput.value = JSON.stringify(macros);
 
   const overlay = document.getElementById('sidebar-overlay');
   const sidebar = document.getElementById('macro-sidebar');
@@ -23,9 +27,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (currentIndex !== null) {
       const macro = macros.find(m => m.index === currentIndex);
       if (macro) {
-        macro.name = nameInput.value.trim() || `Knob ${currentIndex + 1}`;
+        macro.name = nameInput.value.trim();
         const label = document.querySelector(`.macro-label[data-index="${currentIndex}"]`);
-        if (label) label.textContent = macro.name;
+        if (label) label.textContent = macro.name || `Knob ${currentIndex + 1}`;
       }
     }
   });
@@ -47,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
     macros.forEach(m => {
       const label = document.querySelector(`.macro-label[data-index="${m.index}"]`);
       if (!label) return;
-      if (/^(Macro|Knob)\s\d+$/.test(m.name)) {
+      if (!m.name || /^(Macro|Knob)\s\d+$/.test(m.name)) {
         label.textContent = `Knob ${m.index + 1}`;
       } else {
         label.textContent = m.name;
@@ -162,11 +166,11 @@ document.addEventListener('DOMContentLoaded', () => {
     currentIndex = idx;
     let macro = macros.find(m => m.index === idx);
     if (!macro) {
-      macro = { index: idx, name: `Knob ${idx + 1}`, parameters: [] };
+      macro = { index: idx, name: "", parameters: [] };
       macros.push(macro);
     }
     titleEl.textContent = `Knob ${idx + 1}`;
-    nameInput.value = /^(Macro|Knob)\s/.test(macro.name) ? '' : macro.name;
+    nameInput.value = macro.name || '';
     rebuildLists(macro);
     updateAddBtn();
     overlay.classList.remove('hidden');
@@ -179,7 +183,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const macro = macros.find(m=>m.index===currentIndex);
       if (macro) {
         const name = nameInput.value.trim();
-        macro.name = name || `Knob ${currentIndex + 1}`;
+        macro.name = name;
       }
       saveState();
       updateHighlights();

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -74,7 +74,7 @@
     <input type="hidden" id="param-paths-input" value='{{ param_paths_json }}'>
     <div id="macro-sidebar" class="macro-sidebar hidden">
         <h3 id="macro-sidebar-title"></h3>
-        <label>Custom Name: <input type="text" id="macro-name-input"></label>
+        <label>Custom Name: <input type="text" id="macro-name-input" placeholder="No name specified"></label>
         <div class="macro-assigned-list"></div>
         <div class="macro-add-section">
             <select id="macro-param-select"></select>


### PR DESCRIPTION
## Summary
- show `No name specified` placeholder for macro name fields
- keep default knob label but avoid persisting placeholder text
- remove default names when macros are passed to the client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a72636bc8325a9067b04416fbe7a