### PR TITLE
Normalize Wavetable schema ranges and units

### DIFF
--- a/docs/instrument_schemas.md
+++ b/docs/instrument_schemas.md
@@ -13,5 +13,6 @@ These schemas are not currently used beyond documentation but provide a referenc
 Numeric entries may also include a `unit` and `decimals` key. The web editor uses
 this metadata to format values—frequencies labeled `Hz` automatically switch to
 `kHz` when above 1,000 and times labeled `s` display in milliseconds when below
-one second. Gain parameters spanning `0.0`–`2.0` are shown in decibels to match
-Live's controls.
+one second. Gain parameters using a `dB` unit and ranges up to `2.0` (including
+envelope sustain at `0.0–1.0`) are displayed as decibels to match Live's
+controls.

--- a/static/params_knobs.js
+++ b/static/params_knobs.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const displayEl = displayId ? document.getElementById(displayId) : null;
         const min = parseFloat(el.min);
         const max = parseFloat(el.max);
-        const oscGain = unit === 'dB' && !isNaN(min) && !isNaN(max) && min === 0 && max === 2;
+        const oscGain = unit === 'dB' && !isNaN(min) && !isNaN(max) && min === 0 && max <= 2;
         if (oscGain) {
             // allow smooth input; actual rounding happens in handler
             el.step = '0.001';

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -431,7 +431,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Voice_Modulators_Lfo1_Shape_PhaseOffset": {
     "type": "number",
@@ -446,7 +446,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Voice_Modulators_Lfo1_Shape_Type": {
     "type": "enum",
@@ -507,7 +507,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Voice_Modulators_Lfo2_Shape_PhaseOffset": {
     "type": "number",
@@ -522,7 +522,7 @@
     "max": 1.0,
     "options": [],
     "unit": "%",
-    "decimals": 0
+    "decimals": 2
   },
   "Voice_Modulators_Lfo2_Shape_Type": {
     "type": "enum",

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -761,7 +761,9 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Voice_Unison_Mode": {
     "type": "enum",
@@ -776,8 +778,9 @@
   "Voice_Unison_VoiceCount": {
     "type": "number",
     "min": 2,
-    "max": 6,
-    "options": []
+    "max": 8,
+    "options": [],
+    "decimals": 0
   },
   "Volume": {
     "type": "number",

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -736,10 +736,13 @@
     "type": "boolean",
     "min": null,
     "max": null,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 0
   },
-  "Voice_SubOscillator_Tone": {
-    "type": "number",
+    "max": 8,
+    "options": [],
+    "decimals": 0
     "min": 0.0,
     "max": 1.0,
     "options": [],

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -736,13 +736,10 @@
     "type": "boolean",
     "min": null,
     "max": null,
-    "options": [],
-    "unit": "%",
-    "decimals": 0
+    "options": []
   },
-    "max": 8,
-    "options": [],
-    "decimals": 0
+  "Voice_SubOscillator_Tone": {
+    "type": "number",
     "min": 0.0,
     "max": 1.0,
     "options": [],

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -436,7 +436,7 @@
   "Voice_Modulators_Lfo1_Shape_PhaseOffset": {
     "type": "number",
     "min": 0.0,
-    "max": 270.0,
+    "max": 360.0,
     "options": [],
     "unit": "\u00ba"
   },

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -712,9 +712,11 @@
   },
   "Voice_SubOscillator_Gain": {
     "type": "number",
-    "min": 0.0,
-    "max": 1.0,
-    "options": []
+    "min": 0,
+    "max": 2,
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
   },
   "Voice_SubOscillator_On": {
     "type": "boolean",

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -231,18 +231,10 @@
     "max": 1.0,
     "options": []
   },
-  "Voice_Modulators_AmpEnvelope_Sustain": {
-    "type": "number",
-    "min": 0.0,
-    "max": 1.0,
-    "options": [],
-    "unit": "%",
-    "decimals": 2
-  },
   "Voice_Modulators_AmpEnvelope_Times_Attack": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
@@ -250,15 +242,23 @@
   "Voice_Modulators_AmpEnvelope_Times_Decay": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
   },
+  "Voice_Modulators_AmpEnvelope_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
+  },
   "Voice_Modulators_AmpEnvelope_Times_Release": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
@@ -294,7 +294,7 @@
   "Voice_Modulators_Envelope2_Times_Attack": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
@@ -302,15 +302,23 @@
   "Voice_Modulators_Envelope2_Times_Decay": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
   },
+  "Voice_Modulators_Envelope2_Values_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": [],
+    "unit": "%",
+    "decimals": 2
+  },
   "Voice_Modulators_Envelope2_Times_Release": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
@@ -332,14 +340,6 @@
     "min": 0.0,
     "max": 1.0,
     "options": []
-  },
-  "Voice_Modulators_Envelope2_Values_Sustain": {
-    "type": "number",
-    "min": 0.0,
-    "max": 1.0,
-    "options": [],
-    "unit": "%",
-    "decimals": 2
   },
   "Voice_Modulators_Envelope3_LoopMode": {
     "type": "enum",
@@ -372,7 +372,7 @@
   "Voice_Modulators_Envelope3_Times_Attack": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
@@ -380,15 +380,23 @@
   "Voice_Modulators_Envelope3_Times_Decay": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
   },
+  "Voice_Modulators_Envelope3_Values_Sustain": {
+    "type": "number",
+    "min": 0.0,
+    "max": 1.0,
+    "options": [],
+    "unit": "%",
+    "decimals": 2
+  },
   "Voice_Modulators_Envelope3_Times_Release": {
     "type": "number",
     "min": 0,
-    "max": 60,
+    "max": 20,
     "options": [],
     "unit": "s",
     "decimals": 3
@@ -410,14 +418,6 @@
     "min": 0.0,
     "max": 1.0,
     "options": []
-  },
-  "Voice_Modulators_Envelope3_Values_Sustain": {
-    "type": "number",
-    "min": 0.0,
-    "max": 1.0,
-    "options": [],
-    "unit": "%",
-    "decimals": 2
   },
   "Voice_Modulators_Lfo1_Retrigger": {
     "type": "boolean",

--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -49,7 +49,9 @@
     "type": "number",
     "min": 20.0,
     "max": 20480.0,
-    "options": []
+    "options": [],
+    "unit": "Hz",
+    "decimals": 0
   },
   "Voice_Filter1_Morph": {
     "type": "number",
@@ -66,7 +68,7 @@
   "Voice_Filter1_Resonance": {
     "type": "number",
     "min": 0.0,
-    "max": 0.694444,
+    "max": 0.75,
     "options": []
   },
   "Voice_Filter1_Slope": {
@@ -118,7 +120,9 @@
     "type": "number",
     "min": 20.0,
     "max": 20480.0,
-    "options": []
+    "options": [],
+    "unit": "Hz",
+    "decimals": 0
   },
   "Voice_Filter2_Morph": {
     "type": "number",
@@ -135,7 +139,7 @@
   "Voice_Filter2_Resonance": {
     "type": "number",
     "min": 0.0,
-    "max": 0.813492,
+    "max": 0.75,
     "options": []
   },
   "Voice_Filter2_Slope": {
@@ -231,25 +235,33 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Voice_Modulators_AmpEnvelope_Times_Attack": {
     "type": "number",
-    "min": 0.0,
-    "max": 0.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_AmpEnvelope_Times_Decay": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_AmpEnvelope_Times_Release": {
     "type": "number",
-    "min": 0.0,
-    "max": 3.053029,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope2_LoopMode": {
     "type": "enum",
@@ -281,21 +293,27 @@
   },
   "Voice_Modulators_Envelope2_Times_Attack": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope2_Times_Decay": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope2_Times_Release": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope2_Values_Final": {
     "type": "number",
@@ -319,7 +337,9 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Voice_Modulators_Envelope3_LoopMode": {
     "type": "enum",
@@ -351,21 +371,27 @@
   },
   "Voice_Modulators_Envelope3_Times_Attack": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope3_Times_Decay": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope3_Times_Release": {
     "type": "number",
-    "min": 0.0,
-    "max": 20.0,
-    "options": []
+    "min": 0,
+    "max": 60,
+    "options": [],
+    "unit": "s",
+    "decimals": 3
   },
   "Voice_Modulators_Envelope3_Values_Final": {
     "type": "number",
@@ -389,7 +415,9 @@
     "type": "number",
     "min": 0.0,
     "max": 1.0,
-    "options": []
+    "options": [],
+    "unit": "%",
+    "decimals": 2
   },
   "Voice_Modulators_Lfo1_Retrigger": {
     "type": "boolean",
@@ -555,9 +583,11 @@
   },
   "Voice_Oscillator1_Gain": {
     "type": "number",
-    "min": 0.193371,
-    "max": 1.0,
-    "options": []
+    "min": 0,
+    "max": 2,
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
   },
   "Voice_Oscillator1_On": {
     "type": "boolean",
@@ -630,9 +660,11 @@
   },
   "Voice_Oscillator2_Gain": {
     "type": "number",
-    "min": 0.0,
-    "max": 1.0,
-    "options": []
+    "min": 0,
+    "max": 2,
+    "options": [],
+    "unit": "dB",
+    "decimals": 1
   },
   "Voice_Oscillator2_On": {
     "type": "boolean",

--- a/static/style.css
+++ b/static/style.css
@@ -627,6 +627,10 @@ select {
     margin-top: 0.5rem;
 }
 
+.wavetable-param-panels .param-select {
+    width:auto;
+}
+
 .param-panel {
     border: 1px solid #ccc;
     padding: 0.5rem;


### PR DESCRIPTION
## Summary
- update wavetable_schema.json with explicit units, ranges and decimals for envelopes, filters and oscillator gains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488ce5b3f483258505a6a430a3cd41