### PR TITLE
Update oscillator sections with FX rows

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -788,9 +788,9 @@ class WavetableParamEditorHandler(BaseHandler):
             ordered.append(f'<div class="param-row">{row}</div>')
 
         fx_row = "".join([
-            items.pop("Effects_EffectMode", ""),
-            items.pop("Effects_Effect1", ""),
-            items.pop("Effects_Effect2", ""),
+            items.pop("EffectMode", ""),
+            items.pop("Effect1", ""),
+            items.pop("Effect2", ""),
         ])
 
         if items:
@@ -818,9 +818,9 @@ class WavetableParamEditorHandler(BaseHandler):
         """Return FX panel rows for an oscillator."""
         ordered = []
         row = "".join([
-            items.pop("Effects_EffectMode", ""),
-            items.pop("Effects_Effect1", ""),
-            items.pop("Effects_Effect2", ""),
+            items.pop("EffectMode", ""),
+            items.pop("Effect1", ""),
+            items.pop("Effect2", ""),
         ])
         if row.strip():
             ordered.append(f'<div class="param-row">{row}</div>')
@@ -927,9 +927,9 @@ class WavetableParamEditorHandler(BaseHandler):
             ordered.append(f'<div class="param-row">{row}</div>')
         fx_row = "".join(
             [
-                fx_items.pop("Effects_EffectMode", ""),
-                fx_items.pop("Effects_Effect1", ""),
-                fx_items.pop("Effects_Effect2", ""),
+                fx_items.pop("EffectMode", ""),
+                fx_items.pop("Effect1", ""),
+                fx_items.pop("Effect2", ""),
             ]
         )
         if mixer_items:

--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -786,8 +786,19 @@ class WavetableParamEditorHandler(BaseHandler):
         ])
         if row.strip():
             ordered.append(f'<div class="param-row">{row}</div>')
+
+        fx_row = "".join([
+            items.pop("Effects_EffectMode", ""),
+            items.pop("Effects_Effect1", ""),
+            items.pop("Effects_Effect2", ""),
+        ])
+
         if items:
             ordered.extend(items.values())
+
+        if fx_row.strip():
+            ordered.append(f'<div class="param-row">{fx_row}</div>')
+
         return ordered
 
     def _arrange_sub_panel(self, items: dict) -> list:
@@ -914,21 +925,21 @@ class WavetableParamEditorHandler(BaseHandler):
         )
         if row.strip():
             ordered.append(f'<div class="param-row">{row}</div>')
-        row = "".join(
+        fx_row = "".join(
             [
                 fx_items.pop("Effects_EffectMode", ""),
                 fx_items.pop("Effects_Effect1", ""),
                 fx_items.pop("Effects_Effect2", ""),
             ]
         )
-        if row.strip():
-            ordered.append(f'<div class="param-row">{row}</div>')
         if mixer_items:
             ordered.extend(mixer_items.values())
         if fx_items:
             ordered.extend(fx_items.values())
         if osc_items:
             ordered.extend(osc_items.values())
+        if fx_row.strip():
+            ordered.append(f'<div class="param-row">{fx_row}</div>')
         return ordered
 
     def generate_params_html(self, params, mapped_parameters=None):


### PR DESCRIPTION
## Summary
- include FX row at the end of `_arrange_osc_panel`
- add FX row as the final row in `_arrange_osc_column`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848524863f083258f9bba9ef34eb89e