### PR TITLE
Add envelope visualization to wavetable editor

### DIFF
--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -868,8 +868,8 @@ class WavetableParamEditorHandler(BaseHandler):
             ordered.extend(items.values())
         return ordered
 
-    def _arrange_envelope_panel(self, items: dict) -> list:
-        """Return envelope panel rows with ADSR ordering."""
+    def _arrange_envelope_panel(self, items: dict, canvas_id: str = None) -> list:
+        """Return envelope panel rows with ADSR ordering and optional canvas."""
         ordered = []
 
         row = "".join(
@@ -880,8 +880,6 @@ class WavetableParamEditorHandler(BaseHandler):
                 items.pop("Release", ""),
             ]
         )
-        if row.strip():
-            ordered.append(f'<div class="param-row">{row}</div>')
 
         loop = items.pop("LoopMode", "")
         final_val = items.pop("Final", "")
@@ -889,8 +887,23 @@ class WavetableParamEditorHandler(BaseHandler):
         peak_val = items.pop("Peak", "")
 
         second_row = "".join([loop, final_val, initial_val, peak_val])
+
+        rows = []
+        if row.strip():
+            rows.append(f'<div class="param-row">{row}</div>')
         if second_row.strip():
-            ordered.append(f'<div class="param-row">{second_row}</div>')
+            rows.append(f'<div class="param-row">{second_row}</div>')
+
+        if canvas_id:
+            canvas = (
+                f'<canvas id="{canvas_id}" '
+                f'class="adsr-canvas env-visualization" width="200" height="88"></canvas>'
+            )
+            ordered.append(
+                f'<div class="env-container"><div class="env-controls">{"".join(rows)}</div>{canvas}</div>'
+            )
+        else:
+            ordered.extend(rows)
 
         if items:
             ordered.extend(items.values())
@@ -1136,7 +1149,13 @@ class WavetableParamEditorHandler(BaseHandler):
                     if sec == "Filter":
                         group_items.extend(self._arrange_filter_panel(items))
                     elif sec == "Envelopes":
-                        group_items.extend(self._arrange_envelope_panel(items))
+                        canvas_map = {
+                            "Amp Envelope": "amp-env-canvas",
+                            "Envelope 2": "env2-canvas",
+                            "Envelope 3": "env3-canvas",
+                        }
+                        cid = canvas_map.get(label)
+                        group_items.extend(self._arrange_envelope_panel(items, cid))
                     elif sec == "Modulation" and label.startswith("LFO"):
                         group_items.extend(self._arrange_lfo_panel(items))
                     else:

--- a/static/param_adsr.js
+++ b/static/param_adsr.js
@@ -1,63 +1,65 @@
 export function initParamAdsr() {
-  const sets = [
-    {
-      canvas: document.getElementById('amp-env-canvas'),
-      attack: document.querySelector('.param-item[data-name="Envelope1_Attack"] input[type="range"]'),
-      decay: document.querySelector('.param-item[data-name="Envelope1_Decay"] input[type="range"]'),
-      sustain: document.querySelector('.param-item[data-name="Envelope1_Sustain"] input[type="range"]'),
-      release: document.querySelector('.param-item[data-name="Envelope1_Release"] input[type="range"]'),
-    },
-    {
-      canvas: document.getElementById('env2-canvas'),
-      attack: document.querySelector('.param-item[data-name="Envelope2_Attack"] input[type="range"]'),
-      decay: document.querySelector('.param-item[data-name="Envelope2_Decay"] input[type="range"]'),
-      sustain: document.querySelector('.param-item[data-name="Envelope2_Sustain"] input[type="range"]'),
-      release: document.querySelector('.param-item[data-name="Envelope2_Release"] input[type="range"]'),
-      modeInput: document.querySelector('.param-item[data-name="Global_Envelope2Mode"] input[type="hidden"]')
-    }
-  ];
+  document.querySelectorAll('.adsr-canvas').forEach(canvas => {
+    const container = canvas.closest('.env-container') || document;
+    const q = name =>
+      container.querySelector(`.param-item[data-name$="_${name}"] input[type="range"]`);
+    const attack = q('Attack');
+    const decay = q('Decay');
+    const sustain = q('Sustain');
+    const release = q('Release');
+    const initial = q('Initial');
+    const peak = q('Peak');
+    const finalVal = q('Final');
+    const modeInput =
+      canvas.id === 'env2-canvas'
+        ? container.querySelector('.param-item[data-name="Global_Envelope2Mode"] input[type="hidden"]')
+        : null;
 
-  sets.forEach(set => {
-    if (!set.canvas || !set.attack || !set.decay || !set.sustain || !set.release) {
-      return;
-    }
-    const ctx = set.canvas.getContext('2d');
+    if (!attack || !decay || !sustain || !release) return;
+
+    const ctx = canvas.getContext('2d');
     function draw() {
-      const a = parseFloat(set.attack.value);
-      const d = parseFloat(set.decay.value);
-      const s = parseFloat(set.sustain.value);
-      const r = parseFloat(set.release.value);
+      const a = parseFloat(attack.value);
+      const d = parseFloat(decay.value);
+      const s = parseFloat(sustain.value);
+      const r = parseFloat(release.value);
+      const i = initial ? parseFloat(initial.value) : 0;
+      const p = peak ? parseFloat(peak.value) : 1;
+      const f = finalVal ? parseFloat(finalVal.value) : 0;
       const hold = 0.25;
       const total = a + d + r + hold;
-      const w = set.canvas.width;
-      const h = set.canvas.height;
+      const w = canvas.width;
+      const h = canvas.height;
       ctx.clearRect(0, 0, w, h);
       ctx.beginPath();
-      ctx.moveTo(0, h);
+      ctx.moveTo(0, h - i * h);
       let x = (a / total) * w;
-      ctx.lineTo(x, 0);
+      ctx.lineTo(x, h - p * h);
       const decEnd = x + (d / total) * w;
       ctx.lineTo(decEnd, h - s * h);
       const relStart = w - (r / total) * w;
       ctx.lineTo(relStart, h - s * h);
-      ctx.lineTo(w, h);
+      ctx.lineTo(w, h - f * h);
       ctx.strokeStyle = '#f00';
       ctx.stroke();
     }
-    [set.attack, set.decay, set.sustain, set.release].forEach(el => {
-      el.addEventListener('input', draw);
+
+    [attack, decay, sustain, release, initial, peak, finalVal].forEach(el => {
+      if (el) el.addEventListener('input', draw);
     });
-    if (set.modeInput) {
+
+    if (modeInput) {
       function updateVisibility() {
-        const show = set.modeInput.value !== 'Cyc';
-        set.canvas.classList.toggle('hidden', !show);
+        const show = modeInput.value !== 'Cyc';
+        canvas.classList.toggle('hidden', !show);
       }
-      set.modeInput.addEventListener('change', () => {
+      modeInput.addEventListener('change', () => {
         updateVisibility();
         draw();
       });
       updateVisibility();
     }
+
     draw();
   });
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1112,6 +1112,7 @@ button#macro-add-param {
 .param-panel.modulation .mod-matrix-row .param-item:nth-of-type(3) .param-select {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+}
 
 .adsr-canvas {
     display: block;

--- a/static/style.css
+++ b/static/style.css
@@ -1119,3 +1119,21 @@ button#macro-add-param {
     border: 1px solid #dedede;
     width:100%
 }
+
+.env-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.env-container .env-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    flex: 1;
+}
+
+.env-visualization {
+    width: 200px;
+    height: 88px;
+}

--- a/templates_jinja/wavetable_params.html
+++ b/templates_jinja/wavetable_params.html
@@ -135,6 +135,7 @@
 <script type="module" src="{{ host_prefix }}/static/synth_params.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>
+<script type="module" src="{{ host_prefix }}/static/param_adsr.js"></script>
 <script src="{{ host_prefix }}/static/rect-slider.js"></script>
 <script type="module" src="{{ host_prefix }}/static/wavetable_filter_viz.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- draw ADSR envelopes with initial/peak/final stages
- add layout and canvas styling for envelope visualization
- render canvases next to envelope controls in the wavetable editor
- load the ADSR script on the wavetable editor page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488ddf20448325b782aa34710e71ab