### PR TITLE
Add Core Library browsing for Drift preset editor

### DIFF
--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -97,16 +97,27 @@ def generate_dir_html(
     field_name: str,
     action_value: str,
     filter_key: Optional[str] = None,
+    *,
+    path_prefix: str = "",
 ) -> str:
-    """Return HTML listing for the directory."""
+    """Return HTML listing for the directory.
+
+    ``path_prefix`` is prepended to all ``data-path`` attributes so that
+    virtual directory roots can be implemented.
+    """
     filter_func = FILTERS.get(filter_key, lambda p: True)
     dirs, files = _list_directory(base_dir, rel_path)
-    html = f'<ul class="file-tree" data-path="{rel_path}">' \
-        if rel_path else '<ul class="file-tree root" data-path="">'
+    root_path = os.path.join(path_prefix, rel_path) if path_prefix or rel_path else ""
+    html = (
+        f'<ul class="file-tree" data-path="{root_path}">'
+        if path_prefix or rel_path
+        else '<ul class="file-tree root" data-path="">'
+    )
     for d in dirs:
         sub_rel = os.path.join(rel_path, d) if rel_path else d
+        data_path = os.path.join(path_prefix, sub_rel) if path_prefix else sub_rel
         html += (
-            f'<li class="dir closed" data-path="{sub_rel}">'
+            f'<li class="dir closed" data-path="{data_path}">'
             f'<span>📁 {d}</span>'
             '<ul class="hidden"></ul></li>'
         )
@@ -117,8 +128,8 @@ def generate_dir_html(
             html += (
                 '<li class="file">'
                 f'<form method="post" action="{action_url}" class="file-entry">'
-                f'<input type="hidden" name="action" value="{action_value}">' \
-                f'<input type="hidden" name="{field_name}" value="{full}">' \
+                f'<input type="hidden" name="action" value="{action_value}">'\
+                f'<input type="hidden" name="{field_name}" value="{full}">'\
                 f'<button type="submit">📄 {f}</button>'
                 '</form>'
                 '</li>'

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -44,10 +44,10 @@ NEW_PRESET_DIR = os.path.join(
 )
 
 # Base directory for factory presets that should never be modified
-CORE_LIBRARY_DIR = os.path.join(
-    "/data/CoreLibrary/Track Presets",
-    "Drift",
-)
+# These presets are stored as JSON files under ``/data/CoreLibrary/Track Presets``
+# with subfolders for instrument categories (e.g. "Drift").  We only store the
+# base path here so that presets in any subfolder are detected correctly.
+CORE_LIBRARY_DIR = "/data/CoreLibrary/Track Presets"
 
 logger = logging.getLogger(__name__)
 
@@ -150,12 +150,16 @@ class SynthParamEditorHandler(BaseHandler):
             if rename_flag:
                 if not new_name:
                     new_name = os.path.basename(preset_path)
+                # Convert json factory presets to .ablpreset when copying
+                if new_name.endswith('.json'):
+                    new_name = new_name[:-5]
+                if not new_name.endswith('.ablpreset'):
+                    new_name += '.ablpreset'
                 directory = os.path.dirname(preset_path)
                 if is_core:
                     directory = NEW_PRESET_DIR
-                if not new_name.endswith('.ablpreset'):
-                    new_name += '.ablpreset'
                 output_path = os.path.join(directory, new_name)
+                os.makedirs(os.path.dirname(output_path), exist_ok=True)
             result = update_parameter_values(preset_path, updates, output_path)
             if not result['success']:
                 return self.format_error_response(result['message'])

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -214,7 +214,7 @@ class SynthParamEditorHandler(BaseHandler):
 
             message = result['message'] + "; " + macro_result['message']
             if output_path:
-                message += f" Saved as {os.path.basename(output_path)}"
+                message += f" Saved to {output_path}"
             refresh_success, refresh_message = refresh_library()
             if refresh_success:
                 message += " Library refreshed."

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -247,7 +247,21 @@ def browse_dir():
     field_name = request.args.get("field_name", "")
     action_value = request.args.get("action_value", "")
     filter_key = request.args.get("filter")
-    html = generate_dir_html(root, path, action_url, field_name, action_value, filter_key)
+    CORE_LABEL = "Core Library"
+    CORE_ROOT = "/data/CoreLibrary/Track Presets"
+    if path == CORE_LABEL or path.startswith(CORE_LABEL + os.sep):
+        sub = path[len(CORE_LABEL):].lstrip(os.sep)
+        html = generate_dir_html(
+            CORE_ROOT,
+            sub,
+            action_url,
+            field_name,
+            action_value,
+            filter_key,
+            path_prefix=CORE_LABEL if CORE_LABEL else "",
+        )
+    else:
+        html = generate_dir_html(root, path, action_url, field_name, action_value, filter_key)
     return html
 
 


### PR DESCRIPTION
## Summary
- extend `generate_dir_html` with `path_prefix` for virtual roots
- add Core Library handling in `/browse-dir`
- show Core Library folder in Drift preset browser
- ensure saving factory presets writes to user library

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c3bb0348832598fadb7482a2fdd0