### PR TITLE
Group wavetable filter parameters

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -635,6 +635,42 @@ class WavetableParamEditorHandler(BaseHandler):
             return "Global"
         return "Other"
 
+    def _arrange_filter_panel(self, items: dict) -> list:
+        """Return filter panel HTML arranged into sensible rows."""
+        ordered = []
+        row1 = "".join([
+            items.pop("On", ""),
+            items.pop("Frequency", ""),
+            items.pop("Resonance", ""),
+        ])
+        if row1:
+            ordered.append(f'<div class="param-row">{row1}</div>')
+
+        row2 = "".join([
+            items.pop("Drive", ""),
+            items.pop("Morph", ""),
+        ])
+        if row2:
+            ordered.append(f'<div class="param-row">{row2}</div>')
+
+        row3 = "".join([
+            items.pop("Type", ""),
+            items.pop("Slope", ""),
+        ])
+        if row3:
+            ordered.append(f'<div class="param-row">{row3}</div>')
+
+        row4 = "".join([
+            items.pop("CircuitBpNoMo", ""),
+            items.pop("CircuitLpHp", ""),
+        ])
+        if row4:
+            ordered.append(f'<div class="param-row">{row4}</div>')
+
+        if items:
+            ordered.extend(items.values())
+        return ordered
+
     def generate_params_html(self, params, mapped_parameters=None):
         """Return HTML controls for the given parameter values."""
         if not params:
@@ -646,7 +682,7 @@ class WavetableParamEditorHandler(BaseHandler):
         schema = load_wavetable_schema()
         sections = {s: [] for s in self.SECTION_ORDER}
         subpanels = {
-            sec: {lbl: [] for _, lbl, _ in self.SECTION_SUBPANELS.get(sec, [])}
+            sec: {lbl: {} for _, lbl, _ in self.SECTION_SUBPANELS.get(sec, [])}
             for sec in self.SECTION_SUBPANELS
         }
 
@@ -683,7 +719,7 @@ class WavetableParamEditorHandler(BaseHandler):
                             slider=slider,
                             extra_classes=extra,
                         )
-                        subpanels[sec][panel_lbl].append(html)
+                        subpanels[sec][panel_lbl][base] = html
                         assigned = True
                         break
 
@@ -705,9 +741,14 @@ class WavetableParamEditorHandler(BaseHandler):
                 items = subpanels.get(sec, {}).get(label)
                 if items:
                     cls = label.lower().replace(" ", "-")
+                    content = []
+                    if sec == "Filter":
+                        content = self._arrange_filter_panel(items)
+                    else:
+                        content = list(items.values())
                     panel_items.append(
                         f'<div class="param-subpanel {cls}"><h4>{label}</h4>'
-                        f'<div class="param-items">{"".join(items)}</div></div>'
+                        f'<div class="param-items">{"".join(content)}</div></div>'
                     )
             if sections.get(sec):
                 panel_items.extend(sections[sec])

--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -681,7 +681,7 @@ class WavetableParamEditorHandler(BaseHandler):
 
         schema = load_wavetable_schema()
         sections = {s: [] for s in self.SECTION_ORDER}
-        subpanels = {
+        subgroups = {
             sec: {lbl: {} for _, lbl, _ in self.SECTION_SUBPANELS.get(sec, [])}
             for sec in self.SECTION_SUBPANELS
         }
@@ -719,7 +719,7 @@ class WavetableParamEditorHandler(BaseHandler):
                             slider=slider,
                             extra_classes=extra,
                         )
-                        subpanels[sec][panel_lbl][base] = html
+                        subgroups[sec][panel_lbl][base] = html
                         assigned = True
                         break
 
@@ -736,24 +736,21 @@ class WavetableParamEditorHandler(BaseHandler):
                 sections.setdefault(sec, []).append(html)
 
         for sec, groups in self.SECTION_SUBPANELS.items():
-            panel_items = []
+            group_items = []
             for _prefix, label, _ in groups:
-                items = subpanels.get(sec, {}).get(label)
+                items = subgroups.get(sec, {}).get(label)
                 if items:
-                    cls = label.lower().replace(" ", "-")
-                    content = []
-                    if sec == "Filter":
-                        content = self._arrange_filter_panel(items)
-                    else:
-                        content = list(items.values())
-                    panel_items.append(
-                        f'<div class="param-subpanel {cls}"><h4>{label}</h4>'
-                        f'<div class="param-items">{"".join(content)}</div></div>'
+                    group_items.append(
+                        f'<div class="param-group-label">{label}</div>'
                     )
+                    if sec == "Filter":
+                        group_items.extend(self._arrange_filter_panel(items))
+                    else:
+                        group_items.extend(items.values())
             if sections.get(sec):
-                panel_items.extend(sections[sec])
-            if panel_items:
-                sections[sec] = panel_items
+                group_items.extend(sections[sec])
+            if group_items:
+                sections[sec] = group_items
 
         out_html = '<div class="wavetable-param-panels">'
         bottom_panels = []

--- a/static/style.css
+++ b/static/style.css
@@ -672,27 +672,13 @@ select {
     flex-direction: column;
 }
 
-.param-subpanel {
-    border: 1px solid #ccc;
-    padding: 0.25rem;
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 0.5rem;
-}
 
-.param-subpanel:last-child {
-    margin-bottom: 0;
-}
-
-.param-subpanel h4 {
-    margin: 0 0 0.25rem 0;
-    font-size: 0.9rem;
-    text-align: center;
-}
-
-.param-subpanel .param-items {
-    display: flex;
-    flex-direction: column;
+.param-group-label {
+    width: 100%;
+    text-align: left;
+    margin-left: 10px;
+    font-weight: bold;
+    margin-top: 0.5rem;
 }
 
 .param-row {

--- a/static/style.css
+++ b/static/style.css
@@ -672,6 +672,24 @@ select {
     flex-direction: column;
 }
 
+.param-subpanel {
+    border: 1px solid #ccc;
+    padding: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.5rem;
+}
+
+.param-subpanel:last-child {
+    margin-bottom: 0;
+}
+
+.param-subpanel h4 {
+    margin: 0 0 0.25rem 0;
+    font-size: 0.9rem;
+    text-align: center;
+}
+
 .param-row {
     display: flex;
     gap: 0.5rem;

--- a/static/style.css
+++ b/static/style.css
@@ -690,6 +690,11 @@ select {
     text-align: center;
 }
 
+.param-subpanel .param-items {
+    display: flex;
+    flex-direction: column;
+}
+
 .param-row {
     display: flex;
     gap: 0.5rem;


### PR DESCRIPTION
## Summary
- group filter parameters inside the wavetable parameter editor
- show sub-panels for Voice Filter 1 and Voice Filter 2
- style new sub-panels in CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469adc165c8325bf548082f928a058