### PR TITLE
Fix large macro dropdown

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -858,3 +858,8 @@ select {
     display: flex;
     gap: 0.25rem;
 }
+
+.macro-add-section select {
+    padding: 0.25rem 2.5rem 0.25rem 0.5rem;
+    max-width: 100%;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -855,11 +855,11 @@ select {
 }
 .macro-add-section {
     margin-top: 0.5rem;
-    display: flex;
+    /* display: flex; */
     gap: 0.25rem;
 }
 
 .macro-add-section select {
-    padding: 0.25rem 2.5rem 0.25rem 0.5rem;
+    margin-right: 25px;
     max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- shrink macro dropdown height by overriding padding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a8ce67388325badbfe68afff89d2