### PR TITLE
Add wavetable mod matrix editing support

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -18,6 +18,8 @@ from core.synth_preset_inspector_handler import (
     load_wavetable_sprites,
     extract_wavetable_sprites,
     update_wavetable_sprites,
+    extract_wavetable_mod_matrix,
+    update_wavetable_mod_matrix,
 )
 from core.synth_param_editor_handler import (
     update_parameter_values,
@@ -108,6 +110,7 @@ class WavetableParamEditorHandler(BaseHandler):
             'sprites_json': json.dumps(sprites),
             'sprite1': '',
             'sprite2': '',
+            'mod_matrix_json': '[]',
         }
 
     def handle_post(self, form):
@@ -249,6 +252,18 @@ class WavetableParamEditorHandler(BaseHandler):
             if not sprite_res['success']:
                 return self.format_error_response(sprite_res['message'])
 
+            matrix_str = form.getvalue('mod_matrix_data')
+            if matrix_str:
+                try:
+                    matrix_data = json.loads(matrix_str)
+                except Exception:
+                    matrix_data = []
+            else:
+                matrix_data = []
+            matrix_res = update_wavetable_mod_matrix(preset_path, matrix_data, preset_path)
+            if not matrix_res['success']:
+                return self.format_error_response(matrix_res['message'])
+
             message = result['message'] + "; " + macro_result['message']
             if output_path:
                 message += f" Saved to {output_path}"
@@ -326,6 +341,8 @@ class WavetableParamEditorHandler(BaseHandler):
         sprite_info = extract_wavetable_sprites(preset_path)
         sprite1 = sprite_info.get('sprite1') if sprite_info.get('success', True) else None
         sprite2 = sprite_info.get('sprite2') if sprite_info.get('success', True) else None
+        matrix_info = extract_wavetable_mod_matrix(preset_path)
+        mod_matrix_json = json.dumps(matrix_info.get('matrix', [])) if matrix_info.get('success', False) else '[]'
         return {
             'message': message,
             'message_type': 'success',
@@ -343,6 +360,7 @@ class WavetableParamEditorHandler(BaseHandler):
             'available_params_json': available_params_json,
             'param_paths_json': param_paths_json,
             'sprites_json': sprites_json,
+            'mod_matrix_json': mod_matrix_json,
             'sprite1': sprite1 or '',
             'sprite2': sprite2 or '',
         }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -539,6 +539,7 @@ def wavetable_params():
     sprites_json = result.get("sprites_json", "[]")
     sprite1 = result.get("sprite1", "")
     sprite2 = result.get("sprite2", "")
+    mod_matrix_json = result.get("mod_matrix_json", "[]")
     preset_selected = bool(selected_preset)
     return render_template(
         "wavetable_params.html",
@@ -560,6 +561,7 @@ def wavetable_params():
         param_paths_json=param_paths_json,
         schema_json=schema_json,
         sprites_json=sprites_json,
+        mod_matrix_json=mod_matrix_json,
         sprite1=sprite1,
         sprite2=sprite2,
         active_tab="wavetable-params",

--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -150,6 +150,7 @@ function initModMatrix() {
     tr.appendChild(tdSel);
 
     row.values = row.values || Array(headers.length).fill(0);
+    row.extra = row.extra || [];
     row.values.forEach((v, col) => {
       const td = document.createElement('td');
       td.className = 'mod-source-cell';
@@ -185,7 +186,7 @@ function initModMatrix() {
 
   if (addBtn) {
     addBtn.addEventListener('click', () => {
-      matrix.push({ name: '', values: Array(headers.length).fill(0) });
+      matrix.push({ name: '', values: Array(headers.length).fill(0), extra: [] });
       save();
       rebuild();
     });

--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -160,11 +160,21 @@ function initModMatrix() {
       slider.dataset.max = '1';
       slider.dataset.step = '0.01';
       slider.dataset.value = v;
-      slider.addEventListener('change', () => {
-        row.values[col] = parseFloat(slider.querySelector('input')?.value || 0);
+
+      const hidden = document.createElement('input');
+      hidden.type = 'hidden';
+      hidden.value = v;
+      const hidId = `mod-mtx-${idx}-${col}`;
+      hidden.id = hidId;
+      slider.dataset.target = hidId;
+
+      hidden.addEventListener('change', () => {
+        row.values[col] = parseFloat(hidden.value || 0);
         save();
       });
+
       td.appendChild(slider);
+      td.appendChild(hidden);
       tr.appendChild(td);
     });
 

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -98,7 +98,7 @@
 
     <div id="mod-matrix-section">
         <h3>Modulation Matrix</h3>
-        <input type="hidden" id="mod-matrix-data-input" name="mod_matrix_data" value="[]">
+        <input type="hidden" id="mod-matrix-data-input" name="mod_matrix_data" value='{{ mod_matrix_json }}'>
         <table id="mod-matrix-table">
             <thead>
                 <tr>
@@ -147,6 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('save-params-btn');
   const form = document.getElementById('param-form');
   const macrosInput = document.getElementById('macros-data-input');
+  const modMatrixInput = document.getElementById('mod-matrix-data-input');
   const sprite1Sel = document.getElementById('sprite1-select');
   const sprite2Sel = document.getElementById('sprite2-select');
   const spriteNames = {{ sprites_json|safe }};
@@ -167,6 +168,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const initialMacros = macrosInput ? macrosInput.value : null;
+  let initialMatrix = modMatrixInput ? modMatrixInput.value : null;
   const initialValues = {};
 
   function recordInitial() {
@@ -177,11 +179,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     if (sprite1Sel) { initialValues['sprite1'] = sprite1Sel.value; sprite1Sel.addEventListener('change', updateSaveState); }
     if (sprite2Sel) { initialValues['sprite2'] = sprite2Sel.value; sprite2Sel.addEventListener('change', updateSaveState); }
+    if (modMatrixInput) modMatrixInput.addEventListener('change', updateSaveState);
   }
 
   function hasChanges() {
     if (cb && cb.checked) return true;
     if (macrosInput && macrosInput.value !== initialMacros) return true;
+    if (modMatrixInput && modMatrixInput.value !== initialMatrix) return true;
     for (const [name, val] of Object.entries(initialValues)) {
       const cur = form.querySelector(`[name="${name}"]`);
       if (cur && cur.value !== val) return true;

--- a/tests/test_wavetable_mod_matrix.py
+++ b/tests/test_wavetable_mod_matrix.py
@@ -31,10 +31,15 @@ def test_extract_mod_matrix(tmp_path):
 def test_update_mod_matrix(tmp_path):
     p = tmp_path / "preset.json"
     create_preset(p)
-    matrix = [{"name": "ParamB", "values": [0.2] * 11}]
+    matrix = [{"name": "ParamB", "values": [0.2] * 11, "extra": [1, 2]}]
     res = spih.update_wavetable_mod_matrix(str(p), matrix)
     assert res["success"], res.get("message")
     res2 = spih.extract_wavetable_mod_matrix(str(p))
     names = [r["name"] for r in res2["matrix"]]
     assert "ParamB" in names
+    for row in res2["matrix"]:
+        if row["name"] == "ParamB":
+            assert row["values"][0] == 0.2
+            assert row.get("extra") == [1, 2]
+            break
 

--- a/tests/test_wavetable_mod_matrix.py
+++ b/tests/test_wavetable_mod_matrix.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from core import synth_preset_inspector_handler as spih
+
+
+def create_preset(path, mods=None):
+    if mods is None:
+        mods = {"ParamA": [0.1] * 13}
+    preset = {
+        "kind": "instrumentRack",
+        "chains": [
+            {
+                "devices": [
+                    {"kind": "wavetable", "deviceData": {"modulations": mods}}
+                ]
+            }
+        ],
+    }
+    Path(path).write_text(json.dumps(preset))
+
+
+def test_extract_mod_matrix(tmp_path):
+    p = tmp_path / "preset.json"
+    create_preset(p)
+    res = spih.extract_wavetable_mod_matrix(str(p))
+    assert res["success"], res.get("message")
+    assert res["matrix"][0]["name"] == "ParamA"
+    assert len(res["matrix"][0]["values"]) == 11
+
+
+def test_update_mod_matrix(tmp_path):
+    p = tmp_path / "preset.json"
+    create_preset(p)
+    matrix = [{"name": "ParamB", "values": [0.2] * 11}]
+    res = spih.update_wavetable_mod_matrix(str(p), matrix)
+    assert res["success"], res.get("message")
+    res2 = spih.extract_wavetable_mod_matrix(str(p))
+    names = [r["name"] for r in res2["matrix"]]
+    assert "ParamB" in names
+


### PR DESCRIPTION
## Summary
- implement functions for extracting and updating wavetable modulation matrix
- load/save modulation matrix in wavetable parameter editor
- expose matrix data in template and UI
- keep unused values intact and track changes for saving
- provide unit tests for mod matrix helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bb99a46483258e85534a38b447c1