### PR TITLE
Adjust wavetable HP filter range

### DIFF
--- a/static/schemas/wavetable_schema.json
+++ b/static/schemas/wavetable_schema.json
@@ -47,7 +47,7 @@
   },
   "Voice_Filter1_Frequency": {
     "type": "number",
-    "min": 20.0,
+    "min": 10.0,
     "max": 20480.0,
     "options": [],
     "unit": "Hz",
@@ -118,7 +118,7 @@
   },
   "Voice_Filter2_Frequency": {
     "type": "number",
-    "min": 20.0,
+    "min": 10.0,
     "max": 20480.0,
     "options": [],
     "unit": "Hz",

--- a/templates_jinja/filter_viz.html
+++ b/templates_jinja/filter_viz.html
@@ -19,7 +19,7 @@
       </select>
     </label>
     <label>Freq:
-      <input type="number" name="filter1_freq" value="1000" step="1" min="20" max="20000">
+      <input type="number" name="filter1_freq" value="1000" step="1" min="10" max="20000">
     </label>
     <label>Resonance:
       <input type="range" name="filter1_res" value="0.0" min="0" max="1" step="0.01">
@@ -44,7 +44,7 @@
       </select>
     </label>
     <label>Freq:
-      <input type="number" name="filter2_freq" value="1000" step="1" min="20" max="20000">
+      <input type="number" name="filter2_freq" value="1000" step="1" min="10" max="20000">
     </label>
     <label>Resonance:
       <input type="range" name="filter2_res" value="0.0" min="0" max="1" step="0.01">


### PR DESCRIPTION
## Summary
- lower frequency floor to 10Hz in wavetable schema
- allow 10Hz in filter visualization form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490955ce70832580c5f70392b6283a