### PR TITLE
Relocate Wavetable Randomize Button

### DIFF
--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -73,7 +73,6 @@
     <div class="preset-actions">
         <button type="submit" id="save-params-btn" disabled>Save Parameters</button>
         <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another Preset</button>
-        <button type="button" id="randomize-btn">Randomize</button>
     </div>
     <div class="macro-knobs-section">
         <h3>Macros</h3>
@@ -105,6 +104,9 @@
             <tbody></tbody>
         </table>
         <button type="button" id="mod-matrix-add">Add Row</button>
+    </div>
+    <div class="preset-actions">
+        <button type="button" id="randomize-btn">Randomize</button>
     </div>
     <div id="macro-sidebar" class="macro-sidebar hidden">
         <h3 id="macro-sidebar-title"></h3>


### PR DESCRIPTION
## Summary
- rearrange `randomize-btn` on Wavetable preset page so it sits below the mod matrix section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684848f707c483258fb7b96e1a043dc6