### PR TITLE
Improve wavetable filter UI

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -709,37 +709,33 @@ class WavetableParamEditorHandler(BaseHandler):
         return "Other"
 
     def _arrange_filter_panel(self, items: dict) -> list:
-        """Return filter panel HTML arranged into sensible rows."""
+        """Return filter panel HTML arranged into a single row."""
         ordered = []
         sample = next(iter(items.values()), "")
         match = re.search(r"Voice_Filter(\d)_", sample)
         idx = match.group(1) if match else "1"
 
-        row_on = items.pop("On", "")
-        if row_on:
-            ordered.append(f'<div class="param-row">{row_on}</div>')
-
-        row_type = items.pop("Type", "")
-        if row_type:
-            ordered.append(f'<div class="param-row">{row_type}</div>')
-
-        row_slope = items.pop("Slope", "")
-        if row_slope:
-            ordered.append(f'<div class="param-row">{row_slope}</div>')
-
-        row_fr = "".join([
-            items.pop("Frequency", ""),
-            items.pop("Resonance", ""),
-            items.pop("Drive", ""),
-        ])
-        if row_fr:
-            ordered.append(f'<div class="param-row">{row_fr}</div>')
-
+        on = items.pop("On", "")
+        f_type = items.pop("Type", "")
+        slope = items.pop("Slope", "")
+        freq = items.pop("Frequency", "")
+        res = items.pop("Resonance", "")
+        drive = items.pop("Drive", "")
         morph = items.pop("Morph", "")
+
+        stack = "".join([on, f_type, slope])
+        column = f'<div class="param-column">{stack}</div>' if stack.strip() else ""
+
         if morph:
-            ordered.append(
-                f'<div class="param-row filter-morph-row filter{idx}-morph-row hidden">{morph}</div>'
+            morph = morph.replace(
+                'param-item"',
+                f'param-item filter-morph filter{idx}-morph hidden"',
+                1,
             )
+
+        row = f"{column}{freq}{res}{drive}{morph}"
+        if row.strip():
+            ordered.append(f'<div class="param-row">{row}</div>')
 
         items.pop("CircuitBpNoMo", None)
         items.pop("CircuitLpHp", None)

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -168,10 +168,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const match = sel.parentElement.dataset.name.match(/Voice_Filter(\d)_/);
         if (!match) return;
         const idx = match[1];
-        const morphRow = sel.closest('.param-items').querySelector(`.filter${idx}-morph-row`);
+        const morphEl = sel.closest('.param-items').querySelector(`.filter${idx}-morph`);
         function updateMorph() {
-            if (!morphRow) return;
-            morphRow.classList.toggle('hidden', sel.value !== 'Morph');
+            if (!morphEl) return;
+            morphEl.classList.toggle('hidden', sel.value !== 'Morph');
         }
         sel.addEventListener('change', updateMorph);
         updateMorph();

--- a/static/style.css
+++ b/static/style.css
@@ -760,7 +760,7 @@ select {
 }
 
 .filter-type-select {
-    width: 48px;
+    width: 80px;
 }
   
 .param-item {


### PR DESCRIPTION
## Summary
- show filter controls in a single row in wavetable editor
- toggle morph knob visibility on the item itself
- enlarge filter type dropdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b272568083259091b6b12fe74a24