### PR TITLE
Fix save button update on wavetable sprite change

### DIFF
--- a/static/sprite_dropdown.js
+++ b/static/sprite_dropdown.js
@@ -32,6 +32,8 @@ function initSpriteDropdown(catId, waveId, hiddenId, spriteMap, selected) {
     });
   }
 
+  const changeListeners = [];
+
   function setValue(val) {
     let cat = categories.find(c => (spriteMap[c] || []).includes(val));
     if (!cat) cat = categories[0];
@@ -42,6 +44,9 @@ function initSpriteDropdown(catId, waveId, hiddenId, spriteMap, selected) {
     waveSel.value = val;
     hidden.value = val;
     hidden.dispatchEvent(new Event('change'));
+    changeListeners.forEach(fn => {
+      try { fn(val); } catch (_) { /* ignore */ }
+    });
   }
 
   fillCategories();
@@ -53,7 +58,11 @@ function initSpriteDropdown(catId, waveId, hiddenId, spriteMap, selected) {
   });
   waveSel.addEventListener('change', () => setValue(waveSel.value));
 
-  return { setValue, options: allNames };
+  function onChange(fn) {
+    if (typeof fn === 'function') changeListeners.push(fn);
+  }
+
+  return { setValue, onChange, options: allNames };
 }
 if (typeof window !== 'undefined') {
   window.initSpriteDropdown = initSpriteDropdown;

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -154,9 +154,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const spriteMap = {{ sprites_json|safe }};
   const spriteDropdowns = {};
   const s1 = initSpriteDropdown('sprite1-cat', 'sprite1-select', 'sprite1-input', spriteMap, {{ sprite1|tojson }});
-  if (s1) spriteDropdowns.sprite1 = s1;
+  if (s1) {
+    spriteDropdowns.sprite1 = s1;
+    s1.onChange(updateSaveState);
+  }
   const s2 = initSpriteDropdown('sprite2-cat', 'sprite2-select', 'sprite2-input', spriteMap, {{ sprite2|tojson }});
-  if (s2) spriteDropdowns.sprite2 = s2;
+  if (s2) {
+    spriteDropdowns.sprite2 = s2;
+    s2.onChange(updateSaveState);
+  }
   window.spriteDropdowns = spriteDropdowns;
 
   if (cb) cb.addEventListener('change', updateSaveState);


### PR DESCRIPTION
## Summary
- trigger callbacks from sprite dropdown when selection changes
- wire sprite dropdown change handler to save button state logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848488834488325ba7db22ef91b3774