### PR TITLE
Fix blurry envelope and filter charts

### DIFF
--- a/static/adsr.js
+++ b/static/adsr.js
@@ -9,6 +9,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('adsr-canvas');
   const ctx = canvas.getContext('2d');
 
+  function setupCanvas() {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.scale(dpr, dpr);
+  }
+  setupCanvas();
+
   function draw() {
     const a = parseFloat(attack.value);
     const d = parseFloat(decay.value);

--- a/static/drift_filter_viz.js
+++ b/static/drift_filter_viz.js
@@ -14,6 +14,15 @@ export function initDriftFilterViz() {
   }
   const ctx = canvas.getContext('2d');
 
+  function setupCanvas() {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.scale(dpr, dpr);
+  }
+  setupCanvas();
+
   const freqInput = document.querySelector('.param-item[data-name="Filter_Frequency"] input[type="hidden"]');
   const typeInput = document.querySelector('.param-item[data-name="Filter_Type"] input[type="hidden"]');
   const resInput = document.querySelector('.param-item[data-name="Filter_Resonance"] input[type="hidden"]');

--- a/static/param_adsr.js
+++ b/static/param_adsr.js
@@ -18,6 +18,15 @@ export function initParamAdsr() {
     if (!attack || !decay || !sustain || !release) return;
 
     const ctx = canvas.getContext('2d');
+
+    function setupCanvas() {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+    setupCanvas();
     function draw() {
       const a = parseFloat(attack.value);
       const d = parseFloat(decay.value);


### PR DESCRIPTION
## Summary
- make all ADSR canvases aware of devicePixelRatio
- update drift filter visualization canvas resolution

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684905118d108325811df81803f2c40f