### PR TITLE
Update Wavetable filter panel

### DIFF
--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -171,10 +171,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const morphEl = sel.closest('.param-items').querySelector(`.filter${idx}-morph`);
         function updateMorph() {
             if (!morphEl) return;
-            morphEl.classList.toggle('hidden', sel.value !== 'Morph');
+            const disable = sel.value !== 'Morph';
+            const slider = morphEl.querySelector('.rect-slider-container');
+            if (slider) {
+                slider.classList.toggle('disabled', disable);
+                slider.dataset.disabled = disable ? 'true' : 'false';
+            }
         }
         sel.addEventListener('change', updateMorph);
-        updateMorph();
+        setTimeout(updateMorph, 0);
     });
 
     // Update oscillator FX knob labels when the effect mode changes


### PR DESCRIPTION
## Summary
- allow Filter1/2 morph controls to be rect sliders
- map global filter routing into Filter panel
- lay out filter controls in combined rows
- keep morph slider visible but disable when not active

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848481d235483258c82d9bfc67f3929