### PR TITLE
Add wavetable sprite selection

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -533,6 +533,9 @@ def wavetable_params():
     available_params_json = result.get("available_params_json", "[]")
     param_paths_json = result.get("param_paths_json", "{}")
     schema_json = result.get("schema_json", "{}")
+    sprite_options = result.get("sprite_options", [])
+    sprite1_val = result.get("sprite1")
+    sprite2_val = result.get("sprite2")
     preset_selected = bool(selected_preset)
     return render_template(
         "wavetable_params.html",
@@ -553,6 +556,9 @@ def wavetable_params():
         available_params_json=available_params_json,
         param_paths_json=param_paths_json,
         schema_json=schema_json,
+        sprite_options=sprite_options,
+        sprite1=sprite1_val,
+        sprite2=sprite2_val,
         active_tab="wavetable-params",
     )
 

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -75,6 +75,22 @@
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
         <button type="button" id="randomize-btn">Randomize</button>
     </div>
+    <div class="sprite-selects">
+        <label>Osc 1 Sprite:
+            <select name="sprite1" id="sprite1-select">
+            {% for name, uri in sprite_options %}
+                <option value="{{ uri }}" {% if sprite1 == uri %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+            </select>
+        </label>
+        <label>Osc 2 Sprite:
+            <select name="sprite2" id="sprite2-select">
+            {% for name, uri in sprite_options %}
+                <option value="{{ uri }}" {% if sprite2 == uri %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+            </select>
+        </label>
+    </div>
     <div class="macro-knobs-section">
         <h3>Macros</h3>
         {{ macro_knobs_html | safe }}
@@ -137,6 +153,14 @@ document.addEventListener('DOMContentLoaded', () => {
     form.querySelectorAll('input[type="hidden"][name^="param_"], input[type="hidden"][name^="macro_"]').forEach(inp => {
       initialValues[inp.name] = inp.value;
       inp.addEventListener('change', updateSaveState);
+    });
+    const s1 = document.getElementById('sprite1-select');
+    const s2 = document.getElementById('sprite2-select');
+    [s1, s2].forEach(sel => {
+      if (sel) {
+        initialValues[sel.name] = sel.value;
+        sel.addEventListener('change', updateSaveState);
+      }
     });
   }
 

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -16,7 +16,11 @@ from core.midi_pattern_generator import (
     generate_pattern_set,
     create_c_major_downbeats,
 )
-from core.synth_param_editor_handler import update_parameter_values
+from core.synth_param_editor_handler import (
+    update_parameter_values,
+    update_wavetable_sprites,
+    get_wavetable_sprites,
+)
 
 
 def test_reverse_wav_file(tmp_path):
@@ -235,4 +239,21 @@ def test_remove_macro_name(tmp_path):
     with open(preset_copy) as f:
         data = json.load(f)
     assert "customName" not in data["chains"][0]["devices"][0]["parameters"]["Macro0"]
+
+
+def test_update_wavetable_sprites(tmp_path):
+    src = Path("examples/Track Presets/Wavetable/E-Piano Classic.ablpreset")
+    dest = tmp_path / "out.ablpreset"
+    result = update_wavetable_sprites(
+        str(src),
+        {
+            "spriteUri1": "ableton:/device-resources/wavetable-sprites/Miniwaves",
+            "spriteUri2": "ableton:/device-resources/wavetable-sprites/Sub%201",
+        },
+        str(dest),
+    )
+    assert result["success"], result.get("message")
+    info = get_wavetable_sprites(str(dest))
+    assert info["spriteUri1"].endswith("Miniwaves")
+    assert info["spriteUri2"].endswith("Sub%201")
 


### PR DESCRIPTION
## Summary
- implement `get_wavetable_sprites` and `update_wavetable_sprites`
- expose sprite choices in Wavetable parameter editor
- save chosen sprites back into the preset
- update UI and JS to handle sprite fields
- add unit tests for sprite updating

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468cce69388325b6c087662bc57eaa