### PR TITLE
Revise macro parameter UI

### DIFF
--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -129,7 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function buildSelect(current) {
     const select = document.createElement('select');
-    select.className = 'param-select';
+    select.className = 'sidebar-param-select';
     const placeholder = document.createElement('option');
     placeholder.value = '';
     placeholder.textContent = 'Choose a parameter...';

--- a/static/style.css
+++ b/static/style.css
@@ -862,6 +862,9 @@ select {
     gap: 0.25rem;
 }
 
+button#macro-add-param {
+    float:right;
+}
 .macro-add-section select {
     margin-right: 25px;
     max-width: 100%;

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -83,7 +83,6 @@
         <label>Custom Name: <input type="text" id="macro-name-input" placeholder="No name specified"></label>
         <div class="macro-assigned-list"></div>
         <div class="macro-add-section">
-            <select id="macro-param-select"></select>
             <button type="button" id="macro-add-param">Add</button>
         </div>
         <button type="button" id="macro-sidebar-close">Close</button>


### PR DESCRIPTION
## Summary
- revamp macro sidebar so each macro shows dropdown slots for assignments
- allow adding new empty parameter slots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845b9c6b2688325ab59f818744ab311