### PR TITLE
Add cycling envelope visualizer

### DIFF
--- a/core/cycling_env_handler.py
+++ b/core/cycling_env_handler.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Utility functions for the Cycling Envelope visualizer prototype."""
+
+from typing import Dict
+
+
+def get_cycling_env_defaults() -> Dict[str, float | str]:
+    """Return default values for the Cycling Envelope visualizer."""
+    return {
+        "rate": 2.0,  # Hz
+        "tilt": 0.0,
+        "hold": 0.0,
+        "time_mode": "Hz",
+    }

--- a/handlers/cycling_env_handler_class.py
+++ b/handlers/cycling_env_handler_class.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Handler for the Cycling Envelope visualizer prototype."""
+
+from handlers.base_handler import BaseHandler
+from core.cycling_env_handler import get_cycling_env_defaults
+
+
+class CyclingEnvHandler(BaseHandler):
+    """Provide default values for the Cycling Envelope visualizer."""
+
+    def handle_get(self):
+        """Return default Cycling Envelope settings."""
+        return {
+            "defaults": get_cycling_env_defaults(),
+            "message": "Adjust parameters to shape the cycling envelope",
+            "message_type": "info",
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -41,6 +41,7 @@ from handlers.refresh_handler_class import RefreshHandler
 from handlers.filter_viz_handler_class import FilterVizHandler
 from handlers.update_handler_class import UpdateHandler, REPO
 from handlers.adsr_handler_class import AdsrHandler
+from handlers.cycling_env_handler_class import CyclingEnvHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -127,6 +128,7 @@ drum_rack_handler = DrumRackInspectorHandler()
 filter_viz_handler = FilterVizHandler()
 update_handler = UpdateHandler()
 adsr_handler = AdsrHandler()
+cycling_env_handler = CyclingEnvHandler()
 
 
 @app.before_request
@@ -343,6 +345,21 @@ def adsr_route():
         message_type=message_type,
         defaults=defaults,
         active_tab="adsr",
+    )
+
+
+@app.route("/cycling-env", methods=["GET"])
+def cycling_env_route():
+    result = cycling_env_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    defaults = result.get("defaults", {})
+    return render_template(
+        "cycling_env.html",
+        message=message,
+        message_type=message_type,
+        defaults=defaults,
+        active_tab="cycling-env",
     )
 
 

--- a/static/cycling_env.js
+++ b/static/cycling_env.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const rate = document.getElementById('rate');
+  const tilt = document.getElementById('tilt');
+  const hold = document.getElementById('hold');
+  const modeInputs = document.querySelectorAll('input[name="time_mode"]');
+  const canvas = document.getElementById('cycle-canvas');
+  const ctx = canvas.getContext('2d');
+
+  function getTimeMode() {
+    const checked = document.querySelector('input[name="time_mode"]:checked');
+    return checked ? checked.value : 'Hz';
+  }
+
+  function draw() {
+    const r = parseFloat(rate.value);
+    const t = parseFloat(tilt.value);
+    const h = parseFloat(hold.value);
+    const mode = getTimeMode();
+
+    let cycleLen = 1 / r; // default Hz -> seconds per cycle
+    if (mode === 'ms') {
+      cycleLen = parseFloat(rate.value) / 1000;
+    } else if (mode === 'ratio') {
+      cycleLen = 1 / r; // treat same as Hz for prototype
+    } else if (mode === 'sync') {
+      cycleLen = 0.5; // quarter note at 120bpm for prototype
+    }
+    const displayLen = mode === 'sync' ? cycleLen * 3 : 2.25;
+    const cycleCount = displayLen / cycleLen;
+
+    const w = canvas.width;
+    const hgt = canvas.height;
+    ctx.clearRect(0, 0, w, hgt);
+    ctx.strokeStyle = '#0a0';
+    ctx.beginPath();
+
+    const vertPos = (t + 1) / 2; // 0 to 1
+    const peakX = vertPos * (w / cycleCount);
+
+    const points = [];
+    for (let i = 0; i < cycleCount; i++) {
+      const startX = (i / cycleCount) * w;
+      const endX = ((i + 1) / cycleCount) * w;
+      const peak = startX + peakX;
+      points.push([startX, hgt]);
+      points.push([peak, 0]);
+      if (hold.value > 0) {
+        const holdEnd = peak + (endX - startX) * hold.value;
+        points.push([holdEnd, 0]);
+      }
+      points.push([endX, hgt]);
+    }
+    ctx.moveTo(points[0][0], points[0][1]);
+    for (let i = 1; i < points.length; i++) {
+      ctx.lineTo(points[i][0], points[i][1]);
+    }
+    ctx.stroke();
+  }
+
+  [rate, tilt, hold].forEach(el => el.addEventListener('input', draw));
+  modeInputs.forEach(el => el.addEventListener('change', draw));
+  draw();
+});

--- a/static/cycling_env.js
+++ b/static/cycling_env.js
@@ -54,7 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (t >= 0.2) {
-        // Tilt at or above 0.2 draws a straight slope back to baseline
+        // Tilt at or above 0.2 keeps the level flat after the peak
+        points.push([endX, 0]);
         points.push([endX, hgt]);
       } else {
         // Below 0.2 curve down using a simple 1/x style curve

--- a/static/cycling_env.js
+++ b/static/cycling_env.js
@@ -54,8 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (t >= 0.2) {
-        // Tilt at or above 0.2 keeps the level flat after the peak
-        points.push([endX, 0]);
+        // Tilt at or above 0.2 draws a straight slope back to baseline
         points.push([endX, hgt]);
       } else {
         // Below 0.2 curve down using a simple 1/x style curve

--- a/static/cycling_env.js
+++ b/static/cycling_env.js
@@ -39,38 +39,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const points = [];
     const holdVal = parseFloat(hold.value);
-
     for (let i = 0; i < cycleCount; i++) {
       const startX = (i / cycleCount) * w;
       const endX = ((i + 1) / cycleCount) * w;
       const peak = startX + peakX;
-
       points.push([startX, hgt]);
       points.push([peak, 0]);
-
-      const holdEnd = peak + (endX - startX) * holdVal;
       if (holdVal > 0) {
+        const holdEnd = peak + (endX - startX) * holdVal;
         points.push([holdEnd, 0]);
       }
-
-      if (t >= 0.2) {
-        // Tilt at or above 0.2 keeps the level flat after the peak
-        points.push([endX, 0]);
-        points.push([endX, hgt]);
-      } else {
-        // Below 0.2 curve down using a simple 1/x style curve
-        const curveStart = holdVal > 0 ? holdEnd : peak;
-        const segs = 10;
-        for (let s = 1; s <= segs; s++) {
-          const frac = s / segs;
-          const x = curveStart + frac * (endX - curveStart);
-          const yFrac = 1 / (1 + frac * segs); // values ~1 -> ~0
-          points.push([x, (1 - yFrac) * hgt]);
-        }
-        points.push([endX, hgt]);
-      }
+      points.push([endX, hgt]);
     }
-
     ctx.moveTo(points[0][0], points[0][1]);
     for (let i = 1; i < points.length; i++) {
       ctx.lineTo(points[i][0], points[i][1]);

--- a/static/cycling_env.js
+++ b/static/cycling_env.js
@@ -14,12 +14,12 @@ document.addEventListener('DOMContentLoaded', () => {
   function draw() {
     const r = parseFloat(rate.value);
     const t = parseFloat(tilt.value);
-    const h = parseFloat(hold.value);
     const mode = getTimeMode();
 
     let cycleLen = 1 / r; // default Hz -> seconds per cycle
     if (mode === 'ms') {
-      cycleLen = parseFloat(rate.value) / 1000;
+      // map knob range 0.1-10 to roughly 10-1000 ms
+      cycleLen = r / 10; // seconds per cycle
     } else if (mode === 'ratio') {
       cycleLen = 1 / r; // treat same as Hz for prototype
     } else if (mode === 'sync') {
@@ -38,14 +38,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const peakX = vertPos * (w / cycleCount);
 
     const points = [];
+    const holdVal = parseFloat(hold.value);
     for (let i = 0; i < cycleCount; i++) {
       const startX = (i / cycleCount) * w;
       const endX = ((i + 1) / cycleCount) * w;
       const peak = startX + peakX;
       points.push([startX, hgt]);
       points.push([peak, 0]);
-      if (hold.value > 0) {
-        const holdEnd = peak + (endX - startX) * hold.value;
+      if (holdVal > 0) {
+        const holdEnd = peak + (endX - startX) * holdVal;
         points.push([holdEnd, 0]);
       }
       points.push([endX, hgt]);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -17,7 +17,7 @@
         <!-- <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a> -->
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
-        <!-- <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
+        <a href="{{ host_prefix }}/cycling-env" class="{% if active_tab == 'cycling-env' %}active{% endif %}">Cycle Env</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
         <a href="{{ host_prefix }}/update" class="{% if active_tab == 'update' %}active{% endif %} right">Update</a>
     </nav>

--- a/templates_jinja/cycling_env.html
+++ b/templates_jinja/cycling_env.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Cycling Envelope Visualizer</h2>
+{% if message %}
+  <p class="{{ message_type }}">{{ message }}</p>
+{% endif %}
+<canvas id="cycle-canvas" width="400" height="150"></canvas>
+<div id="cycle-controls">
+  <label>Rate
+    <input type="range" id="rate" class="input-knob" min="0.1" max="10" step="0.1" value="{{ defaults.rate }}">
+  </label>
+  <label>Tilt
+    <input type="range" id="tilt" class="input-knob" min="-1" max="1" step="0.01" value="{{ defaults.tilt }}">
+  </label>
+  <label>Hold
+    <input type="range" id="hold" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.hold }}">
+  </label>
+  <div>
+    <label><input type="radio" name="time_mode" value="Hz" {% if defaults.time_mode=='Hz' %}checked{% endif %}>Hz</label>
+    <label><input type="radio" name="time_mode" value="ratio" {% if defaults.time_mode=='ratio' %}checked{% endif %}>Ratio</label>
+    <label><input type="radio" name="time_mode" value="ms" {% if defaults.time_mode=='ms' %}checked{% endif %}>ms</label>
+    <label><input type="radio" name="time_mode" value="sync" {% if defaults.time_mode=='sync' %}checked{% endif %}>Sync</label>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/shared.js"></script>
+<script src="{{ host_prefix }}/static/input-knobs.js"></script>
+<script src="{{ host_prefix }}/static/cycling_env.js"></script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -494,4 +494,18 @@ def test_filter_viz_parallel_post(client, monkeypatch):
     assert resp.json['mag2'] == [0, -6]
 
 
+def test_cycling_env_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'defaults': {'rate': 2.0, 'tilt': 0.0, 'hold': 0.0, 'time_mode': 'Hz'},
+            'message': 'hello',
+            'message_type': 'info'
+        }
+
+    monkeypatch.setattr(move_webserver.cycling_env_handler, 'handle_get', fake_get)
+    resp = client.get('/cycling-env')
+    assert resp.status_code == 200
+    assert b'Cycling Envelope Visualizer' in resp.data
+
+
 


### PR DESCRIPTION
## Summary
- add Cycling Envelope core defaults and handler class
- register `/cycling-env` route in the webserver
- provide a template, JS, and navigation link for the prototype
- test the new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684875f44c808325849e325158d9882f