### PR TITLE
Increase unit test coverage

### DIFF
--- a/tests/test_file_browser_internal.py
+++ b/tests/test_file_browser_internal.py
@@ -1,0 +1,59 @@
+import json
+import os
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.file_browser import _list_directory, _check_json_file, _has_kind
+
+
+def test_list_directory_cache(tmp_path):
+    # create directory structure
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.txt").write_text("x")
+    dirs, files = _list_directory(str(tmp_path), "")
+    assert dirs == ["sub"]
+    assert "a.txt" in files
+
+    # add new file to invalidate cache
+    (tmp_path / "b.txt").write_text("y")
+    dirs2, files2 = _list_directory(str(tmp_path), "")
+    assert "b.txt" in files2
+
+
+def test_list_directory_missing(tmp_path):
+    missing = tmp_path / "missing"
+    dirs, files = _list_directory(str(missing), "")
+    assert dirs == [] and files == []
+
+
+def test_check_json_file_caching(tmp_path, monkeypatch):
+    p = tmp_path / "preset.json"
+    p.write_text(json.dumps({"kind": "drift"}))
+    assert _check_json_file(str(p), "drift") is True
+
+    # patch json.load to ensure it isn't called when cached
+    def fail_load(f):
+        raise AssertionError("json.load called")
+    monkeypatch.setattr("core.file_browser.json.load", fail_load)
+    assert _check_json_file(str(p), "drift") is True
+
+    # updating the file should trigger a reload
+    monkeypatch.setattr("core.file_browser.json.load", lambda f: {})
+    p.write_text("{}")
+    import time
+    time.sleep(0.01)
+    os.utime(p, None)
+    assert _check_json_file(str(p), "drift") is False
+
+
+def test_check_json_file_missing(tmp_path):
+    missing = tmp_path / "nope.json"
+    assert _check_json_file(str(missing), "drift") is False
+
+
+def test_has_kind_nested():
+    data = {"x": [{"kind": "drift"}, {"y": {"kind": "other"}}]}
+    assert _has_kind(data, "drift") is True
+    assert _has_kind(data, "missing") is False

--- a/tests/test_list_msets_handler.py
+++ b/tests/test_list_msets_handler.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import list_msets_handler as lmh
+
+
+def test_list_msets_no_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(lmh, "MSETS_DIRECTORY", str(tmp_path / "missing"))
+    result = lmh.list_msets()
+    assert result == []
+    msets, ids = lmh.list_msets(return_free_ids=True)
+    assert msets == []
+    assert set(ids["free"]) == set(range(32))
+
+
+def test_list_msets_and_free(monkeypatch, tmp_path):
+    monkeypatch.setattr(lmh, "MSETS_DIRECTORY", str(tmp_path))
+    (tmp_path / "uuid1" / "SetA").mkdir(parents=True)
+    (tmp_path / "uuid2" / "SetB").mkdir(parents=True)
+
+    mapping = {
+        ("uuid1", "user.song-index"): "0",
+        ("uuid2", "user.song-index"): "31",
+        ("uuid1", "user.song-color"): "1",
+        ("uuid2", "user.song-color"): "2",
+    }
+
+    def fake_get_xattr(rel, attr):
+        return mapping.get((rel, attr), "")
+
+    monkeypatch.setattr(lmh, "get_xattr_value", fake_get_xattr)
+
+    msets, ids = lmh.list_msets(return_free_ids=True)
+    assert [m["mset_id"] for m in msets] == [0, 31]
+    assert ids["used"] == {0, 31}
+    free = lmh.list_msets_free()
+    assert 0 not in free and 31 not in free
+    assert len(free) == 30

--- a/tests/test_midi_helpers.py
+++ b/tests/test_midi_helpers.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.midi_pattern_generator import (
+    note_name_to_midi,
+    create_scale_pattern,
+    create_rhythm_pattern,
+)
+
+
+def test_note_name_to_midi_basic():
+    assert note_name_to_midi("C4") == 60
+    assert note_name_to_midi("D#5") == 75
+    assert note_name_to_midi("Bb3") == 58
+
+
+def test_note_name_to_midi_invalid():
+    import pytest
+    with pytest.raises(ValueError):
+        note_name_to_midi("H2")
+    with pytest.raises(ValueError):
+        note_name_to_midi("C?")
+
+
+def test_create_scale_pattern_descending():
+    pattern = create_scale_pattern("C4", "major", note_duration=0.5, ascending=False)
+    assert pattern[0]["note"] > pattern[-1]["note"]
+    assert len(pattern) == 8
+    assert pattern[1]["start"] == 0.5
+
+
+def test_create_rhythm_pattern_velocity_cycle():
+    rhythm = [(0, 0.25), (0.5, 0.25), (1.0, 0.25), (1.5, 0.25)]
+    pattern = create_rhythm_pattern("C4", rhythm, velocity_pattern=[80, 100])
+    velocities = [n["velocity"] for n in pattern]
+    assert velocities == [80, 100, 80, 100]
+    assert [n["start"] for n in pattern] == [0, 0.5, 1.0, 1.5]

--- a/tests/test_pad_colors.py
+++ b/tests/test_pad_colors.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.pad_colors import rgb_string
+
+
+def test_rgb_string_valid_and_invalid():
+    assert rgb_string(1) == "rgb(255, 25, 23)"
+    assert rgb_string(999) == ""

--- a/tests/test_refresh_handler_class.py
+++ b/tests/test_refresh_handler_class.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers.refresh_handler_class import RefreshHandler
+
+class SimpleForm(dict):
+    def getvalue(self, key, default=None):
+        return self.get(key, default)
+
+
+def test_refresh_handler_success(monkeypatch):
+    h = RefreshHandler()
+    form = SimpleForm(action="refresh_library")
+    monkeypatch.setattr("handlers.refresh_handler_class.refresh_library", lambda: (True, "ok"))
+    resp = h.handle_post(form)
+    assert resp["message_type"] == "success"
+    assert resp["message"] == "ok"
+
+
+def test_refresh_handler_failure(monkeypatch):
+    h = RefreshHandler()
+    form = SimpleForm(action="refresh_library")
+    monkeypatch.setattr("handlers.refresh_handler_class.refresh_library", lambda: (False, "bad"))
+    resp = h.handle_post(form)
+    assert resp["message_type"] == "error"
+    assert "bad" in resp["message"]
+
+
+def test_refresh_handler_bad_action():
+    h = RefreshHandler()
+    form = SimpleForm(action="wrong")
+    resp = h.handle_post(form)
+    assert resp["message_type"] == "error"
+    assert "Invalid action" in resp["message"]
+
+
+def test_refresh_handler_exception(monkeypatch):
+    h = RefreshHandler()
+    form = SimpleForm(action="refresh_library")
+    def boom():
+        raise RuntimeError("fail")
+    monkeypatch.setattr("handlers.refresh_handler_class.refresh_library", boom)
+    resp = h.handle_post(form)
+    assert resp["message_type"] == "error"
+    assert "fail" in resp["message"]

--- a/tests/test_restore_handler_utils.py
+++ b/tests/test_restore_handler_utils.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers.restore_handler_class import RestoreHandler
+
+
+def test_generate_pad_options_empty():
+    h = RestoreHandler()
+    html = h.generate_pad_options([])
+    assert 'No pads available' in html
+
+
+def test_generate_pad_options_some():
+    h = RestoreHandler()
+    html = h.generate_pad_options([2, 4])
+    assert html.count('<option') == 2
+    assert 'selected' in html.split('<option')[1]
+
+
+def test_generate_pad_grid():
+    h = RestoreHandler()
+    html = h.generate_pad_grid({0, 31}, {0: 1})
+    assert html.count('class="pad-cell occupied"') == 2
+    assert 'restore_pad_1" name="mset_index" value="1" disabled' in html
+    assert 'background-color: rgb(' in html
+
+def test_generate_color_options_custom():
+    h = RestoreHandler()
+    html = h.generate_color_options("clr", "pad")
+    assert 'id="clr_dropdown"' in html
+    assert 'name="clr"' in html
+    assert 'padName = "pad"' in html
+    assert 'color-dropdown' in html

--- a/tests/test_set_management_handler.py
+++ b/tests/test_set_management_handler.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+import json
+import mido
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import core.set_management_handler as sm
+
+
+def patch_output(monkeypatch, tmp_path):
+    real_join = sm.os.path.join
+    def fake_join(a, *p):
+        if a == "/data/UserData/UserLibrary/Sets":
+            return real_join(str(tmp_path), *p)
+        return real_join(a, *p)
+    monkeypatch.setattr(sm.os.path, "join", fake_join)
+    monkeypatch.setattr(sm.os, "makedirs", lambda p, exist_ok=True: None)
+
+
+def test_create_set(monkeypatch, tmp_path):
+    patch_output(monkeypatch, tmp_path)
+    result = sm.create_set("TestSet")
+    assert result["success"]
+    assert (tmp_path / "TestSet").exists()
+
+
+def test_generate_c_major_chord_example(monkeypatch, tmp_path):
+    patch_output(monkeypatch, tmp_path)
+    monkeypatch.setattr(sm, "load_set_template", lambda p: {
+        "tracks": [{"clipSlots": [{"clip": {"notes": [], "region": {"end": 0, "loop": {"end": 0}}}}]}],
+        "tempo": 0
+    })
+    result = sm.generate_c_major_chord_example("ChordSet", tempo=90.0)
+    assert result["success"]
+    out = tmp_path / "ChordSet.abl"
+    with open(out) as f:
+        data = json.load(f)
+    assert data["tempo"] == 90.0
+    assert len(data["tracks"][0]["clipSlots"][0]["clip"]["notes"]) == 12
+
+
+def test_generate_midi_set_from_file(monkeypatch, tmp_path):
+    patch_output(monkeypatch, tmp_path)
+    monkeypatch.setattr(sm, "load_set_template", lambda p: {
+        "tracks": [{"clipSlots": [{"clip": {"notes": [], "region": {"end": 0, "loop": {"end": 0}}}}]}],
+        "tempo": 0
+    })
+    midi_path = tmp_path / "x.mid"
+    mid = mido.MidiFile()
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.Message("note_on", note=60, velocity=100, time=0))
+    track.append(mido.Message("note_off", note=60, velocity=0, time=480))
+    mid.save(midi_path)
+    result = sm.generate_midi_set_from_file("MidiSet", str(midi_path), tempo=110.0)
+    assert result["success"]
+    out = tmp_path / "MidiSet.abl"
+    with open(out) as f:
+        data = json.load(f)
+    assert data["tempo"] == 110.0
+    assert len(data["tracks"][0]["clipSlots"][0]["clip"]["notes"]) == 1
+
+
+def test_generate_drum_set_from_file(monkeypatch, tmp_path):
+    patch_output(monkeypatch, tmp_path)
+    monkeypatch.setattr(sm, "load_set_template", lambda p: {
+        "tracks": [{"clipSlots": [{"clip": {"notes": [], "region": {"end": 0, "loop": {"end": 0}}}}]}],
+        "tempo": 0
+    })
+    midi_path = tmp_path / "d.mid"
+    mid = mido.MidiFile()
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.Message("note_on", note=36, velocity=100, time=0))
+    track.append(mido.Message("note_off", note=36, velocity=0, time=240))
+    mid.save(midi_path)
+    result = sm.generate_drum_set_from_file("DrumSet", str(midi_path), tempo=120.0)
+    assert result["success"]
+    out = tmp_path / "DrumSet.abl"
+    with open(out) as f:
+        data = json.load(f)
+    assert data["tempo"] == 120.0
+    assert len(data["tracks"][0]["clipSlots"][0]["clip"]["notes"]) == 1
+    assert data["tracks"][0]["clipSlots"][0]["clip"]["notes"][0]["noteNumber"] == 36
+


### PR DESCRIPTION
## Summary
- add test for RefreshHandler success/error flows
- exercise RestoreHandler's color dropdown HTML
- create new tests for set_management_handler MIDI utilities

## Testing
- `pytest -q`
- `pytest --cov=core --cov=handlers --cov=move-webserver.py --cov-report term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6846538934608325be17406d68099762