### PR TITLE
Add ADSR envelope visualizer page

### DIFF
--- a/core/adsr_handler.py
+++ b/core/adsr_handler.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Utility functions for the ADSR envelope visualizer."""
+
+from typing import Dict
+
+
+def get_adsr_defaults() -> Dict[str, float]:
+    """Return default ADSR values for the prototype."""
+    return {
+        "attack": 0.2,
+        "decay": 0.2,
+        "sustain": 0.7,
+        "release": 0.3,
+    }

--- a/handlers/adsr_handler_class.py
+++ b/handlers/adsr_handler_class.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Handler for the ADSR envelope visualizer prototype."""
+
+from handlers.base_handler import BaseHandler
+from core.adsr_handler import get_adsr_defaults
+
+
+class AdsrHandler(BaseHandler):
+    """Provide default values for the ADSR visualizer."""
+
+    def handle_get(self):
+        """Return default ADSR settings."""
+        return {
+            "defaults": get_adsr_defaults(),
+            "message": "Adjust the knobs to shape the envelope",
+            "message_type": "info",
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -39,6 +39,7 @@ from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
 from handlers.update_handler_class import UpdateHandler, REPO
+from handlers.adsr_handler_class import AdsrHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -123,6 +124,7 @@ file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
 drum_rack_handler = DrumRackInspectorHandler()
 update_handler = UpdateHandler()
+adsr_handler = AdsrHandler()
 
 
 @app.before_request
@@ -301,6 +303,21 @@ def reverse():
         browser_root=browser_root,
         browser_filter=browser_filter,
         active_tab="reverse",
+    )
+
+
+@app.route("/adsr", methods=["GET"])
+def adsr_route():
+    result = adsr_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    defaults = result.get("defaults", {})
+    return render_template(
+        "adsr.html",
+        message=message,
+        message_type=message_type,
+        defaults=defaults,
+        active_tab="adsr",
     )
 
 

--- a/static/adsr.js
+++ b/static/adsr.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const attack = document.getElementById('attack');
+  const decay = document.getElementById('decay');
+  const sustain = document.getElementById('sustain');
+  const release = document.getElementById('release');
+  const canvas = document.getElementById('adsr-canvas');
+  const ctx = canvas.getContext('2d');
+
+  function draw() {
+    const a = parseFloat(attack.value);
+    const d = parseFloat(decay.value);
+    const s = parseFloat(sustain.value);
+    const r = parseFloat(release.value);
+    const hold = 0.25; // constant hold portion
+    const total = a + d + r + hold;
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    ctx.beginPath();
+    ctx.moveTo(0, h);
+    let x = (a / total) * w;
+    ctx.lineTo(x, 0);
+    const decEnd = x + (d / total) * w;
+    ctx.lineTo(decEnd, h - s * h);
+    const relStart = w - (r / total) * w;
+    ctx.lineTo(relStart, h - s * h);
+    ctx.lineTo(w, h);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+  }
+
+  attack.addEventListener('input', draw);
+  decay.addEventListener('input', draw);
+  sustain.addEventListener('input', draw);
+  release.addEventListener('input', draw);
+  draw();
+});

--- a/templates_jinja/adsr.html
+++ b/templates_jinja/adsr.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>ADSR Envelope Visualizer</h2>
+{% if message %}
+  <p class="{{ message_type }}">{{ message }}</p>
+{% endif %}
+<div id="adsr-controls">
+  <label>Attack
+    <input type="range" id="attack" class="input-knob" min="0" max="2" step="0.01" value="{{ defaults.attack }}">
+  </label>
+  <label>Decay
+    <input type="range" id="decay" class="input-knob" min="0" max="2" step="0.01" value="{{ defaults.decay }}">
+  </label>
+  <label>Sustain
+    <input type="range" id="sustain" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.sustain }}">
+  </label>
+  <label>Release
+    <input type="range" id="release" class="input-knob" min="0" max="2" step="0.01" value="{{ defaults.release }}">
+  </label>
+</div>
+<canvas id="adsr-canvas" width="300" height="150"></canvas>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/input-knobs.js"></script>
+<script src="{{ host_prefix }}/static/adsr.js"></script>
+{% endblock %}

--- a/templates_jinja/adsr.html
+++ b/templates_jinja/adsr.html
@@ -21,6 +21,7 @@
 <canvas id="adsr-canvas" width="300" height="150"></canvas>
 {% endblock %}
 {% block scripts %}
+<script src="{{ host_prefix }}/static/shared.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/adsr.js"></script>
 {% endblock %}

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -16,7 +16,7 @@
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Drift</a>
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
-        <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a>
+        <!-- <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
         <a href="{{ host_prefix }}/update" class="{% if active_tab == 'update' %}active{% endif %} right">Update</a>
     </nav>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -16,6 +16,7 @@
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Drift</a>
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
+        <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
         <a href="{{ host_prefix }}/update" class="{% if active_tab == 'update' %}active{% endif %} right">Update</a>
     </nav>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -35,6 +35,18 @@ def test_reverse_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'ok' in resp.data
 
+def test_adsr_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'defaults': {'attack': 0.1, 'decay': 0.2, 'sustain': 0.5, 'release': 0.3},
+            'message': 'hello',
+            'message_type': 'info'
+        }
+    monkeypatch.setattr(move_webserver.adsr_handler, 'handle_get', fake_get)
+    resp = client.get('/adsr')
+    assert resp.status_code == 200
+    assert b'ADSR Envelope Visualizer' in resp.data
+
 def test_restore_get(client, monkeypatch):
     def fake_get():
         return {'options': '<option value="1">1</option>', 'pad_grid': '<div class="pad-grid"></div>', 'message': ''}


### PR DESCRIPTION
## Summary
- add simple default provider in `core/adsr_handler.py`
- create `AdsrHandler` class for the new page
- wire route `/adsr` into the Flask app
- add template and JavaScript for envelope visualization
- expose page link in the navigation bar
- test new route in `test_flask_routes.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484c474a9c83258e5fae789a6e1f18