### PR TITLE
Add destination value slider to mod matrix

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1026,6 +1026,11 @@ button#macro-add-param {
 .mod-dest-select {
     width: 320px;
 }
+#mod-matrix-table .mod-dest-value.rect-slider-container {
+    width: 60px;
+    display: inline-block;
+    margin-left: 4px;
+}
 #mod-matrix-table .close-x {
     color: blue;
     height: 20px;


### PR DESCRIPTION
## Summary
- show the current destination value in the wavetable mod matrix
- style read-only sliders for destinations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848129924f08325820c7a9e00f8378c