### PR TITLE
Fix envelope row layout in wavetable editor

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -869,20 +869,13 @@ class WavetableParamEditorHandler(BaseHandler):
             ordered.append(f'<div class="param-row">{row}</div>')
 
         loop = items.pop("LoopMode", "")
-        if loop:
-            ordered.append(f'<div class="param-row">{loop}</div>')
-
         final_val = items.pop("Final", "")
-        if final_val:
-            ordered.append(f'<div class="param-row">{final_val}</div>')
-
         initial_val = items.pop("Initial", "")
-        if initial_val:
-            ordered.append(f'<div class="param-row">{initial_val}</div>')
-
         peak_val = items.pop("Peak", "")
-        if peak_val:
-            ordered.append(f'<div class="param-row">{peak_val}</div>')
+
+        second_row = "".join([loop, final_val, initial_val, peak_val])
+        if second_row.strip():
+            ordered.append(f'<div class="param-row">{second_row}</div>')
 
         if items:
             ordered.extend(items.values())


### PR DESCRIPTION
## Summary
- group Loop Mode, Final, Initial and Peak in envelope rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684881cd44ec83259f2cfe6c8592dc2c