### PR TITLE
Add static git support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Tools for extending the Ableton Move. This project provides a companion webserve
   - Uses Move's D-Bus interface
   - Clears cached preset and sample lists used by the web tools
   - File lists are cached for faster loading between scans
+- **In-Place Update**
+  - Visit ``move.local:<port>/update`` to check for new versions
+  - If available, download and install updates directly on the device
     
 ## Installation
 
@@ -236,6 +239,7 @@ Interested in chatting about more Move hacking? Come talk to us on [Discord](htt
 This project is not affiliated with, authorized by, or endorsed by Ableton. Use at your own risk. The authors cannot be held responsible for any damage or issues that may occur. Always refer to official documentation when modifying hardware.
 
 This project includes a statically linked binary of Rubber Band. The source code for Rubber Band is available under GPLv2 at [https://breakfastquay.com/rubberband/](https://breakfastquay.com/rubberband/).
+It also fetches a statically linked Git executable from the [EXALAB/git-static](https://github.com/EXALAB/git-static) project for use on devices without Git. The `update-on-move` script installs this binary to `~/bin/git` on your Move if it isn’t already present.
 
 > These tools are third-party and require SSH access. That means:
 > * There’s a real risk (though unlikely) of breaking things, including potentially bricking a device. You are accessing the Move in ways it was not designed to do.

--- a/core/update_handler.py
+++ b/core/update_handler.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Utilities for checking and applying updates via git."""
+import subprocess
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_REMOTE_URL = "https://github.com/charlesvestal/extending-move.git"
+DEFAULT_BRANCH = "main"
+# Use the static git binary installed in the user's bin directory
+GIT_BIN = os.path.expanduser("~/bin/git")
+
+
+def _run_git_cmd(args):
+    """Run a git command in the repository and return output."""
+    git_exe = GIT_BIN if os.path.exists(GIT_BIN) else "git"
+    try:
+        result = subprocess.run(
+            [git_exe] + list(args),
+            cwd=REPO_DIR,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except FileNotFoundError:
+        logger.error("Git executable not found: %s", git_exe)
+        return None
+    except subprocess.CalledProcessError as exc:
+        logger.error("Git command failed: %s", exc)
+        return None
+
+
+def _ensure_remote(remote="origin", url=DEFAULT_REMOTE_URL):
+    """Ensure the given remote exists; if not, add it."""
+    current_url = _run_git_cmd(["remote", "get-url", remote])
+    if current_url is None:
+        _run_git_cmd(["remote", "add", remote, url])
+
+
+def get_current_commit():
+    """Return the current HEAD commit hash."""
+    return _run_git_cmd(["rev-parse", "HEAD"])
+
+
+def get_latest_remote_commit(remote="origin", branch=DEFAULT_BRANCH):
+    """Fetch and return the latest commit hash for the remote branch."""
+    _ensure_remote(remote)
+    fetch_result = _run_git_cmd(["fetch", remote, branch])
+    if fetch_result is None:
+        return None
+    return _run_git_cmd(["rev-parse", "FETCH_HEAD"])
+
+
+def check_update_available(remote="origin", branch=DEFAULT_BRANCH):
+    """Check if a newer commit exists on the remote."""
+    local = get_current_commit()
+    latest = get_latest_remote_commit(remote, branch)
+    if not local or not latest:
+        return False, "Unable to determine update status"
+    if local == latest:
+        return False, "Already up to date"
+    return True, f"Update available: {latest[:7]}"
+
+
+def perform_update(remote="origin", branch=DEFAULT_BRANCH):
+    """Perform a git pull to update the repository."""
+    try:
+        _ensure_remote(remote)
+        _run_git_cmd(["reset", "--hard", "HEAD"])
+        pull = _run_git_cmd(["pull", remote, branch])
+        if pull is None:
+            return False, "Git pull failed"
+        return True, "Update completed"
+    except Exception as exc:
+        logger.error("Update failed: %s", exc)
+        return False, f"Error during update: {exc}"

--- a/handlers/update_handler_class.py
+++ b/handlers/update_handler_class.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Web handler for the update feature."""
+from handlers.base_handler import BaseHandler
+from core.update_handler import check_update_available, perform_update
+
+
+class UpdateHandler(BaseHandler):
+    """Handle update checks and application."""
+
+    def handle_get(self):
+        available, message = check_update_available()
+        return {
+            "message": message,
+            "message_type": "info",
+            "update_available": available,
+        }
+
+    def handle_post(self, form):
+        valid, error = self.validate_action(form, "perform_update")
+        if not valid:
+            return error
+        success, message = perform_update()
+        msg_type = "success" if success else "error"
+        return {
+            "message": message,
+            "message_type": msg_type,
+            "update_available": False,
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -35,6 +35,7 @@ from handlers.synth_param_editor_handler_class import SynthParamEditorHandler
 from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
+from handlers.update_handler_class import UpdateHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -112,6 +113,7 @@ synth_param_handler = SynthParamEditorHandler()
 file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
 drum_rack_handler = DrumRackInspectorHandler()
+update_handler = UpdateHandler()
 
 
 @app.before_request
@@ -592,6 +594,28 @@ def refresh_get_route():
     resp = make_response(message, status_code)
     resp.mimetype = "text/plain"
     return resp
+
+
+@app.route("/update", methods=["GET", "POST"])
+def update_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = update_handler.handle_post(form)
+    else:
+        result = update_handler.handle_get()
+
+    message = result.get("message")
+    message_type = result.get("message_type")
+    update_available = result.get("update_available", False)
+    success = message_type != "error" if message_type else False
+    return render_template(
+        "update.html",
+        message=message,
+        message_type=message_type,
+        success=success,
+        update_available=update_available,
+        active_tab="update",
+    )
 
 
 @app.route("/pitch-shift", methods=["POST"])

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -16,6 +16,7 @@
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Drift</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
+        <a href="{{ host_prefix }}/update" class="{% if active_tab == 'update' %}active{% endif %}">Update</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/update.html
+++ b/templates_jinja/update.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Update</h2>
+<p>{{ message }}</p>
+{% if update_available %}
+<form method="post">
+  <input type="hidden" name="action" value="perform_update">
+  <button type="submit">Update Now</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -397,4 +397,25 @@ def test_pitch_shift_route(client, monkeypatch):
     assert len(shifted) == len(data)
 
 
+def test_update_get(client, monkeypatch):
+    def fake_get():
+        return {"message": "ok", "message_type": "info", "update_available": False}
+
+    monkeypatch.setattr(move_webserver.update_handler, "handle_get", fake_get)
+    resp = client.get("/update")
+    assert resp.status_code == 200
+    assert b"ok" in resp.data
+
+
+def test_update_post(client, monkeypatch):
+    def fake_post(form):
+        assert form.getvalue("action") == "perform_update"
+        return {"message": "done", "message_type": "success", "update_available": False}
+
+    monkeypatch.setattr(move_webserver.update_handler, "handle_post", fake_post)
+    resp = client.post("/update", data={"action": "perform_update"})
+    assert resp.status_code == 200
+    assert b"done" in resp.data
+
+
 

--- a/utility-scripts/restart-webserver.sh
+++ b/utility-scripts/restart-webserver.sh
@@ -19,6 +19,8 @@ else
   PORT=909
 fi
 
+
+
 echo "Restarting the webserver on ${REMOTE_HOST}..."
 
 if [ -n "${SKIP_MODULE_WARMUP:-}" ]; then
@@ -37,6 +39,10 @@ if [ -f "$CONFIG_FILE" ]; then
 else
   PORT=909
 fi
+
+# Ensure webserver can access bundled binaries
+EXT_DIR="/data/UserData/extending-move/bin"
+export PATH="/data/UserData/bin:$EXT_DIR:$EXT_DIR/rubberband:$PATH"
 
 # Use the absolute paths
 PID_FILE="/data/UserData/extending-move/move-webserver.pid"

--- a/utility-scripts/update-on-move.sh
+++ b/utility-scripts/update-on-move.sh
@@ -18,10 +18,30 @@ else
 fi
 cd "$PROJECT_ROOT"
 
-# --- Remote server configuration ---
+# Remote server configuration
 REMOTE_USER="ableton"
 REMOTE_HOST="move.local"
 REMOTE_DIR="/data/UserData/extending-move"
+
+# --- Ensure static git binary is present locally ---
+GIT_BIN="${PROJECT_ROOT}/bin/git"
+REMOTE_GIT_BIN="/data/UserData/bin/git"
+
+if [ ! -f "$GIT_BIN" ]; then
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "${REMOTE_USER}@${REMOTE_HOST}" "[ -f '${REMOTE_GIT_BIN}' ]" 2>/dev/null; then
+    echo "Copying static git from device..."
+    mkdir -p "${PROJECT_ROOT}/bin"
+    scp "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_GIT_BIN}" "$GIT_BIN" >/dev/null
+  else
+    echo "Downloading static git binary..."
+    mkdir -p "${PROJECT_ROOT}/bin"
+    curl -L -o "$GIT_BIN" \
+      https://raw.githubusercontent.com/EXALAB/git-static/master/output/amd64/bin/git
+  fi
+  chmod +x "$GIT_BIN"
+fi
+
+# --- Remote server configuration (already defined above) ---
 
 # --- Version check: ensure Move version is within tested range ---
 HIGHEST_TESTED_VERSION="1.5.0"
@@ -34,20 +54,32 @@ if ! printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V 
   fi
 fi
 
-# --- Ensure remote directory exists ---
-echo "Creating ${REMOTE_DIR} on ${REMOTE_HOST}…"
-ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p '${REMOTE_DIR}'"
+# --- Install git on the device if needed ---
+if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "${REMOTE_USER}@${REMOTE_HOST}" "[ -x '${REMOTE_GIT_BIN}' ]" 2>/dev/null; then
+  echo "Installing static git on device..."
+  ssh "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p \"$(dirname \"${REMOTE_GIT_BIN}\")\""
+  scp "$GIT_BIN" "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_GIT_BIN}" >/dev/null
+  ssh "${REMOTE_USER}@${REMOTE_HOST}" "chmod +x '${REMOTE_GIT_BIN}'"
+fi
 
-# --- Archive & copy your project files (excludes .git & utility-scripts) ---
-echo "Uploading project files to ${REMOTE_HOST}:${REMOTE_DIR}…"
-tar czf - \
-  --exclude='.git' \
-  --exclude='utility-scripts' \
-  core handlers templates_jinja static examples bin \
-  move-webserver.py requirements.txt port.conf | \
-ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "cd '${REMOTE_DIR}' && tar xzf - && cp -r /opt/move/HttpRoot/fonts static/"
-
-echo "Files copied."
+# --- Clone or update repository on the device ---
+ssh -T "${REMOTE_USER}@${REMOTE_HOST}" <<'EOF'
+set -euo pipefail
+mkdir -p ~/extending-move
+if ! grep -q "$HOME/bin" ~/.bashrc; then
+  echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+fi
+export PATH="$HOME/bin:$PATH"
+if [ -d ~/extending-move/.git ]; then
+  ~/bin/git -C ~/extending-move pull --ff-only
+else
+  ~/bin/git clone https://github.com/charlesvestal/extending-move.git ~/extending-move
+fi
+cp -r /opt/move/HttpRoot/fonts ~/extending-move/static/
+chmod +x ~/extending-move/move-webserver.py
+chmod -R 755 ~/extending-move/static
+chmod -R 755 ~/extending-move/bin
+EOF
 
 # --- Fix permissions remotely (now with proper path expansion) ---
 echo "Setting permissions on remote…"
@@ -63,7 +95,7 @@ else
   echo "Installing requirements with pip on remote..."
   ssh -T "${REMOTE_USER}@${REMOTE_HOST}" <<EOF
 export TMPDIR=/data/UserData/tmp
-export PATH="${REMOTE_DIR}/bin/rubberband:\$PATH"
+export PATH="/data/UserData/bin:${REMOTE_DIR}/bin:${REMOTE_DIR}/bin/rubberband:\$PATH"
 echo "TMPDIR is set to: \$TMPDIR"
 pip install --no-cache-dir -r "${REMOTE_DIR}/requirements.txt" | grep -v 'already satisfied'
 EOF


### PR DESCRIPTION
## Summary
- download EXALAB static `git` when running update script
- look for the bundled git binary in the update handler
- export PATH so the webserver can use binaries from `bin`
- document the static git binary in the README
- avoid downloading if the device already has the binary
- install the static git binary to `~/bin` on the device and clone/pull with it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e669dd68832582ab91bdda1d8f0e