### PR TITLE
Fix sprite dropdown initialization

### DIFF
--- a/static/sprite_dropdown.js
+++ b/static/sprite_dropdown.js
@@ -50,7 +50,11 @@ function initSpriteDropdown(catId, waveId, hiddenId, spriteMap, selected) {
   }
 
   fillCategories();
-  setValue(selected || hidden.value || (spriteMap[categories[0]] || [])[0] || '');
+  const initial = selected || hidden.value || (spriteMap[categories[0]] || [])[0] || '';
+  let initCat = categories.find(c => (spriteMap[c] || []).includes(initial));
+  if (!initCat) initCat = categories[0];
+  fillWaves(initCat);
+  setValue(initial);
 
   catSel.addEventListener('change', () => {
     fillWaves(catSel.value);


### PR DESCRIPTION
## Summary
- ensure initial wavetable options populate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848935b2af483259ad908b51b64fd3c