### PR TITLE
Refresh library after new preset

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -121,9 +121,19 @@ class SynthParamEditorHandler(BaseHandler):
                 return self.format_error_response("Preset already exists")
             try:
                 shutil.copy(DEFAULT_PRESET, preset_path)
+                refresh_success, refresh_message = refresh_library()
+                if refresh_success:
+                    message = (
+                        f"Created new preset {os.path.basename(preset_path)}. "
+                        "Library refreshed."
+                    )
+                else:
+                    message = (
+                        f"Created new preset {os.path.basename(preset_path)}. "
+                        f"Library refresh failed: {refresh_message}"
+                    )
             except Exception as exc:
                 return self.format_error_response(f"Could not create preset: {exc}")
-            message = f"Created new preset {os.path.basename(preset_path)}"
         else:
             preset_path = form.getvalue('preset_select')
 

--- a/tests/test_new_preset_refresh.py
+++ b/tests/test_new_preset_refresh.py
@@ -1,0 +1,39 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers import synth_param_editor_handler_class as speh
+class SimpleForm(dict):
+    def getvalue(self, name, default=None):
+        return self.get(name, default)
+
+
+def test_new_preset_triggers_refresh(monkeypatch, tmp_path):
+    default_preset = tmp_path / "default.json"
+    default_preset.write_text(json.dumps({"kind": "drift", "parameters": {}}))
+
+    monkeypatch.setattr(speh, "DEFAULT_PRESET", str(default_preset))
+    monkeypatch.setattr(speh, "NEW_PRESET_DIR", str(tmp_path))
+    monkeypatch.setattr(speh, "CORE_LIBRARY_DIR", str(tmp_path / "core"))
+
+    monkeypatch.setattr(speh, "generate_dir_html", lambda *a, **k: "")
+    monkeypatch.setattr(speh, "load_drift_schema", lambda: {})
+    monkeypatch.setattr(speh, "extract_parameter_values", lambda p: {"success": True, "parameters": []})
+    monkeypatch.setattr(speh, "extract_macro_information", lambda p: {"success": True, "macros": [], "mapped_parameters": {}})
+    monkeypatch.setattr(speh, "extract_available_parameters", lambda p: {"success": True, "parameters": [], "parameter_paths": {}})
+
+    called = {}
+    def fake_refresh():
+        called['done'] = True
+        return True, "ok"
+    monkeypatch.setattr(speh, "refresh_library", fake_refresh)
+
+    handler = speh.SynthParamEditorHandler()
+    form = SimpleForm({'action': 'new_preset', 'new_preset_name': 'Test'})
+    result = handler.handle_post(form)
+
+    assert called.get('done') is True
+    assert "Library refreshed" in result['message']
+    assert (tmp_path / "Test.ablpreset").exists()


### PR DESCRIPTION
## Summary
- refresh the Move library when creating a new Drift preset
- test new preset refresh behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e6027cdc832580d991aae11d6cee