### PR TITLE
Pre-fill new preset names with random suggestion

### DIFF
--- a/static/random_name.js
+++ b/static/random_name.js
@@ -1,0 +1,14 @@
+const ADJECTIVES = [
+  'Fuzzy', 'Groovy', 'Smooth', 'Bouncy', 'Sharp', 'Lush', 'Bright', 'Warm'
+];
+const NOUNS = [
+  'Bass', 'Chord', 'Lead', 'Pad', 'Beat', 'Rhythm', 'Tone', 'Wave'
+];
+function generateRandomName() {
+  const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+  const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+  return `${adj} ${noun}`;
+}
+if (typeof window !== 'undefined') {
+  window.generateRandomName = generateRandomName;
+}

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -5,6 +5,10 @@ function initNewPresetModal() {
   const closeBtn = modal.querySelector('.modal-close');
   openBtn.addEventListener('click', (e) => {
     e.preventDefault();
+    const nameInput = modal.querySelector('input[name="new_preset_name"]');
+    if (nameInput && typeof generateRandomName === 'function') {
+      nameInput.value = generateRandomName();
+    }
     modal.classList.remove('hidden');
   });
   if (closeBtn) closeBtn.addEventListener('click', () => modal.classList.add('hidden'));

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -106,6 +106,7 @@
 <script>
   window.inputKnobsOptions = { knobDiameter: 32 };
 </script>
+<script src="{{ host_prefix }}/static/random_name.js"></script>
 <script type="module" src="{{ host_prefix }}/static/synth_params.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -130,6 +130,7 @@
 <script>
   window.inputKnobsOptions = { knobDiameter: 32 };
 </script>
+<script src="{{ host_prefix }}/static/random_name.js"></script>
 <script type="module" src="{{ host_prefix }}/static/synth_params.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>


### PR DESCRIPTION
## Summary
- provide a small random name generator script
- default new preset modal names to a random suggestion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ecacec808325819a0a64dc1ab514