### PR TITLE
Fix overwrite warning when choosing new preset

### DIFF
--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -164,6 +164,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (orig && cb && nameInput) {
       form.addEventListener('submit', (e) => {
         if (!cb.checked) return;
+        const actionField = document.getElementById('action-input');
+        if (actionField && actionField.value !== 'save_params') return;
         let newName = nameInput.value.trim();
         if (!newName.endsWith('.ablpreset') && !newName.endsWith('.json')) {
           newName += '.ablpreset';


### PR DESCRIPTION
## Summary
- update drift editor JS so "Choose Another Preset" doesn't show the overwrite warning when 'Save as new' is checked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684679f97ae08325b12f810a9baf4961