### PR TITLE
Add Initial, Peak and Final values to ADSR demo

### DIFF
--- a/core/adsr_handler.py
+++ b/core/adsr_handler.py
@@ -11,4 +11,7 @@ def get_adsr_defaults() -> Dict[str, float]:
         "decay": 0.2,
         "sustain": 0.7,
         "release": 0.3,
+        "initial": 0.0,
+        "peak": 1.0,
+        "final": 0.0,
     }

--- a/static/adsr.js
+++ b/static/adsr.js
@@ -3,6 +3,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const decay = document.getElementById('decay');
   const sustain = document.getElementById('sustain');
   const release = document.getElementById('release');
+  const initial = document.getElementById('initial');
+  const peak = document.getElementById('peak');
+  const finalVal = document.getElementById('final');
   const canvas = document.getElementById('adsr-canvas');
   const ctx = canvas.getContext('2d');
 
@@ -11,20 +14,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const d = parseFloat(decay.value);
     const s = parseFloat(sustain.value);
     const r = parseFloat(release.value);
+    const i = parseFloat(initial.value);
+    const p = parseFloat(peak.value);
+    const f = parseFloat(finalVal.value);
     const hold = 0.25; // constant hold portion
     const total = a + d + r + hold;
     const w = canvas.width;
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
-    ctx.moveTo(0, h);
+    ctx.moveTo(0, h - i * h);
     let x = (a / total) * w;
-    ctx.lineTo(x, 0);
+    ctx.lineTo(x, h - p * h);
     const decEnd = x + (d / total) * w;
     ctx.lineTo(decEnd, h - s * h);
     const relStart = w - (r / total) * w;
     ctx.lineTo(relStart, h - s * h);
-    ctx.lineTo(w, h);
+    ctx.lineTo(w, h - f * h);
     ctx.strokeStyle = '#f00';
     ctx.stroke();
   }
@@ -33,5 +39,8 @@ document.addEventListener('DOMContentLoaded', () => {
   decay.addEventListener('input', draw);
   sustain.addEventListener('input', draw);
   release.addEventListener('input', draw);
+  initial.addEventListener('input', draw);
+  peak.addEventListener('input', draw);
+  finalVal.addEventListener('input', draw);
   draw();
 });

--- a/templates_jinja/adsr.html
+++ b/templates_jinja/adsr.html
@@ -18,6 +18,15 @@
   <label>Release
     <input type="range" id="release" class="input-knob" min="0" max="2" step="0.01" value="{{ defaults.release }}">
   </label>
+  <label>Initial
+    <input type="range" id="initial" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.initial }}">
+  </label>
+  <label>Peak
+    <input type="range" id="peak" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.peak }}">
+  </label>
+  <label>Final
+    <input type="range" id="final" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.final }}">
+  </label>
 </div>
 {% endblock %}
 {% block scripts %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -38,7 +38,15 @@ def test_reverse_post(client, monkeypatch):
 def test_adsr_get(client, monkeypatch):
     def fake_get():
         return {
-            'defaults': {'attack': 0.1, 'decay': 0.2, 'sustain': 0.5, 'release': 0.3},
+            'defaults': {
+                'attack': 0.1,
+                'decay': 0.2,
+                'sustain': 0.5,
+                'release': 0.3,
+                'initial': 0.0,
+                'peak': 1.0,
+                'final': 0.0,
+            },
             'message': 'hello',
             'message_type': 'info'
         }
@@ -46,6 +54,9 @@ def test_adsr_get(client, monkeypatch):
     resp = client.get('/adsr')
     assert resp.status_code == 200
     assert b'ADSR Envelope Visualizer' in resp.data
+    assert b'id="initial"' in resp.data
+    assert b'id="peak"' in resp.data
+    assert b'id="final"' in resp.data
 
 def test_restore_get(client, monkeypatch):
     def fake_get():


### PR DESCRIPTION
## Summary
- allow envelope defaults to include starting, peak and final value
- extend the ADSR page UI with new sliders
- draw envelope using the new parameters
- test that the ADSR page exposes the new controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848822c07bc8325be2b60ec99ad4c88