### PR TITLE
Add web-based updater

### DIFF
--- a/core/update_handler.py
+++ b/core/update_handler.py
@@ -1,0 +1,85 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import List, Dict, Tuple, Callable, Optional
+
+import requests
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "github_update",
+    str((Path(__file__).resolve().parents[1] / "utility-scripts" / "github_update.py")),
+)
+github_update = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(github_update)
+
+REPO = os.environ.get("GITHUB_REPO", "charlesvestal/extending-move")
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SHA_FILE = ROOT_DIR / "last_sha.txt"
+
+
+def _read_current_sha() -> str:
+    if SHA_FILE.exists():
+        return SHA_FILE.read_text().strip()
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT_DIR).decode().strip()
+    except Exception:
+        return ""
+
+
+def list_commits_since(current_sha: str, repo: str) -> List[Dict[str, str]]:
+    url = f"https://api.github.com/repos/{repo}/compare/{current_sha}...main"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    commits = []
+    for c in data.get("commits", []):
+        msg = c.get("commit", {}).get("message", "").split("\n")[0]
+        is_merge = len(c.get("parents", [])) > 1
+        commits.append({"sha": c.get("sha"), "message": msg, "is_merge": is_merge})
+    return commits
+
+
+def check_for_update(repo: str = REPO) -> Tuple[bool, List[Dict[str, str]]]:
+    current = _read_current_sha()
+    latest = github_update.fetch_latest_sha(repo)
+    if not latest or current == latest:
+        return False, []
+    try:
+        commits = list_commits_since(current, repo)
+    except Exception:
+        commits = []
+    return True, commits
+
+
+def perform_update(progress: Optional[Callable[[str], None]] = None, repo: str = REPO) -> bool:
+    def step(msg: str) -> None:
+        if progress:
+            progress(msg)
+
+    current = _read_current_sha()
+    latest = github_update.fetch_latest_sha(repo)
+    if not latest or current == latest:
+        step("already up-to-date")
+        return True
+
+    step("downloading update")
+    content = github_update.download_zip(repo)
+    if not content:
+        step("download failed")
+        return False
+    step("extracting update")
+    try:
+        changed = github_update.overlay_from_zip(content, ROOT_DIR)
+    except Exception as exc:  # noqa: BLE001
+        step(f"error extracting: {exc}")
+        return False
+
+    github_update.write_last_sha(latest)
+    if changed:
+        step("installing requirements")
+        github_update.install_requirements(ROOT_DIR)
+    step("restarting server")
+    github_update.restart_webserver()
+    step("update complete")
+    return True

--- a/handlers/update_handler_class.py
+++ b/handlers/update_handler_class.py
@@ -1,0 +1,27 @@
+from handlers.base_handler import BaseHandler
+from core.update_handler import check_for_update, perform_update
+
+
+class UpdateHandler(BaseHandler):
+    """Handler for checking and applying repository updates."""
+
+    def handle_get(self):
+        update_available, commits = check_for_update()
+        return {
+            "update_available": update_available,
+            "commits": commits,
+        }
+
+    def handle_post(self, form):
+        valid, error_response = self.validate_action(form, "do_update")
+        if not valid:
+            return error_response
+        progress = []
+        success = perform_update(progress.append)
+        message = "Update complete" if success else "Update failed"
+        return {
+            "message": message,
+            "message_type": "success" if success else "error",
+            "progress": progress,
+            "update_available": False,
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -38,6 +38,7 @@ from handlers.wavetable_param_editor_handler_class import (
 from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
+from handlers.update_handler_class import UpdateHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -116,6 +117,7 @@ wavetable_param_handler = WavetableParamEditorHandler()
 file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
 drum_rack_handler = DrumRackInspectorHandler()
+update_handler = UpdateHandler()
 
 
 @app.before_request
@@ -704,6 +706,24 @@ def detect_transients_route():
         resp["content"],
         resp.get("status", 200),
         resp.get("headers", [("Content-Type", "application/json")]),
+    )
+
+
+@app.route("/update", methods=["GET", "POST"])
+def update_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = update_handler.handle_post(form)
+    else:
+        result = update_handler.handle_get()
+    return render_template(
+        "update.html",
+        active_tab="update",
+        update_available=result.get("update_available"),
+        commits=result.get("commits"),
+        message=result.get("message"),
+        message_type=result.get("message_type"),
+        progress=result.get("progress"),
     )
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -126,6 +126,9 @@ h3 {
     background-color: transparent;
     overflow: visible;
 }
+.tab-right {
+    margin-left: auto;
+}
 
 .tab button,
 .tab a {

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -17,6 +17,7 @@
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
+        <a href="{{ host_prefix }}/update" class="tab-right {% if active_tab == 'update' %}active{% endif %}">Update</a>
     </nav>
     <div class="tabcontent">
         {% block content %}{% endblock %}

--- a/templates_jinja/update.html
+++ b/templates_jinja/update.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Update Server</h2>
+{% if message %}
+<p class="{{ message_type }}">{{ message }}</p>
+{% endif %}
+{% if update_available %}
+  <p>New update available.</p>
+  {% if commits %}
+  <ul>
+    {% for c in commits %}
+      <li>{% if c.is_merge %}<b>{{ c.message }}</b>{% else %}{{ c.message }}{% endif %}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  <form method="post" action="{{ host_prefix }}/update">
+    <input type="hidden" name="action" value="do_update">
+    <button type="submit">Update</button>
+  </form>
+{% else %}
+  <p>Your installation is up-to-date.</p>
+{% endif %}
+{% if progress %}
+<pre>
+{% for line in progress %}{{ line }}
+{% endfor %}
+</pre>
+{% endif %}
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -448,4 +448,20 @@ def test_pitch_shift_route(client, monkeypatch):
     assert len(shifted) == len(data)
 
 
+def test_update_get(client, monkeypatch):
+    def fake_get():
+        return {'update_available': False, 'commits': []}
+    monkeypatch.setattr(move_webserver.update_handler, 'handle_get', fake_get)
+    resp = client.get('/update')
+    assert resp.status_code == 200
+
+
+def test_update_post(client, monkeypatch):
+    def fake_post(form):
+        return {'message': 'done', 'message_type': 'success', 'progress': [], 'update_available': False}
+    monkeypatch.setattr(move_webserver.update_handler, 'handle_post', fake_post)
+    resp = client.post('/update', data={'action': 'do_update'})
+    assert resp.status_code == 200
+
+
 


### PR DESCRIPTION
## Summary
- implement self-update logic via GitHub in `core.update_handler`
- add `UpdateHandler` for the web UI
- create `/update` route and template
- add right-aligned Update tab
- test update routes

## Testing
- `pytest tests/test_flask_routes.py::test_update_get -vv`
- `pytest tests/test_flask_routes.py::test_update_post -vv`


------
https://chatgpt.com/codex/tasks/task_e_6847c7d4253883259ecd4542063a1de7