### PR TITLE
Improve Wavetable UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -613,6 +613,17 @@ select {
     margin-top: 0.5rem;
 }
 
+/* Layout for the Wavetable parameter editor */
+.wavetable-param-panels {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.wavetable-param-panels + .wavetable-param-panels {
+    margin-top: 0.5rem;
+}
+
 .param-panel {
     border: 1px solid #ccc;
     padding: 0.5rem;


### PR DESCRIPTION
## Summary
- simplify wavetable parameter layout logic
- group wavetable parameters by raw names
- support friendlier fallback labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684683f0ec3c8325a8283e06507d53c8