### PR TITLE
Remove random name button and auto-fill fields

### DIFF
--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -3,8 +3,10 @@ function initNewPresetModal() {
   const openBtn = document.getElementById('create-new-btn');
   if (!modal || !openBtn) return;
   const closeBtn = modal.querySelector('.modal-close');
+  const modalInput = modal.querySelector('input[name="new_preset_name"]');
   openBtn.addEventListener('click', (e) => {
     e.preventDefault();
+    if (modalInput) modalInput.value = generateRandomName();
     modal.classList.remove('hidden');
   });
   if (closeBtn) closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
@@ -96,17 +98,13 @@ function generateRandomName() {
   return `${adj} ${food}`;
 }
 
-function initRandomNameButtons() {
-  const mainBtn = document.getElementById('generate-name-btn');
-  const modalBtn = document.getElementById('modal-generate-name-btn');
+function initRandomNameFields() {
   const nameInput = document.getElementById('new-preset-name');
-  const modalInput = document.querySelector('#newPresetModal input[name="new_preset_name"]');
   const renameCb = document.getElementById('rename-checkbox');
 
   function ensureRenameChecked() {
     if (renameCb && nameInput) {
-      const orig = nameInput.dataset.originalName;
-      const origBase = orig.replace(/\.[^.]+$/, '');
+      const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
       const changed = nameInput.value.trim() !== origBase;
       if (changed !== renameCb.checked) {
         renameCb.checked = changed;
@@ -115,23 +113,23 @@ function initRandomNameButtons() {
     }
   }
 
-  if (mainBtn && nameInput) {
-    mainBtn.addEventListener('click', (e) => {
-      e.preventDefault();
-      nameInput.value = generateRandomName();
-      nameInput.dispatchEvent(new Event('input'));
-      ensureRenameChecked();
+  if (renameCb && nameInput) {
+    renameCb.addEventListener('change', () => {
+      nameInput.disabled = !renameCb.checked;
+      if (renameCb.checked) {
+        const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
+        if (nameInput.value.trim() === origBase) {
+          nameInput.value = generateRandomName();
+          nameInput.dispatchEvent(new Event('input'));
+        }
+      } else {
+        const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
+        if (nameInput.value !== origBase) {
+          nameInput.value = origBase;
+          nameInput.dispatchEvent(new Event('input'));
+        }
+      }
     });
-  }
-
-  if (modalBtn && modalInput) {
-    modalBtn.addEventListener('click', (e) => {
-      e.preventDefault();
-      modalInput.value = generateRandomName();
-    });
-  }
-
-  if (nameInput) {
     nameInput.addEventListener('input', ensureRenameChecked);
   }
 }
@@ -139,7 +137,7 @@ function initRandomNameButtons() {
 function initSynthParams() {
   initNewPresetModal();
   initRandomizeButton();
-  initRandomNameButtons();
+  initRandomNameFields();
 }
 
 document.addEventListener('DOMContentLoaded', initSynthParams);

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -41,7 +41,6 @@
       <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
       <label>Preset Name:
         <input type="text" name="new_preset_name" required>
-        <button type="button" id="modal-generate-name-btn">Random Name</button>
       </label>
       <button type="submit">Create</button>
     </form>
@@ -68,7 +67,6 @@
     <div class="preset-controls">
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" data-original-base="{{ _prefill }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
-            <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>
@@ -124,20 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('save-params-btn');
   const form = document.getElementById('param-form');
   const macrosInput = document.getElementById('macros-data-input');
-
-  if (cb && nameInput) {
-    cb.addEventListener('change', () => {
-      nameInput.disabled = !cb.checked;
-      if (!cb.checked) {
-        const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
-        if (nameInput.value !== origBase) {
-          nameInput.value = origBase;
-          nameInput.dispatchEvent(new Event('input'));
-        }
-      }
-      updateSaveState();
-    });
-  }
+  if (cb) cb.addEventListener('change', updateSaveState);
 
   const initialMacros = macrosInput ? macrosInput.value : null;
   const initialValues = {};

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -41,7 +41,6 @@
       <input type="hidden" name="preset_select" value="{{ default_preset_path }}">
       <label>Preset Name:
         <input type="text" name="new_preset_name" required>
-        <button type="button" id="modal-generate-name-btn">Random Name</button>
       </label>
       <button type="submit">Create</button>
     </form>
@@ -68,7 +67,6 @@
     <div class="preset-controls">
         <label>Preset Name:
             <input type="text" name="new_preset_name" id="new-preset-name" data-original-name="{{ _basename }}" data-original-base="{{ _prefill }}" value="{{ _prefill }}" {% if not rename_checked %}disabled{% endif %}>
-            <button type="button" id="generate-name-btn">Random Name</button>
         </label>
         <label><input type="checkbox" name="rename" id="rename-checkbox" {% if rename_checked %}checked{% endif %}> Save as new</label>
     </div>
@@ -162,19 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if (cb && nameInput) {
-    cb.addEventListener('change', () => {
-      nameInput.disabled = !cb.checked;
-      if (!cb.checked) {
-        const origBase = nameInput.dataset.originalBase || nameInput.dataset.originalName.replace(/\.[^.]+$/, '');
-        if (nameInput.value !== origBase) {
-          nameInput.value = origBase;
-          nameInput.dispatchEvent(new Event('input'));
-        }
-      }
-      updateSaveState();
-    });
-  }
+  if (cb) cb.addEventListener('change', updateSaveState);
 
   const initialMacros = macrosInput ? macrosInput.value : null;
   let initialMatrix = modMatrixInput ? modMatrixInput.value : null;


### PR DESCRIPTION
## Summary
- auto-populate preset name inputs with a generated name
- drop random name buttons from preset editor templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847faedf3dc8325994cb90aa14443bb