### PR TITLE
Use log scale for filter plot

### DIFF
--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -23,7 +23,9 @@ export function initFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
-    const minFreq = 1;
+    // Use a small positive minimum to avoid log(0) while keeping
+    // the lowest portion of the spectrum from dominating the scale.
+    const minFreq = 3;
     let fMin = Infinity;
     let fMax = 0;
     for (let i = 0; i < freq.length; i++) {

--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -23,8 +23,19 @@ export function initFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    const minFreq = 1;
+    let fMin = Infinity;
+    let fMax = 0;
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minFreq, freq[i]);
+      if (f < fMin) fMin = f;
+      if (f > fMax) fMax = f;
+    }
+    const logMin = Math.log10(fMin);
+    const logMax = Math.log10(fMax);
+    for (let i = 0; i < freq.length; i++) {
+      const f = Math.max(minFreq, freq[i]);
+      const x = (Math.log10(f) - logMin) / (logMax - logMin) * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/wavetable_filter_viz.js
+++ b/static/wavetable_filter_viz.js
@@ -120,8 +120,19 @@ export function initWavetableFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    const minFreq = 1;
+    let fMin = Infinity;
+    let fMax = 0;
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minFreq, freq[i]);
+      if (f < fMin) fMin = f;
+      if (f > fMax) fMax = f;
+    }
+    const logMin = Math.log10(fMin);
+    const logMax = Math.log10(fMax);
+    for (let i = 0; i < freq.length; i++) {
+      const f = Math.max(minFreq, freq[i]);
+      const x = (Math.log10(f) - logMin) / (logMax - logMin) * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/wavetable_filter_viz.js
+++ b/static/wavetable_filter_viz.js
@@ -120,7 +120,9 @@ export function initWavetableFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
-    const minFreq = 1;
+    // Avoid log(0) by clamping to a small value. A slightly higher
+    // threshold keeps the lowest frequencies from stretching the axis.
+    const minFreq = 3;
     let fMin = Infinity;
     let fMax = 0;
     for (let i = 0; i < freq.length; i++) {


### PR DESCRIPTION
## Summary
- render filter frequency responses on a log x-axis
- make the same update for wavetable filter plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684906183988832589ab5ae866f3a8f7