### PR TITLE
Fix mod matrix layout

### DIFF
--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -141,6 +141,7 @@ function initModMatrix() {
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.textContent = 'X';
+    removeBtn.className = 'mod-matrix-remove';
     removeBtn.addEventListener('click', () => {
       matrix.splice(idx, 1);
       save();

--- a/static/style.css
+++ b/static/style.css
@@ -1065,6 +1065,15 @@ button#macro-add-param {
 }
 #mod-matrix-table td:first-child {
     text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+#mod-matrix-table td:first-child .nested-dropdown {
+    flex-grow: 1;
+}
+#mod-matrix-table td:first-child .mod-matrix-remove {
+    margin-left: 0.25rem;
 }
 
 


### PR DESCRIPTION
## Summary
- keep X button inline with dropdown in the modulation matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b9d508b08325a714bae39d4be93d