### PR TITLE
Fix knob wheel interaction when disabled

### DIFF
--- a/static/input-knobs.js
+++ b/static/input-knobs.js
@@ -289,6 +289,7 @@ input[type=checkbox].input-switch:checked,input[type=radio].input-switch:checked
       el.redraw();
     };
     ik.wheel=(ev)=>{
+      if(el.disabled) return;
       let st=ik.getStep(+el.value);
       let delta=ev.deltaY>0?-st:st;
       if(!ev.shiftKey)


### PR DESCRIPTION
## Summary
- prevent mouse wheel from changing values on disabled knobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a7fbee3c8325a5460716e472342a