### PR TITLE
Show both envelopes for Drift

### DIFF
--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -823,13 +823,10 @@ class SynthParamEditorHandler(BaseHandler):
             cycle_mode = env_items.pop("CyclingEnvelope_Mode", "")
 
             ordered = []
-            ordered.append(
-                '<div class="param-row env-switch-row">'
-                '<span class="param-row-label">View</span>'
-                '<label><input type="radio" name="env_select" value="env1" checked> Env 1</label>'
-                ' <label><input type="radio" name="env_select" value="env2"> Env 2</label>'
-                '</div>'
-            )
+            # Display both envelopes simultaneously. The previous implementation
+            # allowed switching between the two via radio buttons, but this made
+            # editing cumbersome. The switch row is removed so both sections are
+            # always visible.
             row1 = "".join(amp_adsr)
             if row1:
                 ordered.append(
@@ -841,17 +838,17 @@ class SynthParamEditorHandler(BaseHandler):
                 )
             if cycle_toggle:
                 ordered.append(
-                    f'<div class="param-row env2-mode env2-section hidden">'
+                    f'<div class="param-row env2-mode env2-section">'
                     f'<span class="param-row-label">Env/Cyc</span>{cycle_toggle}'
                     '</div>'
                 )
             row2_main = "".join(env2_adsr)
             if row2_main.strip():
                 ordered.append(
-                    '<canvas id="env2-canvas" class="adsr-canvas env2-section hidden" width="380" height="100"></canvas>'
+                    '<canvas id="env2-canvas" class="adsr-canvas env2-section" width="380" height="100"></canvas>'
                 )
                 ordered.append(
-                    f'<div class="param-row env2-adsr env2-section hidden"><span class="param-row-label">Env 2</span>{row2_main}</div>'
+                    f'<div class="param-row env2-adsr env2-section"><span class="param-row-label">Env 2</span>{row2_main}</div>'
 
                 )
             if any([cycle_mid, cycle_hold, cycle_rate, cycle_ratio, cycle_time, cycle_sync, cycle_mode]):
@@ -875,7 +872,7 @@ class SynthParamEditorHandler(BaseHandler):
                     cycle_mode,
                 ])
                 ordered.append(
-                    f'<div class="param-row env2-cycling hidden env2-section"><span class="param-row-label">Env 2</span>{row3_extra}</div>'
+                    f'<div class="param-row env2-cycling env2-section"><span class="param-row-label">Env 2</span>{row3_extra}</div>'
                 )
 
             ordered.extend(env_items.values())

--- a/static/param_adsr.js
+++ b/static/param_adsr.js
@@ -49,15 +49,10 @@ export function initParamAdsr() {
     });
     if (set.modeInput) {
       function toggle() {
-        const envSel = document.querySelector('input[name="env_select"]:checked');
-        const env2View = envSel && envSel.value === 'env2';
-        const show = env2View && set.modeInput.value !== 'Cyc';
+        const show = set.modeInput.value !== 'Cyc';
         set.canvas.classList.toggle('hidden', !show);
       }
       set.modeInput.addEventListener('change', toggle);
-      document.querySelectorAll('input[name="env_select"]').forEach(r =>
-        r.addEventListener('change', toggle)
-      );
       toggle();
     }
     draw();

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -168,19 +168,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateLfoRateDisplay();
     }
 
-    const envRadios = document.querySelectorAll('input[name="env_select"]');
-    const env1Els = document.querySelectorAll('.env1-section');
-    const env2Els = document.querySelectorAll('.env2-section');
-    function updateEnvDisplay() {
-        const sel = document.querySelector('input[name="env_select"]:checked');
-        const showEnv1 = !sel || sel.value === 'env1';
-        env1Els.forEach(el => el.classList.toggle('hidden', !showEnv1));
-        env2Els.forEach(el => el.classList.toggle('hidden', showEnv1));
-        if (showEnv1) return;
-        updateCycling();
-    }
-    envRadios.forEach(r => r.addEventListener('change', updateEnvDisplay));
-    updateEnvDisplay();
+
 
     document.querySelectorAll('.param-item[data-name^="Voice_Filter"][data-name$="_Type"] select').forEach(sel => {
         const match = sel.parentElement.dataset.name.match(/Voice_Filter(\d)_/);


### PR DESCRIPTION
## Summary
- remove env1/env2 switching logic
- always show both envelope sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486fe4e4988325a39f85eadfd47983