### PR TITLE
Add modulation matrix UI

### DIFF
--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -7,6 +7,7 @@ function initModMatrix() {
   const headers = [
     'Amp Env','Env 2','Env 3','LFO 1','LFO 2','Velocity','Key','Pitch Bend','Pressure','Mod Wheel','Random'
   ];
+  if (!matrixInput || !tableBody) return;
   let matrix = [];
   try { matrix = JSON.parse(matrixInput.value || '[]'); } catch (e) {}
 

--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -1,0 +1,94 @@
+// Modulation matrix UI script
+function initModMatrix() {
+  const matrixInput = document.getElementById('mod-matrix-data-input');
+  const addBtn = document.getElementById('mod-matrix-add');
+  const tableBody = document.querySelector('#mod-matrix-table tbody');
+  const paramList = JSON.parse(document.getElementById('available-params-input')?.value || '[]');
+  const headers = [
+    'Amp Env','Env 2','Env 3','LFO 1','LFO 2','Velocity','Key','Pitch Bend','Pressure','Mod Wheel','Random'
+  ];
+  let matrix = [];
+  try { matrix = JSON.parse(matrixInput.value || '[]'); } catch (e) {}
+
+  function buildSelect(name) {
+    const sel = document.createElement('select');
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'Choose…';
+    sel.appendChild(opt);
+    paramList.forEach(p => {
+      const o = document.createElement('option');
+      o.value = p;
+      o.textContent = p;
+      sel.appendChild(o);
+    });
+    sel.value = name || '';
+    return sel;
+  }
+
+  function buildRow(row, idx) {
+    const tr = document.createElement('tr');
+    const tdSel = document.createElement('td');
+    const sel = buildSelect(row.name);
+    tdSel.appendChild(sel);
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => {
+      matrix.splice(idx, 1);
+      save();
+      rebuild();
+    });
+    tdSel.appendChild(removeBtn);
+    tr.appendChild(tdSel);
+
+    row.values = row.values || Array(headers.length).fill(0);
+    row.values.forEach((v, col) => {
+      const td = document.createElement('td');
+      const slider = document.createElement('div');
+      slider.className = 'rect-slider center';
+      slider.dataset.min = '-1';
+      slider.dataset.max = '1';
+      slider.dataset.step = '0.01';
+      slider.dataset.value = v;
+      slider.addEventListener('change', () => {
+        row.values[col] = parseFloat(slider.querySelector('input')?.value || 0);
+        save();
+      });
+      td.appendChild(slider);
+      tr.appendChild(td);
+    });
+
+    sel.addEventListener('change', () => {
+      row.name = sel.value;
+      save();
+    });
+
+    return tr;
+  }
+
+  function rebuild() {
+    tableBody.innerHTML = '';
+    matrix.forEach((row, idx) => {
+      tableBody.appendChild(buildRow(row, idx));
+    });
+    if (window.initRectSliders) window.initRectSliders();
+  }
+
+  function save() {
+    matrixInput.value = JSON.stringify(matrix);
+    matrixInput.dispatchEvent(new Event('change'));
+  }
+
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      matrix.push({ name: '', values: Array(headers.length).fill(0) });
+      save();
+      rebuild();
+    });
+  }
+
+  rebuild();
+}
+
+document.addEventListener('DOMContentLoaded', initModMatrix);

--- a/static/rect-slider.js
+++ b/static/rect-slider.js
@@ -1,4 +1,4 @@
-(function(){
+(function(global){
 function clamp(v,min,max){return v<min?min:v>max?max:v;}
 function initSlider(el){
   if(el._sliderInit)return;
@@ -121,7 +121,10 @@ function initSlider(el){
   update();
 }
 
-document.addEventListener('DOMContentLoaded',()=>{
+function initAll(){
   document.querySelectorAll('.rect-slider').forEach(initSlider);
-});
-})();
+}
+global.initRectSlider = initSlider;
+global.initRectSliders = initAll;
+document.addEventListener('DOMContentLoaded', initAll);
+})(window);

--- a/static/style.css
+++ b/static/style.css
@@ -988,6 +988,24 @@ button#macro-add-param {
     max-width: 100%;
 }
 
+/* Modulation matrix table */
+#mod-matrix-section {
+    margin-top: 1rem;
+}
+#mod-matrix-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.8rem;
+}
+#mod-matrix-table th,
+#mod-matrix-table td {
+    padding: 0.25rem;
+    text-align: center;
+}
+#mod-matrix-table td:first-child {
+    text-align: left;
+}
+
 
 /* Modulation matrix control radius overrides */
 .param-panel.modulation .mod-matrix-row .param-item:nth-of-type(1) .param-select {

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -95,6 +95,31 @@
     <div class="param-list">
         {{ params_html | safe }}
     </div>
+
+    <div id="mod-matrix-section">
+        <h3>Modulation Matrix</h3>
+        <input type="hidden" id="mod-matrix-data-input" name="mod_matrix_data" value="[]">
+        <table id="mod-matrix-table">
+            <thead>
+                <tr>
+                    <th>Destination</th>
+                    <th>Amp Env</th>
+                    <th>Env 2</th>
+                    <th>Env 3</th>
+                    <th>LFO 1</th>
+                    <th>LFO 2</th>
+                    <th>Velocity</th>
+                    <th>Key</th>
+                    <th>Pitch Bend</th>
+                    <th>Pressure</th>
+                    <th>Mod Wheel</th>
+                    <th>Random</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <button type="button" id="mod-matrix-add">Add Row</button>
+    </div>
 </form>
 
 {% endif %}
@@ -114,6 +139,7 @@
 window.driftSchema = {{ schema_json|safe }};
 </script>
 <script src="{{ host_prefix }}/static/macro_sidebar.js"></script>
+<script src="{{ host_prefix }}/static/mod_matrix.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -96,30 +96,6 @@
         {{ params_html | safe }}
     </div>
 
-    <div id="mod-matrix-section">
-        <h3>Modulation Matrix</h3>
-        <input type="hidden" id="mod-matrix-data-input" name="mod_matrix_data" value="[]">
-        <table id="mod-matrix-table">
-            <thead>
-                <tr>
-                    <th>Destination</th>
-                    <th>Amp Env</th>
-                    <th>Env 2</th>
-                    <th>Env 3</th>
-                    <th>LFO 1</th>
-                    <th>LFO 2</th>
-                    <th>Velocity</th>
-                    <th>Key</th>
-                    <th>Pitch Bend</th>
-                    <th>Pressure</th>
-                    <th>Mod Wheel</th>
-                    <th>Random</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-        <button type="button" id="mod-matrix-add">Add Row</button>
-    </div>
 </form>
 
 {% endif %}
@@ -139,7 +115,6 @@
 window.driftSchema = {{ schema_json|safe }};
 </script>
 <script src="{{ host_prefix }}/static/macro_sidebar.js"></script>
-<script src="{{ host_prefix }}/static/mod_matrix.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -95,6 +95,31 @@
     <div class="param-list">
         {{ params_html | safe }}
     </div>
+
+    <div id="mod-matrix-section">
+        <h3>Modulation Matrix</h3>
+        <input type="hidden" id="mod-matrix-data-input" name="mod_matrix_data" value="[]">
+        <table id="mod-matrix-table">
+            <thead>
+                <tr>
+                    <th>Destination</th>
+                    <th>Amp Env</th>
+                    <th>Env 2</th>
+                    <th>Env 3</th>
+                    <th>LFO 1</th>
+                    <th>LFO 2</th>
+                    <th>Velocity</th>
+                    <th>Key</th>
+                    <th>Pitch Bend</th>
+                    <th>Pressure</th>
+                    <th>Mod Wheel</th>
+                    <th>Random</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <button type="button" id="mod-matrix-add">Add Row</button>
+    </div>
 </form>
 
 {% endif %}
@@ -114,6 +139,7 @@
 window.driftSchema = {{ schema_json|safe }};
 </script>
 <script src="{{ host_prefix }}/static/macro_sidebar.js"></script>
+<script src="{{ host_prefix }}/static/mod_matrix.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');


### PR DESCRIPTION
## Summary
- expose `initRectSlider` and `initRectSliders` from `rect-slider.js`
- add a simple modulation matrix table to the Drift editor
- style the modulation matrix table
- implement basic JS to manage rows in the modulation matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846eaf8c7b883259b1a1a9c66913efe