### PR TITLE
Fix Wavetable macro label parsing

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -809,15 +809,12 @@ class WavetableParamEditorHandler(BaseHandler):
             """Return a human-friendly version of a parameter name."""
             if not name:
                 return name
-            parts = name.split("_", 1)
-            if len(parts) == 2:
-                group, param = parts
-                group = re.sub(r"([A-Za-z])([0-9])", r"\1 \2", group)
-                group = re.sub(r"([a-z])([A-Z])", r"\1 \2", group)
-                param = re.sub(r"([A-Za-z])([0-9])", r"\1 \2", param)
-                param = re.sub(r"([a-z])([A-Z])", r"\1 \2", param)
-                return f"{group}: {param}"
-            return re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
+            parts = [
+                re.sub(r"([a-z])([A-Z])", r"\1 \2",
+                       re.sub(r"([A-Za-z])([0-9])", r"\1 \2", p))
+                for p in name.split("_")
+            ]
+            return ": ".join(parts)
 
         by_index = {m["index"]: m for m in macros}
         html = ['<div class="macro-knob-row">']

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -13,13 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   function friendly(name) {
     if (!name) return '';
-    const parts = name.split('_');
-    if (parts.length >= 2) {
-      const group = addSpaces(parts[0]);
-      const rest = addSpaces(parts.slice(1).join('_'));
-      return `${group}: ${rest}`;
-    }
-    return addSpaces(name);
+    return name
+      .split('_')
+      .map(p => addSpaces(p))
+      .join(': ');
   }
   availableParams.forEach(p => {
     paramDisplay[p] = friendly(p);


### PR DESCRIPTION
## Summary
- show full path for Wavetable macro parameter names
- match friendly-name parsing in JS macro sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a607a1b48325876ba7edf8244f91