### PR TITLE
Fix web-based update restart

### DIFF
--- a/handlers/update_handler_class.py
+++ b/handlers/update_handler_class.py
@@ -4,8 +4,9 @@
 import logging
 import os
 import time
+import subprocess
+import sys
 from typing import List, Dict, Any, Tuple
-from contextlib import redirect_stdout, redirect_stderr
 
 import requests
 import importlib.util
@@ -200,8 +201,17 @@ class UpdateHandler(BaseHandler):
             log.write("restarting server\n")
             log.flush()
             try:
-                with redirect_stdout(log), redirect_stderr(log):
-                    restart_webserver(log)
+                subprocess.Popen(
+                    [
+                        sys.executable,
+                        str(_util_path),
+                        "--restart-only",
+                        "--log",
+                        str(log_path),
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
             except Exception as exc:  # noqa: BLE001
                 log.write(f"Error restarting server: {exc}\n")
                 log.flush()

--- a/utility-scripts/github_update.py
+++ b/utility-scripts/github_update.py
@@ -24,6 +24,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 import hashlib
+import argparse
 
 import requests
 import subprocess
@@ -237,5 +238,34 @@ def update() -> int:
     return 0
 
 
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Repository update utilities")
+    parser.add_argument(
+        "--restart-only",
+        action="store_true",
+        help="Only restart the webserver",
+    )
+    parser.add_argument(
+        "--log",
+        type=str,
+        default=None,
+        help="Path to log file for restart output",
+    )
+    args = parser.parse_args()
+
+    log: io.TextIOBase | None = None
+    if args.log:
+        log = open(args.log, "a", encoding="utf-8")
+
+    try:
+        if args.restart_only:
+            restart_webserver(log)
+            return 0
+        return update()
+    finally:
+        if log:
+            log.close()
+
+
 if __name__ == "__main__":
-    sys.exit(update())
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- support restarting the server via a separate process
- expose a `--restart-only` CLI in `github_update.py`
- adjust `UpdateHandler` to spawn the helper instead of killing itself

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e652380c8325b98c634006b03a23