### PR TITLE
Make macro knob section sticky

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -822,6 +822,12 @@ select {
 
 .macro-knobs-section {
     text-align: center;
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 10;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
 }
 
 .macro-knobs-section h3 {


### PR DESCRIPTION
## Summary
- ensure the macro knob section stays pinned to the top of the editor when scrolling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492330be708325b9878e011bce0b10