### PR TITLE
Use log scale for filter plot

### DIFF
--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -23,8 +23,21 @@ export function initFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    // Use a small positive minimum to avoid log(0) while keeping
+    // the lowest portion of the spectrum from dominating the scale.
+    const minFreq = 3;
+    let fMin = Infinity;
+    let fMax = 0;
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minFreq, freq[i]);
+      if (f < fMin) fMin = f;
+      if (f > fMax) fMax = f;
+    }
+    const logMin = Math.log10(fMin);
+    const logMax = Math.log10(fMax);
+    for (let i = 0; i < freq.length; i++) {
+      const f = Math.max(minFreq, freq[i]);
+      const x = (Math.log10(f) - logMin) / (logMax - logMin) * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -26,15 +26,8 @@ export function initFilterViz() {
     // Use a small positive minimum to avoid log(0) while keeping
     // the lowest portion of the spectrum from dominating the scale.
     const minFreq = 3;
-    let fMin = Infinity;
-    let fMax = 0;
-    for (let i = 0; i < freq.length; i++) {
-      const f = Math.max(minFreq, freq[i]);
-      if (f < fMin) fMin = f;
-      if (f > fMax) fMax = f;
-    }
-    const logMin = Math.log10(fMin);
-    const logMax = Math.log10(fMax);
+    const logMin = Math.log10(Math.max(minFreq, freq[1] || freq[0] || minFreq));
+    const logMax = Math.log10(Math.max(minFreq, freq[freq.length - 1]));
     for (let i = 0; i < freq.length; i++) {
       const f = Math.max(minFreq, freq[i]);
       const x = (Math.log10(f) - logMin) / (logMax - logMin) * canvas.width;

--- a/static/wavetable_filter_viz.js
+++ b/static/wavetable_filter_viz.js
@@ -120,8 +120,21 @@ export function initWavetableFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    // Avoid log(0) by clamping to a small value. A slightly higher
+    // threshold keeps the lowest frequencies from stretching the axis.
+    const minFreq = 3;
+    let fMin = Infinity;
+    let fMax = 0;
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minFreq, freq[i]);
+      if (f < fMin) fMin = f;
+      if (f > fMax) fMax = f;
+    }
+    const logMin = Math.log10(fMin);
+    const logMax = Math.log10(fMax);
+    for (let i = 0; i < freq.length; i++) {
+      const f = Math.max(minFreq, freq[i]);
+      const x = (Math.log10(f) - logMin) / (logMax - logMin) * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/wavetable_filter_viz.js
+++ b/static/wavetable_filter_viz.js
@@ -123,15 +123,8 @@ export function initWavetableFilterViz() {
     // Avoid log(0) by clamping to a small value. A slightly higher
     // threshold keeps the lowest frequencies from stretching the axis.
     const minFreq = 3;
-    let fMin = Infinity;
-    let fMax = 0;
-    for (let i = 0; i < freq.length; i++) {
-      const f = Math.max(minFreq, freq[i]);
-      if (f < fMin) fMin = f;
-      if (f > fMax) fMax = f;
-    }
-    const logMin = Math.log10(fMin);
-    const logMax = Math.log10(fMax);
+    const logMin = Math.log10(Math.max(minFreq, freq[1] || freq[0] || minFreq));
+    const logMax = Math.log10(Math.max(minFreq, freq[freq.length - 1]));
     for (let i = 0; i < freq.length; i++) {
       const f = Math.max(minFreq, freq[i]);
       const x = (Math.log10(f) - logMin) / (logMax - logMin) * canvas.width;


### PR DESCRIPTION
## Summary
- render filter frequency responses on a log x-axis
- make the same update for wavetable filter plots
- tweak the minimum frequency clamp so the extreme slope occupies less of the view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684906183988832589ab5ae866f3a8f7