### PR TITLE
Improve macro parameter display names

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -3,6 +3,7 @@ import os
 import json
 import logging
 import shutil
+import re
 
 from handlers.base_handler import BaseHandler
 from core.file_browser import generate_dir_html
@@ -934,6 +935,20 @@ class SynthParamEditorHandler(BaseHandler):
         if not macros:
             macros = []
 
+        def friendly(name: str) -> str:
+            """Return a human-friendly version of a parameter name."""
+            if not name:
+                return name
+            parts = name.split("_", 1)
+            if len(parts) == 2:
+                group, param = parts
+                group = re.sub(r"([A-Za-z])([0-9])", r"\1 \2", group)
+                group = re.sub(r"([a-z])([A-Z])", r"\1 \2", group)
+                param = re.sub(r"([A-Za-z])([0-9])", r"\1 \2", param)
+                param = re.sub(r"([a-z])([A-Z])", r"\1 \2", param)
+                return f"{group}: {param}"
+            return re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
+
         by_index = {m["index"]: m for m in macros}
         html = ['<div class="macro-knob-row">']
         for i in range(8):
@@ -943,7 +958,8 @@ class SynthParamEditorHandler(BaseHandler):
             if not name or name == f"Macro {i}":
                 params = info.get("parameters") or []
                 if len(params) == 1:
-                    name = params[0].get("name", f"Knob {i + 1}")
+                    pname = params[0].get("name", f"Knob {i + 1}")
+                    name = friendly(pname)
                     label_class = " placeholder"
                 else:
                     name = f"Knob {i + 1}"

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -3,6 +3,23 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!macrosInput) return;
   const paramPaths = JSON.parse(document.getElementById('param-paths-input').value || '{}');
   const availableParams = JSON.parse(document.getElementById('available-params-input').value || '[]');
+  const paramDisplay = {};
+  function addSpaces(str) {
+    return str
+      .replace(/([A-Za-z])([0-9])/g, '$1 $2')
+      .replace(/([a-z])([A-Z])/g, '$1 $2');
+  }
+  function friendly(name) {
+    if (!name) return '';
+    const parts = name.split('_');
+    if (parts.length >= 2) {
+      const group = addSpaces(parts[0]);
+      const rest = addSpaces(parts.slice(1).join('_'));
+      return `${group}: ${rest}`;
+    }
+    return addSpaces(name);
+  }
+  availableParams.forEach(p => { paramDisplay[p] = friendly(p); });
   let macros = [];
   try { macros = JSON.parse(macrosInput.value || '[]'); } catch (e) {}
   macros.forEach(m => {
@@ -56,7 +73,8 @@ document.addEventListener('DOMContentLoaded', () => {
       if (m.name && !/^(Macro|Knob)\s\d+$/.test(m.name)) {
         text = m.name;
       } else if ((m.parameters || []).length === 1) {
-        text = m.parameters[0].name;
+        const pname = m.parameters[0].name;
+        text = paramDisplay[pname] || pname;
         label.classList.add('placeholder');
       } else {
         text = `Knob ${m.index + 1}`;
@@ -105,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const div = document.createElement('div');
       div.className = 'assign-item';
       const span = document.createElement('span');
-      span.textContent = p.name;
+      span.textContent = paramDisplay[p.name] || p.name;
       const rangeDiv = document.createElement('div');
       rangeDiv.className = 'range-inputs';
       const minInput = document.createElement('input');
@@ -160,7 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!taken.includes(p)) {
         const opt = document.createElement('option');
         opt.value = p;
-        opt.textContent = p;
+        opt.textContent = paramDisplay[p] || p;
         selectEl.appendChild(opt);
       }
     });


### PR DESCRIPTION
## Summary
- show readable parameter names in macro sidebar
- show readable parameter names for unnamed macros

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b114b4d08325b18aa8522f0a1163