### PR TITLE
Add random preset name generator

### DIFF
--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -74,9 +74,48 @@ function initRandomizeButton() {
   });
 }
 
+function generateRandomName() {
+  const adjectives = [
+    'Fluffy', 'Spicy', 'Zesty', 'Creamy', 'Crunchy', 'Savory', 'Sweet',
+    'Tangy', 'Juicy', 'Smoky', 'Fiery', 'Buttery', 'Tender', 'Crispy',
+    'Silky', 'Gooey', 'Fruity', 'Saucy', 'Glazed', 'Wholesome'
+  ];
+  const foods = [
+    'Cheeseburger', 'Pizza', 'Tiramisu', 'Sushi', 'Pancake', 'Brownie',
+    'Curry', 'Taco', 'Donut', 'Risotto', 'Ramen', 'Gnocchi', 'Quiche',
+    'Falafel', 'Burrito', 'Lasagna', 'Muffin', 'Chowder', 'Waffle', 'Scone'
+  ];
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+  const food = foods[Math.floor(Math.random() * foods.length)];
+  return `${adj} ${food}`;
+}
+
+function initRandomNameButtons() {
+  const mainBtn = document.getElementById('generate-name-btn');
+  const modalBtn = document.getElementById('modal-generate-name-btn');
+  const nameInput = document.getElementById('new-preset-name');
+  const modalInput = document.querySelector('#newPresetModal input[name="new_preset_name"]');
+
+  if (mainBtn && nameInput) {
+    mainBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      nameInput.value = generateRandomName();
+      nameInput.dispatchEvent(new Event('input'));
+    });
+  }
+
+  if (modalBtn && modalInput) {
+    modalBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      modalInput.value = generateRandomName();
+    });
+  }
+}
+
 function initSynthParams() {
   initNewPresetModal();
   initRandomizeButton();
+  initRandomNameButtons();
 }
 
 document.addEventListener('DOMContentLoaded', initSynthParams);

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -41,6 +41,7 @@
       <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
       <label>Preset Name:
         <input type="text" name="new_preset_name" required>
+        <button type="button" id="modal-generate-name-btn">Random Name</button>
       </label>
       <button type="submit">Create</button>
     </form>
@@ -67,6 +68,7 @@
     <div class="preset-controls">
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+            <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -41,6 +41,7 @@
       <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
       <label>Preset Name:
         <input type="text" name="new_preset_name" required>
+        <button type="button" id="modal-generate-name-btn">Random Name</button>
       </label>
       <button type="submit">Create</button>
     </form>
@@ -67,6 +68,7 @@
     <div class="preset-controls">
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+            <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>


### PR DESCRIPTION
## Summary
- allow generating random names in Drift and Wavetable editors
- update templates to show "Random Name" buttons
- implement helper in `synth_params.js` to build adjective + food names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847daee361c8325b940bad7db0f6d94