### PR TITLE
Improve macro knob visual switching

### DIFF
--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -163,6 +163,13 @@ export function initDriftCombinedViz() {
   }
 
   let active = 'filter';
+
+  window.driftVizSetMode = (mode) => {
+    if (['filter', 'env1', 'env2'].includes(mode)) {
+      active = mode;
+      update();
+    }
+  };
   function update() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     if (active === 'env1') {


### PR DESCRIPTION
## Summary
- add `paramSection` helper for macro handling
- switch the Drift combined visualization when turning macro knobs
- expose `driftVizSetMode` in combined viz JS for external control

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684926be5fe48325898959e2c060205b