### PR TITLE
Align mod matrix remove button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1076,6 +1076,9 @@ button#macro-add-param {
 }
 #mod-matrix-table td:first-child {
     text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
 }
 
 


### PR DESCRIPTION
## Summary
- tweak CSS layout so the remove `X` button is inline with the dropdown in the modulation matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bc4e46b88325beb7233a750761b8