### PR TITLE
Update drift visualization

### DIFF
--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -4,12 +4,18 @@ export function initDriftCombinedViz() {
   const envPanelItems = env2Canvas ? env2Canvas.parentElement : null;
   if (!filterPanel || !envPanelItems) return;
 
+  const env2ModeRow = envPanelItems.querySelector('.env2-mode');
+
   const canvas = document.createElement('canvas');
   canvas.id = 'driftVizCanvas';
   canvas.width = 300;
   canvas.height = 88;
   canvas.style.border = '1px solid #ccc';
-  envPanelItems.insertBefore(canvas, env2Canvas);
+  if (env2ModeRow) {
+    envPanelItems.insertBefore(canvas, env2ModeRow);
+  } else {
+    envPanelItems.insertBefore(canvas, env2Canvas);
+  }
 
   ['driftFilterChart', 'amp-env-canvas', 'env2-canvas'].forEach(id => {
     const el = document.getElementById(id);

--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -1,0 +1,166 @@
+export function initDriftCombinedViz() {
+  const filterPanel = document.querySelector('.param-panel.filter');
+  if (!filterPanel) return;
+
+  const canvas = document.createElement('canvas');
+  canvas.id = 'driftVizCanvas';
+  canvas.width = 300;
+  canvas.height = 88;
+  canvas.style.border = '1px solid #ccc';
+  const paramItems = filterPanel.querySelector('.param-items');
+  if (paramItems) filterPanel.insertBefore(canvas, paramItems); else filterPanel.appendChild(canvas);
+
+  ['driftFilterChart', 'amp-env-canvas', 'env2-canvas'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.style.display = 'none';
+  });
+
+  const ctx = canvas.getContext('2d');
+
+  const qsel = name => document.querySelector(`.param-item[data-name="${name}"] input[type="hidden"]`);
+
+  const filterInputs = {
+    freq: qsel('Filter_Frequency'),
+    type: qsel('Filter_Type'),
+    res: qsel('Filter_Resonance'),
+    hp: qsel('Filter_HiPassFrequency')
+  };
+
+  const qenv = name => document.querySelector(`.param-item[data-name="${name}"] input[type="range"]`);
+
+  const env1 = {
+    attack: qenv('Envelope1_Attack'),
+    decay: qenv('Envelope1_Decay'),
+    sustain: qenv('Envelope1_Sustain'),
+    release: qenv('Envelope1_Release')
+  };
+
+  const env2 = {
+    attack: qenv('Envelope2_Attack'),
+    decay: qenv('Envelope2_Decay'),
+    sustain: qenv('Envelope2_Sustain'),
+    release: qenv('Envelope2_Release'),
+    mode: qsel('Global_Envelope2Mode')
+  };
+
+  function biquadCoeffs(type, freq, q, sr) {
+    const w0 = 2 * Math.PI * freq / sr;
+    const alpha = Math.sin(w0) / (2 * q);
+    const cosw0 = Math.cos(w0);
+    let b0, b1, b2, a0, a1, a2;
+    switch (type) {
+      case 'highpass':
+        b0 = (1 + cosw0) / 2; b1 = -(1 + cosw0); b2 = (1 + cosw0) / 2;
+        a0 = 1 + alpha; a1 = -2 * cosw0; a2 = 1 - alpha; break;
+      case 'lowpass':
+      default:
+        b0 = (1 - cosw0) / 2; b1 = 1 - cosw0; b2 = (1 - cosw0) / 2;
+        a0 = 1 + alpha; a1 = -2 * cosw0; a2 = 1 - alpha; break;
+    }
+    return { b: [b0 / a0, b1 / a0, b2 / a0], a: [1, a1 / a0, a2 / a0] };
+  }
+
+  function biquadMag(b, a, w) {
+    const cos = Math.cos(w);
+    const sin = Math.sin(w);
+    const cos2 = Math.cos(2 * w);
+    const sin2 = Math.sin(2 * w);
+    const numReal = b[0] + b[1] * cos + b[2] * cos2;
+    const numImag = -(b[1] * sin + b[2] * sin2);
+    const denReal = a[0] + a[1] * cos + a[2] * cos2;
+    const denImag = -(a[1] * sin + a[2] * sin2);
+    const numMag = Math.hypot(numReal, numImag);
+    const denMag = Math.hypot(denReal, denImag);
+    return numMag / denMag;
+  }
+
+  function computeResponse(type, freq, res, slope, sr = 44100, n = 256) {
+    const q = 0.5 + 9.5 * res;
+    const { b, a } = biquadCoeffs(type, freq, q, sr);
+    const freqArr = [];
+    const mag = [];
+    for (let i = 0; i < n; i++) {
+      const w = Math.PI * i / (n - 1);
+      let m = biquadMag(b, a, w);
+      if (String(slope) === '24') m *= biquadMag(b, a, w);
+      freqArr.push(sr * i / (2 * (n - 1)));
+      mag.push(20 * Math.log10(m + 1e-9));
+    }
+    return { freq: freqArr, mag };
+  }
+
+  function drawFilter() {
+    const { freq, type, res, hp } = filterInputs;
+    if (!freq || !type || !res || !hp) return;
+    const slope = type.value === 'II' ? '24' : '12';
+    const lp = computeResponse('lowpass', parseFloat(freq.value), parseFloat(res.value), slope);
+    const hpResp = computeResponse('highpass', parseFloat(hp.value), 0, '12');
+    const mag = lp.mag.map((m, i) => {
+      const h1 = Math.pow(10, m / 20);
+      const h2 = Math.pow(10, hpResp.mag[i] / 20);
+      return 20 * Math.log10(h1 * h2 + 1e-9);
+    });
+    drawLine(lp.freq, mag, '#0074D9');
+  }
+
+  function drawEnv(inputs) {
+    const a = parseFloat(inputs.attack.value);
+    const d = parseFloat(inputs.decay.value);
+    const s = parseFloat(inputs.sustain.value);
+    const r = parseFloat(inputs.release.value);
+    const i = inputs.initial ? parseFloat(inputs.initial.value) : 0;
+    const p = inputs.peak ? parseFloat(inputs.peak.value) : 1;
+    const f = inputs.finalVal ? parseFloat(inputs.finalVal.value) : 0;
+    const hold = 0.25;
+    const total = a + d + r + hold;
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.beginPath();
+    ctx.moveTo(0, h - i * h);
+    let x = (a / total) * w;
+    ctx.lineTo(x, h - p * h);
+    const decEnd = x + (d / total) * w;
+    ctx.lineTo(decEnd, h - s * h);
+    const relStart = w - (r / total) * w;
+    ctx.lineTo(relStart, h - s * h);
+    ctx.lineTo(w, h - f * h);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+  }
+
+  function drawLine(freq, mag, color) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.beginPath();
+    const minDb = -60;
+    const maxDb = 12;
+    for (let i = 0; i < freq.length; i++) {
+      const x = (i / (freq.length - 1)) * canvas.width;
+      const db = Math.max(minDb, Math.min(maxDb, mag[i]));
+      const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = color;
+    ctx.stroke();
+  }
+
+  let active = 'filter';
+  function update() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (active === 'env1') drawEnv(env1);
+    else if (active === 'env2' && (!env2.mode || env2.mode.value !== 'Cyc')) drawEnv(env2);
+    else drawFilter();
+  }
+
+  const setFilter = () => { active = 'filter'; update(); };
+  const setEnv1 = () => { active = 'env1'; update(); };
+  const setEnv2 = () => { active = 'env2'; update(); };
+
+  Object.values(filterInputs).forEach(el => el && el.addEventListener('change', setFilter));
+  [env1.attack, env1.decay, env1.sustain, env1.release].forEach(el => el && el.addEventListener('input', setEnv1));
+  [env2.attack, env2.decay, env2.sustain, env2.release].forEach(el => el && el.addEventListener('input', setEnv2));
+  if (env2.mode) env2.mode.addEventListener('change', () => { if (active === 'env2') update(); });
+
+  update();
+}
+
+document.addEventListener('DOMContentLoaded', initDriftCombinedViz);

--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -1,14 +1,15 @@
 export function initDriftCombinedViz() {
   const filterPanel = document.querySelector('.param-panel.filter');
-  if (!filterPanel) return;
+  const env2Canvas = document.getElementById('env2-canvas');
+  const envPanelItems = env2Canvas ? env2Canvas.parentElement : null;
+  if (!filterPanel || !envPanelItems) return;
 
   const canvas = document.createElement('canvas');
   canvas.id = 'driftVizCanvas';
   canvas.width = 300;
   canvas.height = 88;
   canvas.style.border = '1px solid #ccc';
-  const paramItems = filterPanel.querySelector('.param-items');
-  if (paramItems) filterPanel.insertBefore(canvas, paramItems); else filterPanel.appendChild(canvas);
+  envPanelItems.insertBefore(canvas, env2Canvas);
 
   ['driftFilterChart', 'amp-env-canvas', 'env2-canvas'].forEach(id => {
     const el = document.getElementById(id);

--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -90,6 +90,16 @@ export function initDriftCombinedViz() {
     return { freq: freqArr, mag };
   }
 
+  function drawLabel(text) {
+    ctx.save();
+    ctx.font = '10px sans-serif';
+    ctx.fillStyle = '#000';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillText(text, canvas.width - 4, 2);
+    ctx.restore();
+  }
+
   function drawFilter() {
     const { freq, type, res, hp } = filterInputs;
     if (!freq || !type || !res || !hp) return;
@@ -102,9 +112,10 @@ export function initDriftCombinedViz() {
       return 20 * Math.log10(h1 * h2 + 1e-9);
     });
     drawLine(lp.freq, mag, '#0074D9');
+    drawLabel('Filter');
   }
 
-  function drawEnv(inputs) {
+  function drawEnv(inputs, label) {
     const a = parseFloat(inputs.attack.value);
     const d = parseFloat(inputs.decay.value);
     const s = parseFloat(inputs.sustain.value);
@@ -127,6 +138,7 @@ export function initDriftCombinedViz() {
     ctx.lineTo(w, h - f * h);
     ctx.strokeStyle = '#f00';
     ctx.stroke();
+    drawLabel(label);
   }
 
   function drawLine(freq, mag, color) {
@@ -147,9 +159,13 @@ export function initDriftCombinedViz() {
   let active = 'filter';
   function update() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    if (active === 'env1') drawEnv(env1);
-    else if (active === 'env2' && (!env2.mode || env2.mode.value !== 'Cyc')) drawEnv(env2);
-    else drawFilter();
+    if (active === 'env1') {
+      drawEnv(env1, 'Amp');
+    } else if (active === 'env2' && (!env2.mode || env2.mode.value !== 'Cyc')) {
+      drawEnv(env2, 'Env2');
+    } else {
+      drawFilter();
+    }
   }
 
   const setFilter = () => { active = 'filter'; update(); };

--- a/templates_jinja/synth_params.html
+++ b/templates_jinja/synth_params.html
@@ -109,9 +109,8 @@
 <script type="module" src="{{ host_prefix }}/static/synth_params.js"></script>
 <script src="{{ host_prefix }}/static/input-knobs.js"></script>
 <script src="{{ host_prefix }}/static/params_knobs.js"></script>
-<script type="module" src="{{ host_prefix }}/static/param_adsr.js"></script>
 <script src="{{ host_prefix }}/static/rect-slider.js"></script>
-<script type="module" src="{{ host_prefix }}/static/drift_filter_viz.js"></script>
+<script type="module" src="{{ host_prefix }}/static/drift_combined_viz.js"></script>
 <script>
 // Expose parameter metadata before loading the macro sidebar script
 window.driftSchema = {{ schema_json|safe }};


### PR DESCRIPTION
## Summary
- combine Drift envelope and filter displays into a single area
- hide old canvases and draw whichever control was last touched

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, mido, flask)*

------
https://chatgpt.com/codex/tasks/task_e_684909f85a848325af35ddf70b958363