### PR TITLE
Fix pitch modulation amount step size

### DIFF
--- a/static/schemas/drift_schema.json
+++ b/static/schemas/drift_schema.json
@@ -681,7 +681,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 1
+    "decimals": 2
   },
   "PitchModulation_Amount2": {
     "type": "number",
@@ -689,7 +689,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 1
+    "decimals": 2
   },
   "PitchModulation_Source1": {
     "type": "enum",


### PR DESCRIPTION
## Summary
- allow fine-grained increments for `PitchModulation_Amount1` and `PitchModulation_Amount2`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ced12da48325845d3885c20ea075