### PR TITLE
Improve test coverage

### DIFF
--- a/tests/test_base_handler.py
+++ b/tests/test_base_handler.py
@@ -1,0 +1,67 @@
+import io
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers.base_handler import BaseHandler
+
+class DummyField:
+    def __init__(self, filename, data):
+        self.filename = filename
+        self.file = io.BytesIO(data)
+
+class DummyForm(dict):
+    def getvalue(self, key, default=None):
+        return self.get(key, default)
+
+
+def test_validate_action_success():
+    handler = BaseHandler()
+    form = DummyForm(action="do")
+    ok, err = handler.validate_action(form, "do")
+    assert ok is True
+    assert err is None
+
+
+def test_validate_action_failure():
+    handler = BaseHandler()
+    form = DummyForm(action="bad")
+    ok, err = handler.validate_action(form, "good")
+    assert ok is False
+    assert err["message_type"] == "error"
+    assert "Invalid action" in err["message"]
+
+
+def test_handle_file_upload_and_cleanup(tmp_path):
+    handler = BaseHandler()
+    handler.upload_dir = tmp_path
+    form = DummyForm()
+    form["file"] = DummyField("test.txt", b"abc")
+    success, path, err = handler.handle_file_upload(form)
+    assert success is True
+    assert err is None
+    assert Path(path).exists()
+    with open(path, "rb") as f:
+        assert f.read() == b"abc"
+    handler.cleanup_upload(path)
+    assert not Path(path).exists()
+
+
+def test_format_responses():
+    handler = BaseHandler()
+    ok = handler.format_success_response("ok", extra=1)
+    err = handler.format_error_response("bad")
+    info = handler.format_info_response("info")
+    assert ok["message"] == "ok" and ok["message_type"] == "success" and ok["extra"] == 1
+    assert err["message_type"] == "error"
+    assert info["message_type"] == "info"
+
+
+def test_format_json_response():
+    handler = BaseHandler()
+    result = handler.format_json_response({"a": 1}, status=201)
+    assert result["status"] == 201
+    assert ("Content-Type", "application/json") in result["headers"]
+    assert result["content"] == "{" + '"a": 1' + "}"
+

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import cache_manager as cm
+
+
+def test_set_get_invalidate():
+    cm.set_cache("a", 1)
+    assert cm.get_cache("a") == 1
+
+    cm.invalidate_cache("a")
+    assert cm.get_cache("a") is None
+
+    cm.set_cache("b", 2)
+    cm.invalidate_cache()
+    assert cm.get_cache("b") is None

--- a/tests/test_drum_rack_inspector_handler.py
+++ b/tests/test_drum_rack_inspector_handler.py
@@ -1,0 +1,117 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import drum_rack_inspector_handler as drih
+
+
+def create_simple_preset(path, sample_uri="file:///orig.wav"):
+    preset = {
+        "kind": "instrumentRack",
+        "chains": [
+            {
+                "devices": [
+                    {
+                        "kind": "drumRack",
+                        "chains": [
+                            {
+                                "devices": [
+                                    {
+                                        "kind": "drumCell",
+                                        "deviceData": {"sampleUri": sample_uri},
+                                        "parameters": {
+                                            "Voice_PlaybackStart": 0.0,
+                                            "Voice_PlaybackLength": 1.0,
+                                        },
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    Path(path).write_text(json.dumps(preset))
+
+
+def test_update_and_get_samples(tmp_path):
+    preset = tmp_path / "preset.json"
+    create_simple_preset(preset)
+
+    new_path = "/data/UserData/UserLibrary/Samples/kick 1.wav"
+    ok, msg = drih.update_drum_cell_sample(
+        str(preset), 1, new_path, new_playback_start=0.2, new_playback_length=0.5
+    )
+    assert ok, msg
+
+    info = drih.get_drum_cell_samples(str(preset))
+    assert info["success"], info.get("message")
+    assert len(info["samples"]) == 1
+    sample = info["samples"][0]
+    assert sample["pad"] == 1
+    assert sample["path"].endswith("kick 1.wav")
+    assert sample["playback_start"] == pytest.approx(0.2)
+    assert sample["playback_length"] == pytest.approx(0.5)
+
+    with open(preset) as f:
+        data = json.load(f)
+    cell = data["chains"][0]["devices"][0]["chains"][0]["devices"][0]
+    assert cell["deviceData"]["sampleUri"] == "ableton:/user-library/Samples/kick%201.wav"
+
+
+def test_find_original_sample(tmp_path):
+    base = tmp_path / "snare.wav"
+    base.write_text("x")
+    derived = tmp_path / "snare_reversed.wav"
+    derived.write_text("y")
+    assert drih.find_original_sample(str(derived)) == str(base)
+
+
+def test_scan_for_drum_rack_presets(monkeypatch, tmp_path):
+    base = "/data/UserData/UserLibrary/Track Presets"
+    (tmp_path / "Preset.json").write_text(json.dumps({"kind": "drumRack"}))
+
+    real_join = os.path.join
+    real_exists = os.path.exists
+    real_walk = os.walk
+
+    def fake_join(a, *p):
+        if a == base:
+            return real_join(str(tmp_path), *p)
+        return real_join(a, *p)
+
+    def fake_exists(path):
+        if path == base:
+            return True
+        return real_exists(path)
+
+    def fake_walk(path):
+        if path == base:
+            for item in real_walk(str(tmp_path)):
+                yield base, item[1], item[2]
+            return
+        yield from real_walk(path)
+
+    monkeypatch.setattr(drih.os.path, "join", fake_join)
+    monkeypatch.setattr(drih.os.path, "exists", fake_exists)
+    monkeypatch.setattr(drih.os, "walk", fake_walk)
+    monkeypatch.setattr(drih, "get_cache", lambda k: None)
+    captured = {}
+    monkeypatch.setattr(drih, "set_cache", lambda k, v: captured.setdefault("data", v))
+
+    result = drih.scan_for_drum_rack_presets()
+    assert result["success"]
+    assert result["presets"] == captured["data"]
+    assert result["presets"][0]["name"] == "Preset"
+
+    # Simulate cached call
+    monkeypatch.setattr(drih, "get_cache", lambda k: captured["data"])
+    result_cached = drih.scan_for_drum_rack_presets()
+    assert "cached" in result_cached["message"]

--- a/tests/test_synth_inspector_extra.py
+++ b/tests/test_synth_inspector_extra.py
@@ -1,0 +1,50 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.synth_preset_inspector_handler import (
+    extract_available_parameters,
+    extract_parameter_values,
+    load_drift_schema,
+)
+
+
+def create_simple_drift_preset(path):
+    preset = {
+        "kind": "instrumentRack",
+        "chains": [
+            {
+                "devices": [
+                    {
+                        "kind": "drift",
+                        "parameters": {
+                            "Enabled": True,
+                            "Volume": {"value": 0.75}
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+    Path(path).write_text(json.dumps(preset))
+
+
+def test_load_drift_schema():
+    schema = load_drift_schema()
+    assert isinstance(schema, dict)
+    assert "CyclingEnvelope_Hold" in schema
+
+
+def test_extract_available_and_values(tmp_path):
+    p = tmp_path / "preset.json"
+    create_simple_drift_preset(p)
+    info = extract_available_parameters(str(p))
+    assert info["success"]
+    assert "Volume" in info["parameters"]
+    vals = extract_parameter_values(str(p))
+    assert vals["success"]
+    param = {p["name"]: p["value"] for p in vals["parameters"]}
+    assert param["Volume"] == 0.75
+

--- a/tests/test_synth_inspector_updates.py
+++ b/tests/test_synth_inspector_updates.py
@@ -1,0 +1,111 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import synth_preset_inspector_handler as spih
+
+
+def create_basic_preset(path, custom_name="Old", vol=0.5):
+    preset = {
+        "kind": "instrumentRack",
+        "parameters": {"Macro0": 0.0},
+        "chains": [
+            {
+                "devices": [
+                    {
+                        "kind": "drift",
+                        "parameters": {
+                            "Macro0": {"value": 0.0, "customName": custom_name},
+                            "Volume": vol,
+                        },
+                    }
+                ]
+            }
+        ],
+    }
+    Path(path).write_text(json.dumps(preset))
+
+
+def test_update_macro_names(tmp_path):
+    p = tmp_path / "preset.json"
+    create_basic_preset(p)
+
+    res = spih.update_preset_macro_names(str(p), {0: "New"})
+    assert res["success"], res.get("message")
+    with open(p) as f:
+        data = json.load(f)
+    assert data["chains"][0]["devices"][0]["parameters"]["Macro0"]["customName"] == "New"
+    assert data["parameters"]["Macro0"] == 0.0
+
+    res = spih.update_preset_macro_names(str(p), {0: ""})
+    assert res["success"]
+    with open(p) as f:
+        data = json.load(f)
+    assert "customName" not in data["chains"][0]["devices"][0]["parameters"]["Macro0"]
+
+
+def test_update_and_delete_parameter_mapping(tmp_path):
+    p = tmp_path / "preset.json"
+    create_basic_preset(p)
+
+    res = spih.update_preset_parameter_mappings(
+        str(p), {0: {"parameter_path": "chains[0].devices[0].parameters.Volume"}}
+    )
+    assert res["success"], res.get("message")
+    with open(p) as f:
+        data = json.load(f)
+    vol = data["chains"][0]["devices"][0]["parameters"]["Volume"]
+    assert vol["value"] == 0.5
+    assert vol["macroMapping"]["macroIndex"] == 0
+
+    res = spih.delete_parameter_mapping(str(p), "chains[0].devices[0].parameters.Volume")
+    assert res["success"], res.get("message")
+    with open(p) as f:
+        data = json.load(f)
+    assert data["chains"][0]["devices"][0]["parameters"]["Volume"] == 0.5
+
+
+def test_scan_for_synth_presets(monkeypatch, tmp_path):
+    preset_path = tmp_path / "Preset.ablpreset"
+    create_basic_preset(preset_path)
+
+    base = "/data/UserData/UserLibrary/Track Presets"
+    real_join = os.path.join
+    real_exists = os.path.exists
+    real_walk = os.walk
+
+    def fake_join(a, *p):
+        if a == base:
+            return real_join(str(tmp_path), *p)
+        return real_join(a, *p)
+
+    def fake_exists(path):
+        if path == base:
+            return True
+        return real_exists(path)
+
+    def fake_walk(path):
+        if path == base:
+            for item in real_walk(str(tmp_path)):
+                yield base, item[1], item[2]
+            return
+        yield from real_walk(path)
+
+    monkeypatch.setattr(spih.os.path, "join", fake_join)
+    monkeypatch.setattr(spih.os.path, "exists", fake_exists)
+    monkeypatch.setattr(spih.os, "walk", fake_walk)
+    monkeypatch.setattr(spih, "get_cache", lambda k: None)
+    captured = {}
+    monkeypatch.setattr(spih, "set_cache", lambda k, v: captured.setdefault("data", v))
+
+    result = spih.scan_for_synth_presets()
+    assert result["success"]
+    assert result["presets"] == captured["data"]
+    assert result["presets"][0]["name"] == "Preset"
+
+    monkeypatch.setattr(spih, "get_cache", lambda k: captured["data"])
+    result_cached = spih.scan_for_synth_presets()
+    assert "cached" in result_cached["message"]

--- a/tests/test_utils_and_refresh.py
+++ b/tests/test_utils_and_refresh.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.utils import load_set_template
+from core.refresh_handler import refresh_library
+
+class DummyProcError(Exception):
+    pass
+
+
+def test_load_set_template(tmp_path):
+    tpl = {"x": 1}
+    p = tmp_path / "set.json"
+    p.write_text(json.dumps(tpl))
+    result = load_set_template(str(p))
+    assert result == tpl
+
+
+def test_load_set_template_error(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{bad}")
+    try:
+        load_set_template(str(p))
+    except Exception as e:
+        assert "Failed to load template" in str(e)
+    else:
+        assert False, "Expected exception"
+
+
+def test_refresh_library_success(monkeypatch):
+    called = {}
+    def fake_check(cmd, stderr=None):
+        called['cmd'] = cmd
+        return b''
+    def fake_invalidate():
+        called['inv'] = True
+    monkeypatch.setattr('subprocess.check_output', fake_check)
+    monkeypatch.setattr('core.refresh_handler.invalidate_cache', fake_invalidate)
+    success, msg = refresh_library()
+    assert success is True
+    assert 'successfully' in msg
+    assert called['cmd'][0] == 'dbus-send'
+    assert called['inv'] is True
+
+
+def test_refresh_library_failure(monkeypatch):
+    class FakeError(Exception):
+        output = b'bad'
+    def fake_check(cmd, stderr=None):
+        raise subprocess.CalledProcessError(1, cmd, output=b'bad')
+    import subprocess
+    monkeypatch.setattr(subprocess, 'check_output', fake_check)
+    monkeypatch.setattr('core.refresh_handler.invalidate_cache', lambda: None)
+    success, msg = refresh_library()
+    assert not success
+    assert 'Failed to refresh library' in msg
+


### PR DESCRIPTION
## Summary
- create new unit tests for BaseHandler utility methods
- add tests for refresh_library and load_set_template
- add synth inspector tests for simple drift presets
- **new:** verify synth preset update helpers and scanning behavior

## Testing
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bf960a0c832589877efe24745e6e