### PR TITLE
Organize wavetable global section

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -549,6 +549,11 @@ class WavetableParamEditorHandler(BaseHandler):
         "Global_ResetOscillatorPhase": "Reset Osc Phase",
         "Global_HiQuality": "HQ",
         "Global_SerialNumber": "Serial",
+        "Voice_Global_Glide": "Glide",
+        "Voice_Global_Transpose": "Transpose",
+        "Voice_Unison_Mode": "Unison",
+        "Voice_Unison_Amount": "Amount",
+        "Voice_Unison_VoiceCount": "Voices",
 
     }
 
@@ -944,6 +949,38 @@ class WavetableParamEditorHandler(BaseHandler):
             ordered.append(f'<div class="param-row">{fx_row}</div>')
         return ordered
 
+    def _arrange_global_panel(self, items: dict) -> list:
+        """Return ordered rows for the Global panel."""
+        ordered = []
+        row = "".join([
+            items.pop("HiQ", ""),
+            items.pop("Volume", ""),
+        ])
+        if row.strip():
+            ordered.append(f'<div class="param-row">{row}</div>')
+        row = "".join([
+            items.pop("Glide", ""),
+            items.pop("Transpose", ""),
+        ])
+        if row.strip():
+            ordered.append(f'<div class="param-row">{row}</div>')
+        row = "".join([
+            items.pop("MonoPoly", ""),
+            items.pop("PolyVoices", ""),
+        ])
+        if row.strip():
+            ordered.append(f'<div class="param-row">{row}</div>')
+        row = "".join([
+            items.pop("Mode", ""),
+            items.pop("Amount", ""),
+            items.pop("VoiceCount", ""),
+        ])
+        if row.strip():
+            ordered.append(f'<div class="param-row">{row}</div>')
+        if items:
+            ordered.extend(items.values())
+        return ordered
+
     def generate_params_html(self, params, mapped_parameters=None):
         """Return HTML controls for the given parameter values."""
         if not params:
@@ -965,6 +1002,7 @@ class WavetableParamEditorHandler(BaseHandler):
             sec: {lbl: {} for _, lbl, _ in self.SECTION_SUBPANELS.get(sec, [])}
             for sec in self.SECTION_SUBPANELS
         }
+        global_items = {}
 
         for i, item in enumerate(params):
             name = item["name"]
@@ -1031,7 +1069,18 @@ class WavetableParamEditorHandler(BaseHandler):
                     slider=slider,
                     extra_classes=extra,
                 )
-                sections.setdefault(sec, []).append(html)
+                if sec == "Global":
+                    base = name
+                    if base.startswith("Voice_Global_"):
+                        base = base[len("Voice_Global_") :]
+                    elif base.startswith("Voice_Unison_"):
+                        base = base[len("Voice_Unison_") :]
+                    elif base.startswith("Global_"):
+                        base = base[len("Global_") :]
+                    base = self._strip_qualifiers(base)
+                    global_items[base] = html
+                else:
+                    sections.setdefault(sec, []).append(html)
 
         for sec, groups in self.SECTION_SUBPANELS.items():
             if sec in {"Oscillators", "FX", "Mixer"}:
@@ -1053,6 +1102,8 @@ class WavetableParamEditorHandler(BaseHandler):
                 group_items.extend(sections[sec])
             if group_items:
                 sections[sec] = group_items
+
+        sections["Global"] = self._arrange_global_panel(global_items)
 
         # Custom top panels for Sub and Oscillators
         sub_items = subgroups.get("Oscillators", {}).get("Sub Oscillator", {})


### PR DESCRIPTION
## Summary
- arrange the Wavetable preset editor's Global panel into four rows
- rename several Global parameter labels for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684887ff75d0832588b6cbb8832c0e57