### PR TITLE
Exclude wavetable parameters from macro dropdown

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -68,6 +68,20 @@ MACRO_HIGHLIGHT_COLORS = {
     7: "#ffb6c1",  # lightpink
 }
 
+# Parameters that should not be assignable to macros. These cause issues
+# with the wavetable editor, so they are removed from the dropdown list
+# when editing presets.
+EXCLUDED_MACRO_PARAMS = {
+    "HiQ",
+    "MonoPoly",
+    "PolyVoices",
+    "Voice_Global_FilterRouting",
+    "Voice_Oscillator1_Effects_EffectMode",
+    "Voice_Oscillator2_Effects_EffectMode",
+    "Voice_Unison_Mode",
+    "Voice_Unison_VoiceCount",
+}
+
 
 class WavetableParamEditorHandler(BaseHandler):
     def handle_get(self):
@@ -312,8 +326,16 @@ class WavetableParamEditorHandler(BaseHandler):
             schema_loader=load_wavetable_schema,
         )
         if param_info['success']:
-            available_params_json = json.dumps(param_info['parameters'])
-            param_paths_json = json.dumps(param_info.get('parameter_paths', {}))
+            params = [
+                p for p in param_info['parameters'] if p not in EXCLUDED_MACRO_PARAMS
+            ]
+            paths = {
+                k: v
+                for k, v in param_info.get('parameter_paths', {}).items()
+                if k not in EXCLUDED_MACRO_PARAMS
+            }
+            available_params_json = json.dumps(params)
+            param_paths_json = json.dumps(paths)
         
         if values['success']:
             params_html = self.generate_params_html(values['parameters'], mapped_params)

--- a/tests/test_wavetable_macro_exclude.py
+++ b/tests/test_wavetable_macro_exclude.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+
+from handlers import wavetable_param_editor_handler_class as wpeh
+
+class SimpleForm(dict):
+    def getvalue(self, name, default=None):
+        return self.get(name, default)
+
+
+def create_wt_preset(path):
+    preset = {
+        "kind": "instrumentRack",
+        "chains": [
+            {
+                "devices": [
+                    {"kind": "wavetable", "parameters": {"Volume": 0.5}}
+                ]
+            }
+        ],
+    }
+    Path(path).write_text(json.dumps(preset))
+
+
+def test_excluded_macro_params(monkeypatch, tmp_path):
+    p = tmp_path / "preset.ablpreset"
+    create_wt_preset(p)
+
+    monkeypatch.setattr(wpeh, "refresh_library", lambda: (True, "ok"))
+    monkeypatch.setattr(wpeh, "generate_dir_html", lambda *a, **k: "")
+
+    handler = wpeh.WavetableParamEditorHandler()
+    form = SimpleForm({"action": "select_preset", "preset_select": str(p)})
+    result = handler.handle_post(form)
+
+    params = json.loads(result["available_params_json"])
+    for name in wpeh.EXCLUDED_MACRO_PARAMS:
+        assert name not in params


### PR DESCRIPTION
## Summary
- avoid assigning certain Wavetable parameters to macros
- add test ensuring excluded parameters are not offered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480a3138808325bf8ab3eacc982bed