### PR TITLE
Filter knob visibility by filter type

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -757,6 +757,13 @@ class WavetableParamEditorHandler(BaseHandler):
         stack = "".join([on, f_type, slope])
         column = f'<div class="param-column">{stack}</div>' if stack.strip() else ""
 
+        if drive:
+            drive = drive.replace(
+                'param-item"',
+                f'param-item filter-drive filter{idx}-drive hidden"',
+                1,
+            )
+
         if morph:
             morph = morph.replace(
                 'param-item"',

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -175,12 +175,18 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!match) return;
         const idx = match[1];
         const morphEl = sel.closest('.param-items').querySelector(`.filter${idx}-morph`);
-        function updateMorph() {
-            if (!morphEl) return;
-            morphEl.classList.toggle('hidden', sel.value !== 'Morph');
+        const driveEl = sel.closest('.param-items').querySelector(`.filter${idx}-drive`);
+        function updateExtras() {
+            if (morphEl) {
+                morphEl.classList.toggle('hidden', sel.value !== 'Morph');
+            }
+            if (driveEl) {
+                const showDrive = sel.value === 'Lowpass' || sel.value === 'Highpass';
+                driveEl.classList.toggle('hidden', !showDrive);
+            }
         }
-        sel.addEventListener('change', updateMorph);
-        updateMorph();
+        sel.addEventListener('change', updateExtras);
+        updateExtras();
     });
 
     // Update oscillator FX knob labels when the effect mode changes


### PR DESCRIPTION
## Summary
- hide drive and morph knobs by default
- show drive for Lowpass and Highpass
- show morph for Morph filter type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487a74e82c8325bb95690aa6e09977