### PR TITLE
Add ADSR previews to Wavetable envelopes

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -867,25 +867,41 @@ class WavetableParamEditorHandler(BaseHandler):
         """Return envelope panel rows with ADSR ordering."""
         ordered = []
 
-        row = "".join(
-            [
-                items.pop("Attack", ""),
-                items.pop("Sustain", ""),
-                items.pop("Decay", ""),
-                items.pop("Release", ""),
-            ]
-        )
-        if row.strip():
-            ordered.append(f'<div class="param-row">{row}</div>')
+        row1 = "".join([
+            items.pop("Attack", ""),
+            items.pop("Sustain", ""),
+            items.pop("Decay", ""),
+            items.pop("Release", ""),
+        ])
 
         loop = items.pop("LoopMode", "")
         final_val = items.pop("Final", "")
         initial_val = items.pop("Initial", "")
         peak_val = items.pop("Peak", "")
 
-        second_row = "".join([loop, final_val, initial_val, peak_val])
-        if second_row.strip():
-            ordered.append(f'<div class="param-row">{second_row}</div>')
+        row2 = "".join([loop, final_val, initial_val, peak_val])
+
+        sample = next(iter([row1, row2] + list(items.values())), "")
+        match = re.search(r"Envelope(\d)", sample)
+        idx = match.group(1) if match else "1"
+
+        rows_html = []
+        if row1.strip():
+            rows_html.append(f'<div class="param-row">{row1}</div>')
+        if row2.strip():
+            rows_html.append(f'<div class="param-row">{row2}</div>')
+
+        if rows_html:
+            canvas = (
+                f'<canvas id="env{idx}-canvas" '
+                f'class="adsr-canvas env-canvas env{idx}-section" '
+                f'width="200" height="88"></canvas>'
+            )
+            wrapper = (
+                f'<div class="env-wrapper">'
+                f'<div class="env-controls">{"".join(rows_html)}</div>{canvas}</div>'
+            )
+            ordered.append(wrapper)
 
         if items:
             ordered.extend(items.values())

--- a/static/param_adsr.js
+++ b/static/param_adsr.js
@@ -6,6 +6,9 @@ export function initParamAdsr() {
       decay: document.querySelector('.param-item[data-name="Envelope1_Decay"] input[type="range"]'),
       sustain: document.querySelector('.param-item[data-name="Envelope1_Sustain"] input[type="range"]'),
       release: document.querySelector('.param-item[data-name="Envelope1_Release"] input[type="range"]'),
+      initial: document.querySelector('.param-item[data-name="Envelope1_Initial"] input[type="range"]'),
+      peak: document.querySelector('.param-item[data-name="Envelope1_Peak"] input[type="range"]'),
+      finalVal: document.querySelector('.param-item[data-name="Envelope1_Final"] input[type="range"]'),
     },
     {
       canvas: document.getElementById('env2-canvas'),
@@ -13,7 +16,20 @@ export function initParamAdsr() {
       decay: document.querySelector('.param-item[data-name="Envelope2_Decay"] input[type="range"]'),
       sustain: document.querySelector('.param-item[data-name="Envelope2_Sustain"] input[type="range"]'),
       release: document.querySelector('.param-item[data-name="Envelope2_Release"] input[type="range"]'),
+      initial: document.querySelector('.param-item[data-name="Envelope2_Initial"] input[type="range"]'),
+      peak: document.querySelector('.param-item[data-name="Envelope2_Peak"] input[type="range"]'),
+      finalVal: document.querySelector('.param-item[data-name="Envelope2_Final"] input[type="range"]'),
       modeInput: document.querySelector('.param-item[data-name="Global_Envelope2Mode"] input[type="hidden"]')
+    },
+    {
+      canvas: document.getElementById('env3-canvas'),
+      attack: document.querySelector('.param-item[data-name="Envelope3_Attack"] input[type="range"]'),
+      decay: document.querySelector('.param-item[data-name="Envelope3_Decay"] input[type="range"]'),
+      sustain: document.querySelector('.param-item[data-name="Envelope3_Sustain"] input[type="range"]'),
+      release: document.querySelector('.param-item[data-name="Envelope3_Release"] input[type="range"]'),
+      initial: document.querySelector('.param-item[data-name="Envelope3_Initial"] input[type="range"]'),
+      peak: document.querySelector('.param-item[data-name="Envelope3_Peak"] input[type="range"]'),
+      finalVal: document.querySelector('.param-item[data-name="Envelope3_Final"] input[type="range"]')
     }
   ];
 
@@ -27,26 +43,31 @@ export function initParamAdsr() {
       const d = parseFloat(set.decay.value);
       const s = parseFloat(set.sustain.value);
       const r = parseFloat(set.release.value);
+      const i = set.initial ? parseFloat(set.initial.value) : 0;
+      const p = set.peak ? parseFloat(set.peak.value) : 1;
+      const f = set.finalVal ? parseFloat(set.finalVal.value) : 0;
       const hold = 0.25;
       const total = a + d + r + hold;
       const w = set.canvas.width;
       const h = set.canvas.height;
       ctx.clearRect(0, 0, w, h);
       ctx.beginPath();
-      ctx.moveTo(0, h);
+      ctx.moveTo(0, h - i * h);
       let x = (a / total) * w;
-      ctx.lineTo(x, 0);
+      ctx.lineTo(x, h - p * h);
       const decEnd = x + (d / total) * w;
       ctx.lineTo(decEnd, h - s * h);
       const relStart = w - (r / total) * w;
       ctx.lineTo(relStart, h - s * h);
-      ctx.lineTo(w, h);
+      ctx.lineTo(w, h - f * h);
       ctx.strokeStyle = '#f00';
       ctx.stroke();
     }
-    [set.attack, set.decay, set.sustain, set.release].forEach(el => {
-      el.addEventListener('input', draw);
-    });
+    [set.attack, set.decay, set.sustain, set.release, set.initial, set.peak, set.finalVal]
+      .filter(Boolean)
+      .forEach(el => {
+        el.addEventListener('input', draw);
+      });
     if (set.modeInput) {
       function updateVisibility() {
         const show = set.modeInput.value !== 'Cyc';

--- a/static/style.css
+++ b/static/style.css
@@ -1117,5 +1117,21 @@ button#macro-add-param {
     display: block;
     margin: 0.5rem 0;
     border: 1px solid #dedede;
-    width:100%
+    width: 100%;
+}
+
+.env-wrapper {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.env-wrapper .env-controls {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.env-canvas {
+    width: 200px;
+    height: 88px;
 }

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -136,6 +136,7 @@
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>
 <script src="{{ host_prefix }}/static/rect-slider.js"></script>
+<script type="module" src="{{ host_prefix }}/static/param_adsr.js"></script>
 <script>
 // Expose parameter metadata before loading the macro sidebar script
 window.driftSchema = {{ schema_json|safe }};


### PR DESCRIPTION
## Summary
- add envelope canvases to wavetable params layout
- show canvases beside both rows of ADSR controls
- draw envelopes with initial/peak/final support
- include ADSR script on wavetable params page
- tweak styles for new envelope display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488aef5d9c8325a12a335b494d4729