### PR TITLE
Fix filter routing section

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -721,6 +721,8 @@ class WavetableParamEditorHandler(BaseHandler):
 
     def _get_section(self, name):
         """Return the panel section for a raw Wavetable parameter name."""
+        if name == "Voice_Global_FilterRouting":
+            return "Filter"
         if name.startswith(("Voice_Oscillator1_Effects_", "Voice_Oscillator2_Effects_")):
             return "FX"
         if re.search(r"Voice_(?:Oscillator[12]|SubOscillator)_(?:On|Gain|Pan)$", name):

--- a/tests/test_wavetable_filter_section.py
+++ b/tests/test_wavetable_filter_section.py
@@ -1,0 +1,6 @@
+import handlers.wavetable_param_editor_handler_class as wpeh
+
+
+def test_filter_routing_section():
+    handler = wpeh.WavetableParamEditorHandler()
+    assert handler._get_section("Voice_Global_FilterRouting") == "Filter"


### PR DESCRIPTION
## Summary
- keep Voice Global Filter Routing parameter grouped with the Filter section
- verify section mapping for the parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487de178f483259bb54f74b0901e14