### PR TITLE
Add conditional rect sliders for wavetable filters

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -593,6 +593,10 @@ class WavetableParamEditorHandler(BaseHandler):
         "Voice_Modulators_Lfo2_Time_Rate",
         "Voice_Global_Glide",
         "Voice_Global_Transpose",
+        "Voice_Filter1_Drive",
+        "Voice_Filter2_Drive",
+        "Voice_Filter1_Morph",
+        "Voice_Filter2_Morph",
     }
 
     def _friendly_label(self, name: str) -> str:
@@ -752,6 +756,8 @@ class WavetableParamEditorHandler(BaseHandler):
         freq = items.pop("Frequency", "")
         res = items.pop("Resonance", "")
         drive = items.pop("Drive", "")
+        if drive:
+            drive = drive.replace('param-item"', f'param-item filter-drive filter{idx}-drive hidden"', 1)
         morph = items.pop("Morph", "")
 
         stack = "".join([on, f_type, slope])

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -192,7 +192,13 @@ document.addEventListener('DOMContentLoaded', () => {
             morphEl.classList.toggle('hidden', sel.value !== 'Morph');
         }
         sel.addEventListener('change', updateMorph);
-        updateMorph();
+                const driveEl = sel.closest('.param-items').querySelector(`.filter${idx}-drive`);
+        function updateDrive() {
+            if (!driveEl) return;
+            driveEl.classList.toggle('hidden', !['Lowpass','Highpass'].includes(sel.value));
+        }
+        sel.addEventListener('change', updateDrive);
+        updateDrive();
     });
 
     // Update oscillator FX knob labels when the effect mode changes

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -198,6 +198,7 @@ document.addEventListener('DOMContentLoaded', () => {
             driveEl.classList.toggle('hidden', !['Lowpass','Highpass'].includes(sel.value));
         }
         sel.addEventListener('change', updateDrive);
+        updateMorph();
         updateDrive();
     });
 


### PR DESCRIPTION
## Summary
- use rect sliders for Wavetable filter Drive and Morph
- hide Drive unless filter type is Lowpass or Highpass
- hide Morph unless filter type is Morph

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyrubberband')*

------
https://chatgpt.com/codex/tasks/task_e_6848702a5d908325b1203b472706cbdb