### PR TITLE
UI cleanup for editing preset message

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -203,7 +203,7 @@ class SynthParamEditorHandler(BaseHandler):
                 message += f" Library refresh failed: {refresh_message}"
         elif action in ['select_preset', 'new_preset']:
             if action == 'select_preset':
-                message = f"Selected preset: {os.path.basename(preset_path)}"
+                message = ""
         else:
             return self.format_error_response("Unknown action")
 

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -57,15 +57,14 @@
     {% elif selected_preset.startswith('examples/Track Presets') %}
         {% set _display = '/' + selected_preset.split('examples/Track Presets', 1)[1] %}
     {% endif %}
-    <p class="current-preset">Editing: {{ _display }}</p>
     {% set _basename = selected_preset.split('/')[-1] %}
     {% if _basename.endswith('.json') or _basename.endswith('.ablpreset') %}
         {% set _prefill = _basename.rsplit('.', 1)[0] %}
     {% else %}
         {% set _prefill = _basename %}
     {% endif %}
-    <div class="preset-controls">
-        <label>Preset Name:
+    <div class="preset-controls current-preset">
+        <label>Editing //
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -125,7 +125,7 @@ def test_synth_params_get(client, monkeypatch):
     resp = client.get('/synth-params')
     assert resp.status_code == 200
     assert b'pick' in resp.data
-    assert b'Editing:' not in resp.data
+    assert b'Editing //' not in resp.data
     assert b'Create New Drift Preset' in resp.data
     assert b'name="new_preset_name"' in resp.data
     assert b'id="newPresetModal"' in resp.data
@@ -144,7 +144,7 @@ def test_synth_params_post(client, monkeypatch):
     resp = client.post('/synth-params', data={'action': 'select_preset'})
     assert resp.status_code == 200
     assert b'done' in resp.data
-    assert b'Editing:' in resp.data
+    assert b'Editing //' in resp.data
     assert b'<div>p</div>' in resp.data
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
@@ -168,8 +168,7 @@ def test_synth_params_get_with_preset(client, monkeypatch):
     monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
     resp = client.get('/synth-params?preset=x')
     assert resp.status_code == 200
-    assert b'loaded' in resp.data
-    assert b'Editing:' in resp.data
+    assert b'Editing //' in resp.data
 
 def test_synth_params_new_preset(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
@@ -187,8 +186,7 @@ def test_synth_params_new_preset(client, monkeypatch):
     monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
     resp = client.post('/synth-params', data={'action': 'new_preset', 'new_preset_name': 'Test'})
     assert resp.status_code == 200
-    assert b'loaded' in resp.data
-    assert b'Editing:' in resp.data
+    assert b'Editing //' in resp.data
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
 


### PR DESCRIPTION
## Summary
- integrate loaded preset information into the editing field
- drop extra success message when selecting a preset
- adjust tests for updated wording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c4973a208325b5f5e9d293d6a8cf