### PR TITLE
Add randomize button for Drift preset editor

### DIFF
--- a/static/rect-slider.js
+++ b/static/rect-slider.js
@@ -67,6 +67,7 @@ function initSlider(el){
       fill.style.width=(pct*100)+'%';
     }
   }
+  el._sliderUpdate = (v)=>{ value = clamp(parseFloat(v),min,max); update(); };
   function start(ev){
     if(el.classList.contains('disabled') || el.dataset.disabled==='true') return;
     ev.preventDefault();

--- a/static/style.css
+++ b/static/style.css
@@ -736,6 +736,15 @@ select {
 .preset-controls label {
     margin-bottom: 0;
 }
+.preset-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+#randomize-btn {
+    margin-left: auto;
+}
 
 /* Highlight parameters and macros by macro index */
 .param-item.macro-0, .macro-knob.macro-0 {

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -11,4 +11,59 @@ function initNewPresetModal() {
   window.addEventListener('click', (e) => { if (e.target === modal) modal.classList.add('hidden'); });
 }
 
-document.addEventListener('DOMContentLoaded', initNewPresetModal);
+function randomizeParams() {
+  document.querySelectorAll('.param-item').forEach(item => {
+    const dial = item.querySelector('input.param-dial');
+    const select = item.querySelector('select.param-select');
+    const toggle = item.querySelector('input.param-toggle');
+    const slider = item.querySelector('.rect-slider');
+
+    if (dial) {
+      const min = parseFloat(dial.min || '0');
+      const max = parseFloat(dial.max || '1');
+      const step = parseFloat(dial.step || '1');
+      const unit = dial.dataset.unit || '';
+      const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
+      const val = Math.random() * (max - min) + min;
+      const st = getPercentStep(val, unit, step, shouldScale);
+      const q = Math.round((val - min) / st) * st + min;
+      dial.value = q;
+      dial.dispatchEvent(new Event('input'));
+    } else if (select) {
+      const opts = Array.from(select.options).map(o => o.value);
+      select.value = opts[Math.floor(Math.random() * opts.length)];
+      select.dispatchEvent(new Event('change'));
+    } else if (toggle) {
+      toggle.checked = Math.random() < 0.5;
+      toggle.dispatchEvent(new Event('change'));
+    } else if (slider) {
+      const min = parseFloat(slider.dataset.min || '0');
+      const max = parseFloat(slider.dataset.max || '1');
+      const step = parseFloat(slider.dataset.step || '1');
+      const unit = slider.dataset.unit || '';
+      const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
+      let val = Math.random() * (max - min) + min;
+      const st = getPercentStep(val, unit, step, shouldScale);
+      val = Math.round((val - min) / st) * st + min;
+      slider.dataset.value = val;
+      if (typeof slider._sliderUpdate === 'function') slider._sliderUpdate(val);
+    }
+  });
+  const saveBtn = document.getElementById('save-params-btn');
+  if (saveBtn) saveBtn.disabled = false;
+}
+
+function initRandomizeButton() {
+  const btn = document.getElementById('randomize-btn');
+  if (btn) btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    randomizeParams();
+  });
+}
+
+function initSynthParams() {
+  initNewPresetModal();
+  initRandomizeButton();
+}
+
+document.addEventListener('DOMContentLoaded', initSynthParams);

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -71,9 +71,9 @@
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>
     <div class="preset-actions">
-        <button type="button" id="randomize-btn">Randomize</button>
         <button type="submit" id="save-params-btn" disabled>Save Parameters</button>
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
+        <button type="button" id="randomize-btn">Randomize</button>
     </div>
     <div class="macro-knobs-section">
         <h3>Macros</h3>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -71,6 +71,7 @@
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>
     <div class="preset-actions">
+        <button type="button" id="randomize-btn">Randomize</button>
         <button type="submit" id="save-params-btn" disabled>Save Parameters</button>
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
     </div>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -149,6 +149,7 @@ def test_synth_params_post(client, monkeypatch):
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
     assert b'disabled' in resp.data
+    assert b'id="randomize-btn"' in resp.data
 
 def test_synth_params_get_with_preset(client, monkeypatch):
     def fake_post(form):
@@ -170,6 +171,7 @@ def test_synth_params_get_with_preset(client, monkeypatch):
     assert resp.status_code == 200
     assert b'loaded' in resp.data
     assert b'Editing:' in resp.data
+    assert b'id="randomize-btn"' in resp.data
 
 def test_synth_params_new_preset(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
@@ -191,6 +193,7 @@ def test_synth_params_new_preset(client, monkeypatch):
     assert b'Editing:' in resp.data
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
+    assert b'id="randomize-btn"' in resp.data
 
 def test_drum_rack_inspector_get(client, monkeypatch):
     def fake_get():


### PR DESCRIPTION
## Summary
- add a Randomize button in the Drift preset editor page
- support updating custom sliders programmatically
- enable client-side parameter randomization
- expect the Randomize button on routes that load the editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dce2555c832595367d1ac977e823