### PR TITLE
Add schema parameters in extractor

### DIFF
--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -159,11 +159,14 @@ def extract_available_parameters(
         # Find all parameters
         find_parameters(preset_data)
         
-        # Convert set to sorted list
-        parameters_list = sorted(list(parameters))
-
         schema = schema_loader()
-        parameter_info = {p: schema.get(p, {}) for p in parameters_list}
+        if schema:
+            parameters.update(schema.keys())
+
+        # Convert set to sorted list
+        parameters_list = sorted(parameters)
+
+        parameter_info = {p: schema.get(p, {}) if schema else {} for p in parameters_list}
 
         return {
             'success': True,

--- a/tests/test_synth_inspector_extra.py
+++ b/tests/test_synth_inspector_extra.py
@@ -43,6 +43,12 @@ def test_extract_available_and_values(tmp_path):
     info = extract_available_parameters(str(p))
     assert info["success"]
     assert "Volume" in info["parameters"]
+    # Parameters from the schema should also be included even if absent
+    assert "CyclingEnvelope_Hold" in info["parameters"]
+    # Schema data should be provided for known parameters
+    assert info["parameter_info"]["CyclingEnvelope_Hold"]["type"] == "number"
+    # Unknown parameters should have empty info
+    assert info["parameter_info"]["Volume"] == {}
     vals = extract_parameter_values(str(p))
     assert vals["success"]
     param = {p["name"]: p["value"] for p in vals["parameters"]}


### PR DESCRIPTION
## Summary
- ensure synth parameter extractor merges keys from schema
- update `test_synth_inspector_extra` for schema-only parameters
- keep wavetable schema JSON validated

## Testing
- `pytest -q`
- `python -m json.tool static/schemas/wavetable_schema.json`


------
https://chatgpt.com/codex/tasks/task_e_6847c1ddf5a883258e772b63749a72d1