### PR TITLE
Enable wavetable preset editor

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -613,6 +613,17 @@ select {
     margin-top: 0.5rem;
 }
 
+/* Layout for the Wavetable parameter editor */
+.wavetable-param-panels {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.wavetable-param-panels + .wavetable-param-panels {
+    margin-top: 0.5rem;
+}
+
 .param-panel {
     border: 1px solid #ccc;
     padding: 0.5rem;

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -14,7 +14,7 @@
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
         <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Drift</a>
-        <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
+        <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
     </nav>


### PR DESCRIPTION
## Summary
- link to wavetable preset editor from navigation
- style Wavetable parameter panels like the Drift editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68468286a4508325813e7edbc9a546c7