### PR TITLE
Update Wavetable FX labels

### DIFF
--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -176,4 +176,28 @@ document.addEventListener('DOMContentLoaded', () => {
         sel.addEventListener('change', updateMorph);
         updateMorph();
     });
+
+    // Update oscillator FX knob labels when the effect mode changes
+    document.querySelectorAll('.param-item[data-name$="Effects_EffectMode"] select').forEach(sel => {
+        const match = sel.parentElement.dataset.name.match(/Voice_Oscillator(\d)_/);
+        if (!match) return;
+        const idx = match[1];
+        const item = sel.closest('.param-items');
+        const knob1 = item.querySelector(`.param-item[data-name="Voice_Oscillator${idx}_Effects_Effect1"] .param-label`);
+        const knob2 = item.querySelector(`.param-item[data-name="Voice_Oscillator${idx}_Effects_Effect2"] .param-label`);
+        const labelMap = {
+            'None': ['FX 1', 'FX 2'],
+            'Fm': ['Tune', 'Amt'],
+            'Classic': ['PW', 'Sync'],
+            'Modern': ['Warp', 'Fold'],
+        };
+        function updateFxLabels() {
+            const mode = sel.value;
+            const labels = labelMap[mode] || labelMap['None'];
+            if (knob1) knob1.textContent = labels[0];
+            if (knob2) knob2.textContent = labels[1];
+        }
+        sel.addEventListener('change', updateFxLabels);
+        updateFxLabels();
+    });
 });

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -532,13 +532,15 @@
     "type": "number",
     "min": -1.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%"
   },
   "Voice_Oscillator1_Effects_Effect2": {
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%"
   },
   "Voice_Oscillator1_Effects_EffectMode": {
     "type": "enum",
@@ -597,13 +599,15 @@
     "type": "number",
     "min": -1.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%"
   },
   "Voice_Oscillator2_Effects_Effect2": {
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%"
   },
   "Voice_Oscillator2_Effects_EffectMode": {
     "type": "enum",


### PR DESCRIPTION
## Summary
- treat oscillator FX1 and FX2 values as percentages
- change default FX labels to `FX 1` and `FX 2`
- update labels dynamically depending on selected FX mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684840354a348325969709d6ed48571f