### PR TITLE
Add filter visualization prototype

### DIFF
--- a/core/filter_visualizer.py
+++ b/core/filter_visualizer.py
@@ -1,0 +1,78 @@
+import numpy as np
+from scipy import signal
+
+
+def _biquad_coeffs(filter_type: str, freq: float, q: float, sr: int = 44100):
+    """Return biquad filter coefficients."""
+    w0 = 2 * np.pi * freq / sr
+    alpha = np.sin(w0) / (2 * q)
+    cosw0 = np.cos(w0)
+
+    f = filter_type.lower()
+    if f == "lowpass":
+        b0 = (1 - cosw0) / 2
+        b1 = 1 - cosw0
+        b2 = (1 - cosw0) / 2
+        a0 = 1 + alpha
+        a1 = -2 * cosw0
+        a2 = 1 - alpha
+    elif f == "highpass":
+        b0 = (1 + cosw0) / 2
+        b1 = -(1 + cosw0)
+        b2 = (1 + cosw0) / 2
+        a0 = 1 + alpha
+        a1 = -2 * cosw0
+        a2 = 1 - alpha
+    elif f == "bandpass":
+        b0 = alpha
+        b1 = 0
+        b2 = -alpha
+        a0 = 1 + alpha
+        a1 = -2 * cosw0
+        a2 = 1 - alpha
+    elif f == "notch":
+        b0 = 1
+        b1 = -2 * cosw0
+        b2 = 1
+        a0 = 1 + alpha
+        a1 = -2 * cosw0
+        a2 = 1 - alpha
+    else:  # default to lowpass
+        b0 = (1 - cosw0) / 2
+        b1 = 1 - cosw0
+        b2 = (1 - cosw0) / 2
+        a0 = 1 + alpha
+        a1 = -2 * cosw0
+        a2 = 1 - alpha
+
+    b = np.array([b0, b1, b2]) / a0
+    a = np.array([1, a1 / a0, a2 / a0])
+    return b, a
+
+
+def compute_filter_response(filter_type: str, cutoff: float, resonance: float, slope: str, sr: int = 44100, n: int = 512):
+    """Compute frequency response for a single filter."""
+    q = 0.5 + 9.5 * resonance
+    b, a = _biquad_coeffs(filter_type, cutoff, q, sr)
+    w, h = signal.freqz(b, a, n, fs=sr)
+    if str(slope) == "24":
+        w2, h2 = signal.freqz(b, a, n, fs=sr)
+        h *= h2
+    mag = 20 * np.log10(np.abs(h) + 1e-9)
+    return w.tolist(), mag.tolist()
+
+
+def compute_chain_response(filter1: dict, filter2: dict | None = None, routing: str = "Serial", sr: int = 44100, n: int = 512):
+    """Compute frequency response for two filters combined."""
+    f1_w, f1_mag = compute_filter_response(**filter1, sr=sr, n=n)
+    if not filter2:
+        return f1_w, f1_mag
+    f2_w, f2_mag = compute_filter_response(**filter2, sr=sr, n=n)
+    h1 = 10 ** (np.array(f1_mag) / 20)
+    h2 = 10 ** (np.array(f2_mag) / 20)
+    if routing.lower() == "serial":
+        h = h1 * h2
+    else:  # parallel or split
+        h = 0.5 * (h1 + h2)
+    mag = 20 * np.log10(np.abs(h) + 1e-9)
+    return f1_w, mag.tolist()

--- a/handlers/filter_viz_handler_class.py
+++ b/handlers/filter_viz_handler_class.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from handlers.base_handler import BaseHandler
+from core.filter_visualizer import compute_chain_response
+
+
+class FilterVizHandler(BaseHandler):
+    """Handle requests for the filter visualization feature."""
+
+    def handle_get(self):
+        return {
+            "message": "Adjust parameters to visualize the filter response",
+            "message_type": "info",
+        }
+
+    def handle_post(self, form):
+        f1_type = form.getvalue("filter1_type", "Lowpass")
+        f1_freq = float(form.getvalue("filter1_freq", 1000))
+        f1_res = float(form.getvalue("filter1_res", 0.0))
+        f1_slope = form.getvalue("filter1_slope", "12")
+
+        filter1 = {
+            "filter_type": f1_type,
+            "cutoff": f1_freq,
+            "resonance": f1_res,
+            "slope": f1_slope,
+        }
+
+        if form.getvalue("use_filter2"):
+            f2_type = form.getvalue("filter2_type", "Lowpass")
+            f2_freq = float(form.getvalue("filter2_freq", 1000))
+            f2_res = float(form.getvalue("filter2_res", 0.0))
+            f2_slope = form.getvalue("filter2_slope", "12")
+            filter2 = {
+                "filter_type": f2_type,
+                "cutoff": f2_freq,
+                "resonance": f2_res,
+                "slope": f2_slope,
+            }
+        else:
+            filter2 = None
+
+        routing = form.getvalue("routing", "Serial")
+        freq, mag = compute_chain_response(filter1, filter2, routing)
+        data = {"freq": freq, "mag": mag}
+        return self.format_json_response(data)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -38,6 +38,7 @@ from handlers.wavetable_param_editor_handler_class import (
 from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
+from handlers.filter_viz_handler_class import FilterVizHandler
 from handlers.update_handler_class import UpdateHandler, REPO
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
@@ -122,6 +123,7 @@ wavetable_param_handler = WavetableParamEditorHandler()
 file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
 drum_rack_handler = DrumRackInspectorHandler()
+filter_viz_handler = FilterVizHandler()
 update_handler = UpdateHandler()
 
 
@@ -302,6 +304,30 @@ def reverse():
         browser_filter=browser_filter,
         active_tab="reverse",
     )
+
+
+@app.route("/filter-viz", methods=["GET", "POST"])
+def filter_viz_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        resp = filter_viz_handler.handle_post(form)
+        return (
+            resp["content"],
+            resp.get("status", 200),
+            resp.get("headers", [("Content-Type", "application/json")]),
+        )
+    else:
+        result = filter_viz_handler.handle_get()
+        message = result.get("message")
+        message_type = result.get("message_type")
+        success = message_type != "error" if message_type else False
+        return render_template(
+            "filter_viz.html",
+            message=message,
+            message_type=message_type,
+            success=success,
+            active_tab="filter-viz",
+        )
 
 
 @app.route("/restore", methods=["GET", "POST"])

--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -1,0 +1,37 @@
+export function initFilterViz() {
+  const form = document.getElementById('filter-form');
+  const canvas = document.getElementById('filterChart');
+  if (!form || !canvas) return;
+  const ctx = canvas.getContext('2d');
+
+  async function update() {
+    const formData = new FormData(form);
+    const resp = await fetch(form.action, {
+      method: 'POST',
+      body: formData
+    });
+    if (!resp.ok) return;
+    const data = await resp.json();
+    draw(data.freq, data.mag);
+  }
+
+  function draw(freq, mag) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.beginPath();
+    const minDb = -60;
+    const maxDb = 12;
+    for (let i = 0; i < freq.length; i++) {
+      const x = (i / (freq.length - 1)) * canvas.width;
+      const db = Math.max(minDb, Math.min(maxDb, mag[i]));
+      const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = '#0074D9';
+    ctx.stroke();
+  }
+
+  form.addEventListener('input', update);
+  update();
+}
+
+document.addEventListener('DOMContentLoaded', initFilterViz);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -14,7 +14,7 @@
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
         <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Drift</a>
-        <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a>
+        <!-- <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a> -->
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -14,6 +14,7 @@
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
         <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>
         <a href="{{ host_prefix }}/synth-params" class="{% if active_tab == 'synth-params' %}active{% endif %}">Drift</a>
+        <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a>
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>

--- a/templates_jinja/filter_viz.html
+++ b/templates_jinja/filter_viz.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Wavetable Filter Visualizer</h2>
+<p><em>Use the controls to view the filter cutoff slope and resonance.</em></p>
+{% if message %}
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+<form id="filter-form" action="{{ host_prefix }}/filter-viz" method="post">
+  <fieldset>
+    <legend>Filter 1</legend>
+    <label>Type:
+      <select name="filter1_type">
+        <option>Lowpass</option>
+        <option>Highpass</option>
+        <option>Bandpass</option>
+        <option>Notch</option>
+        <option>Morph</option>
+      </select>
+    </label>
+    <label>Freq:
+      <input type="number" name="filter1_freq" value="1000" step="1" min="20" max="20000">
+    </label>
+    <label>Resonance:
+      <input type="range" name="filter1_res" value="0.0" min="0" max="1" step="0.01">
+    </label>
+    <label>Slope:
+      <select name="filter1_slope">
+        <option value="12">12</option>
+        <option value="24">24</option>
+      </select>
+    </label>
+  </fieldset>
+  <fieldset>
+    <legend>Filter 2</legend>
+    <label><input type="checkbox" name="use_filter2"> Enable</label>
+    <label>Type:
+      <select name="filter2_type">
+        <option>Lowpass</option>
+        <option>Highpass</option>
+        <option>Bandpass</option>
+        <option>Notch</option>
+        <option>Morph</option>
+      </select>
+    </label>
+    <label>Freq:
+      <input type="number" name="filter2_freq" value="1000" step="1" min="20" max="20000">
+    </label>
+    <label>Resonance:
+      <input type="range" name="filter2_res" value="0.0" min="0" max="1" step="0.01">
+    </label>
+    <label>Slope:
+      <select name="filter2_slope">
+        <option value="12">12</option>
+        <option value="24">24</option>
+      </select>
+    </label>
+  </fieldset>
+  <label>Routing:
+    <select name="routing">
+      <option value="Serial">Serial</option>
+      <option value="Parallel">Parallel</option>
+      <option value="Split">Split</option>
+    </select>
+  </label>
+</form>
+<canvas id="filterChart" width="600" height="300" style="margin-top:1em;border:1px solid #ccc;"></canvas>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/filter_viz.js"></script>
+{% endblock %}

--- a/templates_jinja/filter_viz.html
+++ b/templates_jinja/filter_viz.html
@@ -66,5 +66,5 @@
 <canvas id="filterChart" width="600" height="300" style="margin-top:1em;border:1px solid #ccc;"></canvas>
 {% endblock %}
 {% block scripts %}
-<script src="{{ host_prefix }}/static/filter_viz.js"></script>
+<script type="module" src="{{ host_prefix }}/static/filter_viz.js"></script>
 {% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -448,4 +448,24 @@ def test_pitch_shift_route(client, monkeypatch):
     assert len(shifted) == len(data)
 
 
+def test_filter_viz_get(client):
+    resp = client.get('/filter-viz')
+    assert resp.status_code == 200
+    assert b'id="filterChart"' in resp.data
+
+
+def test_filter_viz_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'status': 200,
+            'headers': [('Content-Type', 'application/json')],
+            'content': '{"freq": [0, 1], "mag": [0, -3]}'
+        }
+
+    monkeypatch.setattr(move_webserver.filter_viz_handler, 'handle_post', fake_post)
+    resp = client.post('/filter-viz', data={'filter1_type': 'Lowpass'})
+    assert resp.status_code == 200
+    assert resp.json['freq'] == [0, 1]
+
+
 


### PR DESCRIPTION
## Summary
- visualize wavetable filter slope and resonance
- add FilterVizHandler and route
- support serial/parallel routing for two filters
- include new template and javascript
- add navigation link
- test filter viz route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484c92250083259de5b963b1490b6e