### PR TITLE
Add random preset name generator

### DIFF
--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -106,7 +106,8 @@ function initRandomNameButtons() {
   function ensureRenameChecked() {
     if (renameCb && nameInput) {
       const orig = nameInput.dataset.originalName;
-      const changed = nameInput.value.trim() !== orig;
+      const origBase = orig.replace(/\.[^.]+$/, '');
+      const changed = nameInput.value.trim() !== origBase;
       if (changed !== renameCb.checked) {
         renameCb.checked = changed;
         renameCb.dispatchEvent(new Event('change'));

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -74,9 +74,48 @@ function initRandomizeButton() {
   });
 }
 
+function generateRandomName() {
+  const adjectives = [
+    'Fluffy', 'Spicy', 'Zesty', 'Creamy', 'Crunchy', 'Savory', 'Sweet',
+    'Tangy', 'Juicy', 'Smoky', 'Fiery', 'Buttery', 'Tender', 'Crispy',
+    'Silky', 'Gooey', 'Fruity', 'Saucy', 'Glazed', 'Wholesome'
+  ];
+  const foods = [
+    'Cheeseburger', 'Pizza', 'Tiramisu', 'Sushi', 'Pancake', 'Brownie',
+    'Curry', 'Taco', 'Donut', 'Risotto', 'Ramen', 'Gnocchi', 'Quiche',
+    'Falafel', 'Burrito', 'Lasagna', 'Muffin', 'Chowder', 'Waffle', 'Scone'
+  ];
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+  const food = foods[Math.floor(Math.random() * foods.length)];
+  return `${adj} ${food}`;
+}
+
+function initRandomNameButtons() {
+  const mainBtn = document.getElementById('generate-name-btn');
+  const modalBtn = document.getElementById('modal-generate-name-btn');
+  const nameInput = document.getElementById('new-preset-name');
+  const modalInput = document.querySelector('#newPresetModal input[name="new_preset_name"]');
+
+  if (mainBtn && nameInput) {
+    mainBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      nameInput.value = generateRandomName();
+      nameInput.dispatchEvent(new Event('input'));
+    });
+  }
+
+  if (modalBtn && modalInput) {
+    modalBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      modalInput.value = generateRandomName();
+    });
+  }
+}
+
 function initSynthParams() {
   initNewPresetModal();
   initRandomizeButton();
+  initRandomNameButtons();
 }
 
 document.addEventListener('DOMContentLoaded', initSynthParams);

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -78,12 +78,18 @@ function generateRandomName() {
   const adjectives = [
     'Fluffy', 'Spicy', 'Zesty', 'Creamy', 'Crunchy', 'Savory', 'Sweet',
     'Tangy', 'Juicy', 'Smoky', 'Fiery', 'Buttery', 'Tender', 'Crispy',
-    'Silky', 'Gooey', 'Fruity', 'Saucy', 'Glazed', 'Wholesome'
+    'Silky', 'Gooey', 'Fruity', 'Saucy', 'Glazed', 'Wholesome',
+    'Bouncy', 'Chilled', 'Crumbly', 'Delightful', 'Earthy', 'Fizzy',
+    'Garlicky', 'Hearty', 'Icy', 'Jumbo', 'Luscious', 'Minty', 'Nutty',
+    'Peppy', 'Quirky', 'Roasted', 'Sugary', 'Toasty', 'Velvety', 'Zingy'
   ];
   const foods = [
     'Cheeseburger', 'Pizza', 'Tiramisu', 'Sushi', 'Pancake', 'Brownie',
     'Curry', 'Taco', 'Donut', 'Risotto', 'Ramen', 'Gnocchi', 'Quiche',
-    'Falafel', 'Burrito', 'Lasagna', 'Muffin', 'Chowder', 'Waffle', 'Scone'
+    'Falafel', 'Burrito', 'Lasagna', 'Muffin', 'Chowder', 'Waffle', 'Scone',
+    'Omelette', 'Pasta', 'Cupcake', 'Cookie', 'Gelato', 'Bagel', 'Samosa',
+    'Dumpling', 'Paella', 'Kebab', 'Steak', 'Salad', 'Stew', 'Poutine',
+    'Croissant', 'Baguette', 'Frittata', 'Pudding', 'Sandwich', 'Chili'
   ];
   const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
   const food = foods[Math.floor(Math.random() * foods.length)];
@@ -95,12 +101,25 @@ function initRandomNameButtons() {
   const modalBtn = document.getElementById('modal-generate-name-btn');
   const nameInput = document.getElementById('new-preset-name');
   const modalInput = document.querySelector('#newPresetModal input[name="new_preset_name"]');
+  const renameCb = document.getElementById('rename-checkbox');
+
+  function ensureRenameChecked() {
+    if (renameCb && nameInput) {
+      const orig = nameInput.dataset.originalName;
+      const changed = nameInput.value.trim() !== orig;
+      if (changed !== renameCb.checked) {
+        renameCb.checked = changed;
+        renameCb.dispatchEvent(new Event('change'));
+      }
+    }
+  }
 
   if (mainBtn && nameInput) {
     mainBtn.addEventListener('click', (e) => {
       e.preventDefault();
       nameInput.value = generateRandomName();
       nameInput.dispatchEvent(new Event('input'));
+      ensureRenameChecked();
     });
   }
 
@@ -109,6 +128,10 @@ function initRandomNameButtons() {
       e.preventDefault();
       modalInput.value = generateRandomName();
     });
+  }
+
+  if (nameInput) {
+    nameInput.addEventListener('input', ensureRenameChecked);
   }
 }
 

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -41,6 +41,7 @@
       <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
       <label>Preset Name:
         <input type="text" name="new_preset_name" required>
+        <button type="button" id="modal-generate-name-btn">Random Name</button>
       </label>
       <button type="submit">Create</button>
     </form>
@@ -67,6 +68,7 @@
     <div class="preset-controls">
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+            <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -67,7 +67,7 @@
     {% endif %}
     <div class="preset-controls">
         <label>Preset Name:
-            <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+            <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" data-original-base="{{ _prefill }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
             <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
@@ -128,6 +128,13 @@ document.addEventListener('DOMContentLoaded', () => {
   if (cb && nameInput) {
     cb.addEventListener('change', () => {
       nameInput.disabled = !cb.checked;
+      if (!cb.checked) {
+        const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
+        if (nameInput.value !== origBase) {
+          nameInput.value = origBase;
+          nameInput.dispatchEvent(new Event('input'));
+        }
+      }
       updateSaveState();
     });
   }

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -67,7 +67,7 @@
     {% endif %}
     <div class="preset-controls">
         <label>Preset Name:
-            <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+            <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" data-original-base="{{ _prefill }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
             <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
@@ -165,6 +165,13 @@ document.addEventListener('DOMContentLoaded', () => {
   if (cb && nameInput) {
     cb.addEventListener('change', () => {
       nameInput.disabled = !cb.checked;
+      if (!cb.checked) {
+        const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
+        if (nameInput.value !== origBase) {
+          nameInput.value = origBase;
+          nameInput.dispatchEvent(new Event('input'));
+        }
+      }
       updateSaveState();
     });
   }

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -41,6 +41,7 @@
       <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
       <label>Preset Name:
         <input type="text" name="new_preset_name" required>
+        <button type="button" id="modal-generate-name-btn">Random Name</button>
       </label>
       <button type="submit">Create</button>
     </form>
@@ -67,6 +68,7 @@
     <div class="preset-controls">
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
+            <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>


### PR DESCRIPTION
## Summary
- allow generating random names in Drift and Wavetable editors
- update templates to show "Random Name" buttons
- implement helper in `synth_params.js` to build adjective + food names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847daee361c8325b940bad7db0f6d94