### PR TITLE
Improve filter viz axis scaling

### DIFF
--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -86,11 +86,14 @@ export function initDriftCombinedViz() {
     const { b, a } = biquadCoeffs(type, freq, q, sr);
     const freqArr = [];
     const mag = [];
+    const minF = 10;
+    const maxF = sr / 2;
     for (let i = 0; i < n; i++) {
-      const w = Math.PI * i / (n - 1);
+      const f = minF * Math.pow(maxF / minF, i / (n - 1));
+      const w = 2 * Math.PI * f / sr;
       let m = biquadMag(b, a, w);
       if (String(slope) === '24') m *= biquadMag(b, a, w);
-      freqArr.push(sr * i / (2 * (n - 1)));
+      freqArr.push(f);
       mag.push(20 * Math.log10(m + 1e-9));
     }
     return { freq: freqArr, mag };
@@ -152,8 +155,14 @@ export function initDriftCombinedViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    const minF = 10;
+    const maxF = 22050;
+    const logMin = Math.log10(minF);
+    const logMax = Math.log10(maxF);
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minF, Math.min(maxF, freq[i]));
+      const norm = (Math.log10(f) - logMin) / (logMax - logMin);
+      const x = norm * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/drift_filter_viz.js
+++ b/static/drift_filter_viz.js
@@ -58,13 +58,16 @@ export function initDriftFilterViz() {
     const { b, a } = biquadCoeffs(type, freq, q, sr);
     const freqArr = [];
     const mag = [];
+    const minF = 10;
+    const maxF = sr / 2;
     for (let i = 0; i < n; i++) {
-      const w = Math.PI * i / (n - 1);
+      const f = minF * Math.pow(maxF / minF, i / (n - 1));
+      const w = 2 * Math.PI * f / sr;
       let m = biquadMag(b, a, w);
       if (String(slope) === '24') {
         m *= biquadMag(b, a, w);
       }
-      freqArr.push(sr * i / (2 * (n - 1)));
+      freqArr.push(f);
       mag.push(20 * Math.log10(m + 1e-9));
     }
     return { freq: freqArr, mag };
@@ -87,8 +90,14 @@ export function initDriftFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    const minF = 10;
+    const maxF = 22050;
+    const logMin = Math.log10(minF);
+    const logMax = Math.log10(maxF);
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minF, Math.min(maxF, freq[i]));
+      const norm = (Math.log10(f) - logMin) / (logMax - logMin);
+      const x = norm * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -23,8 +23,14 @@ export function initFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    const minF = 10;
+    const maxF = 22050;
+    const logMin = Math.log10(minF);
+    const logMax = Math.log10(maxF);
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minF, Math.min(maxF, freq[i]));
+      const norm = (Math.log10(f) - logMin) / (logMax - logMin);
+      const x = norm * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);

--- a/static/wavetable_filter_viz.js
+++ b/static/wavetable_filter_viz.js
@@ -73,11 +73,14 @@ export function initWavetableFilterViz() {
     const { b, a } = biquadCoeffs(type, freq, q, sr);
     const freqArr = [];
     const mag = [];
+    const minF = 10;
+    const maxF = sr / 2;
     for (let i = 0; i < n; i++) {
-      const w = Math.PI * i / (n - 1);
+      const f = minF * Math.pow(maxF / minF, i / (n - 1));
+      const w = 2 * Math.PI * f / sr;
       let m = biquadMag(b, a, w);
       if (String(slope) === '24') m *= biquadMag(b, a, w);
-      freqArr.push(sr * i / (2 * (n - 1)));
+      freqArr.push(f);
       mag.push(20 * Math.log10(m + 1e-9));
     }
     return { freq: freqArr, mag };
@@ -120,8 +123,14 @@ export function initWavetableFilterViz() {
     ctx.beginPath();
     const minDb = -60;
     const maxDb = 12;
+    const minF = 10;
+    const maxF = 22050;
+    const logMin = Math.log10(minF);
+    const logMax = Math.log10(maxF);
     for (let i = 0; i < freq.length; i++) {
-      const x = (i / (freq.length - 1)) * canvas.width;
+      const f = Math.max(minF, Math.min(maxF, freq[i]));
+      const norm = (Math.log10(f) - logMin) / (logMax - logMin);
+      const x = norm * canvas.width;
       const db = Math.max(minDb, Math.min(maxDb, mag[i]));
       const y = canvas.height - ((db - minDb) / (maxDb - minDb)) * canvas.height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);


### PR DESCRIPTION
## Summary
- update filter visualization scripts to use logarithmic frequency mapping
- keep the amplitude axis in dB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, flask, mido)*

------
https://chatgpt.com/codex/tasks/task_e_68491fdfe4588325997cfb4c53e1e3e8