### PR TITLE
Improve random patch generation

### DIFF
--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -27,6 +27,18 @@ function randomizeParams() {
     if (param === 'Filter_Frequency') refs.cutoff = dial || slider;
     if (param === 'Global_Volume') refs.volume = dial || slider;
 
+    if (param === 'Global_Volume') {
+      const vol = 1.0;
+      if (dial) {
+        dial.value = vol;
+        dial.dispatchEvent(new Event('input'));
+      } else if (slider) {
+        slider.dataset.value = vol;
+        if (typeof slider._sliderUpdate === 'function') slider._sliderUpdate(vol);
+      }
+      return;
+    }
+
     if (dial) {
       const min = parseFloat(dial.min || '0');
       const max = parseFloat(dial.max || '1');
@@ -35,7 +47,6 @@ function randomizeParams() {
       const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
       let lo = min;
       if (param === 'Mixer_OscillatorGain1' || param === 'Mixer_OscillatorGain2') lo = Math.max(min, 0.3);
-      if (param === 'Global_Volume') lo = Math.max(min, 0.4);
       if (param === 'Filter_Frequency') lo = Math.max(min, 100);
       let val = Math.random() * (max - lo) + lo;
       const st = getPercentStep(val, unit, step, shouldScale);
@@ -57,7 +68,6 @@ function randomizeParams() {
       const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
       let lo = min;
       if (param === 'Mixer_OscillatorGain1' || param === 'Mixer_OscillatorGain2') lo = Math.max(min, 0.3);
-      if (param === 'Global_Volume') lo = Math.max(min, 0.4);
       if (param === 'Filter_Frequency') lo = Math.max(min, 100);
       let val = Math.random() * (max - lo) + lo;
       const st = getPercentStep(val, unit, step, shouldScale);
@@ -71,6 +81,36 @@ function randomizeParams() {
     const pick = Math.random() < 0.5 ? refs.oscOn1 : refs.oscOn2;
     pick.checked = true;
     pick.dispatchEvent(new Event('change'));
+  }
+
+  function getVal(ctrl) {
+    if (!ctrl) return 0;
+    if (ctrl.classList && ctrl.classList.contains('rect-slider')) {
+      return parseFloat(ctrl.dataset.value || '0');
+    }
+    return parseFloat(ctrl.value || '0');
+  }
+
+  function setVal(ctrl, v) {
+    if (!ctrl) return;
+    if (ctrl.classList && ctrl.classList.contains('rect-slider')) {
+      ctrl.dataset.value = v;
+      if (typeof ctrl._sliderUpdate === 'function') ctrl._sliderUpdate(v);
+    } else {
+      ctrl.value = v;
+      ctrl.dispatchEvent(new Event('input'));
+    }
+  }
+
+  if (refs.gain1 || refs.gain2) {
+    const g1 = getVal(refs.gain1);
+    const g2 = getVal(refs.gain2);
+    const maxG = Math.max(g1, g2);
+    if (maxG > 0 && maxG !== 1) {
+      const factor = 1 / maxG;
+      if (refs.gain1) setVal(refs.gain1, Math.min(g1 * factor, 1));
+      if (refs.gain2) setVal(refs.gain2, Math.min(g2 * factor, 1));
+    }
   }
 
   const saveBtn = document.getElementById('save-params-btn');

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -12,11 +12,20 @@ function initNewPresetModal() {
 }
 
 function randomizeParams() {
+  const refs = {};
   document.querySelectorAll('.param-item').forEach(item => {
+    const param = item.dataset.name;
     const dial = item.querySelector('input.param-dial');
     const select = item.querySelector('select.param-select');
     const toggle = item.querySelector('input.param-toggle');
     const slider = item.querySelector('.rect-slider');
+
+    if (param === 'Mixer_OscillatorOn1') refs.oscOn1 = toggle;
+    if (param === 'Mixer_OscillatorOn2') refs.oscOn2 = toggle;
+    if (param === 'Mixer_OscillatorGain1') refs.gain1 = dial || slider;
+    if (param === 'Mixer_OscillatorGain2') refs.gain2 = dial || slider;
+    if (param === 'Filter_Frequency') refs.cutoff = dial || slider;
+    if (param === 'Global_Volume') refs.volume = dial || slider;
 
     if (dial) {
       const min = parseFloat(dial.min || '0');
@@ -24,7 +33,11 @@ function randomizeParams() {
       const step = parseFloat(dial.step || '1');
       const unit = dial.dataset.unit || '';
       const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
-      const val = Math.random() * (max - min) + min;
+      let lo = min;
+      if (param === 'Mixer_OscillatorGain1' || param === 'Mixer_OscillatorGain2') lo = Math.max(min, 0.3);
+      if (param === 'Global_Volume') lo = Math.max(min, 0.4);
+      if (param === 'Filter_Frequency') lo = Math.max(min, 100);
+      let val = Math.random() * (max - lo) + lo;
       const st = getPercentStep(val, unit, step, shouldScale);
       const q = Math.round((val - min) / st) * st + min;
       dial.value = q;
@@ -42,13 +55,24 @@ function randomizeParams() {
       const step = parseFloat(slider.dataset.step || '1');
       const unit = slider.dataset.unit || '';
       const shouldScale = unit === '%' && Math.abs(max) <= 1 && Math.abs(min) <= 1;
-      let val = Math.random() * (max - min) + min;
+      let lo = min;
+      if (param === 'Mixer_OscillatorGain1' || param === 'Mixer_OscillatorGain2') lo = Math.max(min, 0.3);
+      if (param === 'Global_Volume') lo = Math.max(min, 0.4);
+      if (param === 'Filter_Frequency') lo = Math.max(min, 100);
+      let val = Math.random() * (max - lo) + lo;
       const st = getPercentStep(val, unit, step, shouldScale);
       val = Math.round((val - min) / st) * st + min;
       slider.dataset.value = val;
       if (typeof slider._sliderUpdate === 'function') slider._sliderUpdate(val);
     }
   });
+
+  if (refs.oscOn1 && refs.oscOn2 && !refs.oscOn1.checked && !refs.oscOn2.checked) {
+    const pick = Math.random() < 0.5 ? refs.oscOn1 : refs.oscOn2;
+    pick.checked = true;
+    pick.dispatchEvent(new Event('change'));
+  }
+
   const saveBtn = document.getElementById('save-params-btn');
   if (saveBtn) saveBtn.disabled = false;
 }


### PR DESCRIPTION
## Summary
- enforce minimum values for volume, oscillator levels, and filter cutoff when randomizing
- ensure at least one oscillator remains enabled after randomization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472ee8f85c8325b5e8ff6dfadd886f