### PR TITLE
Update Drift preset layout

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -315,11 +315,11 @@ class SynthParamEditorHandler(BaseHandler):
 
     SECTION_ORDER = [
         "Oscillators",
-        "Mixer",
+        "Osc Mix",
         "Filter",
         "Envelopes",
         "LFO",
-        "Modulation",
+        "Mod",
         "Global",
         "Extras",
         "Other",
@@ -604,7 +604,7 @@ class SynthParamEditorHandler(BaseHandler):
         if name.startswith(("Oscillator1_", "Oscillator2_", "PitchModulation_")):
             return "Oscillators"
         if name.startswith("Mixer_") or name.startswith("Filter_OscillatorThrough") or name.startswith("Filter_NoiseThrough"):
-            return "Mixer"
+            return "Osc Mix"
         if name.startswith("Filter_"):
             return "Filter"
         if name.startswith(("Envelope1_", "Envelope2_", "CyclingEnvelope_")):
@@ -612,7 +612,7 @@ class SynthParamEditorHandler(BaseHandler):
         if name.startswith("Lfo_"):
             return "LFO"
         if name.startswith("ModulationMatrix_"):
-            return "Modulation"
+            return "Mod"
         if name.startswith("Global_"):
             if name in {
                 "Global_HiQuality",
@@ -708,13 +708,13 @@ class SynthParamEditorHandler(BaseHandler):
                 env_items[name] = html
             elif section == "LFO":
                 lfo_items[name] = html
-            elif section == "Mixer":
+            elif section == "Osc Mix":
                 mixer_items[name] = html
             elif section == "Global":
                 global_items[name] = html
             elif section == "Extras":
                 extras_items[name] = html
-            elif section == "Modulation":
+            elif section == "Mod":
                 mod_items[name] = html
             else:
                 sections[section].append(html)
@@ -761,7 +761,7 @@ class SynthParamEditorHandler(BaseHandler):
                 if row_html:
                     ordered.append(f'<div class="param-row">{row_html}</div>')
             ordered.extend(mixer_items.values())
-            sections["Mixer"] = ordered
+            sections["Osc Mix"] = ordered
 
         if osc_items:
             ordered = []
@@ -920,7 +920,7 @@ class SynthParamEditorHandler(BaseHandler):
                     )
 
             ordered.extend(mod_items.values())
-            sections["Modulation"] = ordered
+            sections["Mod"] = ordered
 
         if lfo_items:
             rate = lfo_items.pop("Lfo_Rate", "")
@@ -960,7 +960,7 @@ class SynthParamEditorHandler(BaseHandler):
 
         out_html = '<div class="drift-param-panels">'
         bottom_panels = []
-        second_row = {"LFO", "Modulation", "Global", "Extras"}
+        second_row = {"LFO", "Mod", "Global", "Extras"}
         for sec in self.SECTION_ORDER:
             items = sections.get(sec)
             if not items:

--- a/static/drift_device.css
+++ b/static/drift_device.css
@@ -1,0 +1,33 @@
+#drift-canvas {
+  width: 1024px;
+  height: 300px;
+  background-color: #292929;
+  font-family: "Akzidenz-Grotesk", sans-serif;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #CCCCCC;
+  padding: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+#drift-canvas .param-panel h3 {
+  font-size: 9px;
+  color: #999999;
+  letter-spacing: 1px;
+  margin-bottom: 4px;
+}
+#drift-canvas .param-panel {
+  border: none;
+  padding: 0;
+  background: transparent;
+  gap: 8px;
+}
+#drift-canvas .param-panel.osc-mix { width: 140px; height: 120px; }
+#drift-canvas .param-panel.filter { width: 200px; height: 120px; }
+#drift-canvas .param-panel.envelopes { width: 360px; height: 120px; }
+#drift-canvas .param-panel.lfo,
+#drift-canvas .param-panel.mod { width: 240px; height: 120px; }
+#drift-canvas .param-panel.global { width: 968px; height: 120px; }

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Move - Extended</title>
     <link rel="stylesheet" href="{{ host_prefix }}/static/style.css">
+    {% block extra_head %}{% endblock %}
 </head>
 <body>
     <h1 id="header">Move - Extended</h1>

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block extra_head %}
+<link rel="stylesheet" href="{{ host_prefix }}/static/drift_device.css">
+{% endblock %}
 {% block content %}
 <h2>Drift Preset Editor</h2>
 <p><em>Edit parameter values and assign macros. Note that Macro assignments override other values.</em></p>
@@ -92,8 +95,10 @@
         <button type="button" id="macro-sidebar-close">Close</button>
     </div>
     <div id="sidebar-overlay" class="sidebar-overlay hidden"></div>
-    <div class="param-list">
-        {{ params_html | safe }}
+    <div id="drift-canvas" class="drift-canvas">
+        <div class="param-list">
+            {{ params_html | safe }}
+        </div>
     </div>
 
 </form>


### PR DESCRIPTION
## Summary
- style drift editor with new layout
- provide block in base template for extra head elements
- rename mixer/mod sections to match new spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485fbae2d8832594f10eb6a21c9bca