### PR TITLE
Enable double-click reset for knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Tools for extending the Ableton Move. This project provides a companion webserve
   - Save changes as a new preset file
   - Numeric parameters use sliders with an input field
   - Slider steps are 0.01 for values near ±1 and adapt to the parameter's default precision
+  - Double-click a slider or knob to reset it to its default value (0 if unspecified)
   - Enum parameters provide a dropdown of options
   - Create new presets starting from the included Analog Shape example
  

--- a/static/input-knobs.js
+++ b/static/input-knobs.js
@@ -123,6 +123,7 @@ input[type=checkbox].input-switch:checked,input[type=radio].input-switch:checked
   };
   let initKnobs=(el)=>{
     let w,h,d,fg,bg;
+    const defaultValue = el.dataset.default !== undefined ? parseFloat(el.dataset.default) : 0;
     if(el.inputKnobs){
       el.redraw();
       return;
@@ -322,10 +323,15 @@ input[type=checkbox].input-switch:checked,input[type=radio].input-switch:checked
     el.refresh();
     el.redraw(true);
     el.addEventListener("keydown",ik.keydown);
-    el.addEventListener("mousedown",ik.pointerdown);
-    el.addEventListener("touchstart",ik.pointerdown);
-    el.addEventListener("wheel",ik.wheel);
-  }
+      el.addEventListener("mousedown",ik.pointerdown);
+      el.addEventListener("touchstart",ik.pointerdown);
+      el.addEventListener("wheel",ik.wheel);
+      el.addEventListener("dblclick", () => {
+        const clamped = Math.max(ik.valrange.min, Math.min(ik.valrange.max, defaultValue));
+        el.setValue(clamped);
+        el.dispatchEvent(new Event("change"));
+      });
+    }
   let refreshque=()=>{
     let elem=document.querySelectorAll("input.input-knob,input.input-slider");
     for(let i=0;i<elem.length;++i)

--- a/static/rect-slider.js
+++ b/static/rect-slider.js
@@ -7,6 +7,7 @@ function initSlider(el){
   const max=parseFloat(el.dataset.max||1);
   const step=parseFloat(el.dataset.step||1);
   const unit=el.dataset.unit||'';
+  const defaultValue=el.dataset.default!==undefined?parseFloat(el.dataset.default):0;
   function getStep(v){
     return getPercentStep(v, unit, step, shouldScale);
   }
@@ -105,6 +106,10 @@ function initSlider(el){
   }
   el.addEventListener('mousedown',start);
   el.addEventListener('touchstart',start);
+  el.addEventListener('dblclick',()=>{
+    value=clamp(defaultValue,min,max);
+    update();
+  });
   el.addEventListener('keydown',(e)=>{
     if(['ArrowUp','ArrowRight'].includes(e.key)){
       let st=getStep(value);


### PR DESCRIPTION
## Summary
- make knobs resettable by double-click just like sliders
- document knob reset in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846c8fb55b883259cdfa9bcfde91e4f