### PR TITLE
Add --overwrite option for update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Everything that it does can be found in `utility-scripts/install-on-move.sh`
 
 #### Updating
 
-To update, you can use the similar `utility-scripts/update-on-move.command` or `utility-scripts/update-on-move.sh` to copy over the files and restart the webserver.
+To update, you can use the similar `utility-scripts/update-on-move.command` or `utility-scripts/update-on-move.sh` to copy over the files and restart the webserver. The script accepts `--dev` to skip installing dependencies and `--overwrite` to remove the existing directory before copying.
 
 ### Manual Installation
 
@@ -151,7 +151,7 @@ Note: Execute these scripts from your computer, not the Move.
 Located in `utility-scripts/`:
 - `setup-ssh-and-install-on-move.command`: Walks through setting up an ssh key, installing files, and setting auto-start
 - `install-on-move.sh` / `.command`: Content installation
-- `update-on-move.sh` / `.command`: Update with latest files
+- `update-on-move.sh` / `.command`: Update with latest files (use `--overwrite` to delete the target before copying)
 - `restart-webserver.sh`: Restart the webserver
 
 

--- a/utility-scripts/update-on-move.command
+++ b/utility-scripts/update-on-move.command
@@ -3,4 +3,4 @@
 cd "$(dirname "$0")"
 
 # Run the Bash script
-sh ./update-on-move.sh
+sh ./update-on-move.sh "$@"

--- a/utility-scripts/update-on-move.sh
+++ b/utility-scripts/update-on-move.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Check for dev mode
+# Check for flags
 DEV_MODE=false
+OVERWRITE=false
 for arg in "$@"; do
-  if [ "$arg" = "--dev" ]; then
-    DEV_MODE=true
-  fi
+  case "$arg" in
+    --dev)
+      DEV_MODE=true
+      ;;
+    --overwrite)
+      OVERWRITE=true
+      ;;
+  esac
 done
 
 # --- Figure out where we live ---
@@ -35,6 +41,10 @@ if ! printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V 
 fi
 
 # --- Ensure remote directory exists ---
+if [ "$OVERWRITE" = true ]; then
+  echo "Overwrite enabled: deleting ${REMOTE_DIR} on ${REMOTE_HOST}…"
+  ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "rm -rf '${REMOTE_DIR}'"
+fi
 echo "Creating ${REMOTE_DIR} on ${REMOTE_HOST}…"
 ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p '${REMOTE_DIR}'"
 


### PR DESCRIPTION
## Summary
- add `--overwrite` flag to `update-on-move.sh`
- pass arguments through `.command` wrapper
- document new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846806c1cc88325a7586bdf01a3abcf