### PR TITLE
Fix mod matrix dropdown initial state

### DIFF
--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -55,6 +55,7 @@ function initModMatrix() {
     container.appendChild(toggle);
     const menu = document.createElement('div');
     menu.className = 'dropdown-menu';
+    menu.style.display = 'none';
     const ulRoot = document.createElement('ul');
     ulRoot.className = 'file-tree root';
     menu.appendChild(ulRoot);
@@ -127,6 +128,7 @@ function initModMatrix() {
       if (open && !container.contains(e.target)) close();
     });
 
+    container._close = close;
     return container;
   }
 
@@ -171,12 +173,19 @@ function initModMatrix() {
     return tr;
   }
 
+  function collapseAllDropdowns() {
+    tableBody.querySelectorAll('.nested-dropdown').forEach(dd => {
+      if (typeof dd._close === 'function') dd._close();
+    });
+  }
+
   function rebuild() {
     tableBody.innerHTML = '';
     matrix.forEach((row, idx) => {
       tableBody.appendChild(buildRow(row, idx));
     });
     if (window.initRectSliders) window.initRectSliders();
+    collapseAllDropdowns();
   }
 
   function save() {

--- a/static/mod_matrix.js
+++ b/static/mod_matrix.js
@@ -139,7 +139,6 @@ function initModMatrix() {
       row.name = val;
       save();
     });
-    tdSel.appendChild(dropdown);
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.textContent = 'X';
@@ -150,6 +149,7 @@ function initModMatrix() {
       rebuild();
     });
     tdSel.appendChild(removeBtn);
+    tdSel.appendChild(dropdown);
     tr.appendChild(tdSel);
 
     row.values = row.values || Array(headers.length).fill(0);


### PR DESCRIPTION
## Summary
- collapse mod matrix dropdowns by default and when rebuilding the table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847be00dc0c8325a17d1646c193908e