### PR TITLE
Show mapped param name when macro unnamed

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -939,8 +939,14 @@ class SynthParamEditorHandler(BaseHandler):
         for i in range(8):
             info = by_index.get(i, {"name": f"Macro {i}", "value": 0.0})
             name = info.get("name", f"Macro {i}")
+            label_class = ""
             if not name or name == f"Macro {i}":
-                name = f"Knob {i + 1}"
+                params = info.get("parameters") or []
+                if len(params) == 1:
+                    name = params[0].get("name", f"Knob {i + 1}")
+                    label_class = " placeholder"
+                else:
+                    name = f"Knob {i + 1}"
             val = info.get("value", 0.0)
             try:
                 val = float(val)
@@ -953,7 +959,7 @@ class SynthParamEditorHandler(BaseHandler):
             cls_str = " ".join(classes)
             html.append(
                 f'<div class="{cls_str}" data-index="{i}">'
-                f'<span class="macro-label" data-index="{i}">{name}</span>'
+                f'<span class="macro-label{label_class}" data-index="{i}">{name}</span>'
                 f'<input id="macro_{i}_dial" type="range" class="macro-dial input-knob" '
                 f'data-target="macro_{i}_value" data-display="macro_{i}_disp" '
                 f'value="{display_val}" min="0" max="127" step="0.1" data-decimals="1">'

--- a/handlers/synth_preset_inspector_handler_class.py
+++ b/handlers/synth_preset_inspector_handler_class.py
@@ -265,11 +265,17 @@ class SynthPresetInspectorHandler(BaseHandler):
             html += f'<div class="macro-item">'
             html += '<div class="macro-top">'
             name_label = macro.get("name", f"Macro {macro['index']}")
-            if name_label == f"Macro {macro['index']}":
-                name_label = f"Knob {macro['index'] + 1}"
+            label_class = ""
+            if not name_label or name_label == f"Macro {macro['index']}":
+                params = macro.get("parameters") or []
+                if len(params) == 1:
+                    name_label = params[0].get("name", f"Knob {macro['index'] + 1}")
+                    label_class = " placeholder"
+                else:
+                    name_label = f"Knob {macro['index'] + 1}"
             html += (
                 f'<div class="macro-knob macro-{macro["index"]}">'
-                f'<span class="macro-label">{name_label}</span>'
+                f'<span class="macro-label{label_class}">{name_label}</span>'
                 f'<input type="range" class="macro-dial input-knob" '
                 f'value="{display_val}" min="0" max="127" step="0.1" data-decimals="1" disabled>'
                 f'<span class="macro-number">{display_val}</span>'

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -51,11 +51,17 @@ document.addEventListener('DOMContentLoaded', () => {
     macros.forEach(m => {
       const label = document.querySelector(`.macro-label[data-index="${m.index}"]`);
       if (!label) return;
-      if (!m.name || /^(Macro|Knob)\s\d+$/.test(m.name)) {
-        label.textContent = `Knob ${m.index + 1}`;
+      label.classList.remove('placeholder');
+      let text;
+      if (m.name && !/^(Macro|Knob)\s\d+$/.test(m.name)) {
+        text = m.name;
+      } else if ((m.parameters || []).length === 1) {
+        text = m.parameters[0].name;
+        label.classList.add('placeholder');
       } else {
-        label.textContent = m.name;
+        text = `Knob ${m.index + 1}`;
       }
+      label.textContent = text;
     });
   }
 

--- a/static/style.css
+++ b/static/style.css
@@ -699,6 +699,9 @@ select {
     margin-bottom: 0.25rem;
     cursor: pointer;
 }
+.macro-label.placeholder {
+    color: #777;
+}
 
 .macro-number {
     margin-top: 0.25rem;


### PR DESCRIPTION
## Summary
- display mapped parameter name as knob label when macro has no saved name and only one mapping
- style placeholder labels in gray
- sync label logic on macro sidebar with Python

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a9a9ce908325a614d7dc415f6615