### PR TITLE
Fix mod matrix row layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -584,6 +584,7 @@ select {
 
 .mod-matrix-row {
     justify-content: center;
+    width: 100%;
 }
 
 .mod-matrix-row .mod-group {

--- a/static/style.css
+++ b/static/style.css
@@ -585,6 +585,7 @@ select {
 .mod-matrix-row {
     justify-content: center;
     width: 100%;
+    flex: 0 0 100%;
 }
 
 .mod-matrix-row .mod-group {


### PR DESCRIPTION
## Summary
- ensure modulation matrix rows span the full width so each mod appears on its own row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684673521acc8325a3e673723dc3d287