### PR TITLE
Fix unwanted overwrite warning

### DIFF
--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -161,9 +161,11 @@ document.addEventListener('DOMContentLoaded', () => {
     updateSaveState();
 
     const orig = nameInput ? nameInput.dataset.originalName : null;
+    const actionInput = document.getElementById('action-input');
     if (orig && cb && nameInput) {
       form.addEventListener('submit', (e) => {
         if (!cb.checked) return;
+        if (actionInput && actionInput.value !== 'save_params') return;
         let newName = nameInput.value.trim();
         if (!newName.endsWith('.ablpreset') && !newName.endsWith('.json')) {
           newName += '.ablpreset';


### PR DESCRIPTION
## Summary
- avoid overwrite alert unless saving preset parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466e582c5c83259e41b50ecc7184a5