### PR TITLE
Improve macro knob visual switching

### DIFF
--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -163,6 +163,13 @@ export function initDriftCombinedViz() {
   }
 
   let active = 'filter';
+
+  window.driftVizSetMode = (mode) => {
+    if (['filter', 'env1', 'env2'].includes(mode)) {
+      active = mode;
+      update();
+    }
+  };
   function update() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     if (active === 'env1') {

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -6,6 +6,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const schema = window.driftSchema || {};
   const paramDisplay = {};
   const paramInfo = {};
+  function paramSection(name) {
+    if (!name) return null;
+    const n = name.toLowerCase();
+    if (n.includes('filter')) return 'filter';
+    if (n.startsWith('envelope1_') || n.includes('ampenvelope')) return 'amp';
+    if (n.startsWith('envelope2_') || n.startsWith('cyclingenvelope_') || n === 'global_envelope2mode') return 'env';
+    return null;
+  }
   function addSpaces(str) {
     return str
       .replace(/([A-Za-z])([0-9])/g, '$1 $2')
@@ -493,7 +501,24 @@ document.addEventListener('DOMContentLoaded', () => {
 
   macrosInput.addEventListener('change', applyMacroVisuals);
   document.querySelectorAll('.macro-dial').forEach(d => {
-    d.addEventListener('input', applyMacroVisuals);
+    d.addEventListener('input', () => {
+      const m = d.dataset.target.match(/macro_(\d+)_value/);
+      const idx = m ? parseInt(m[1], 10) : NaN;
+      const macro = macros.find(mc => mc.index === idx);
+      if (macro && window.driftVizSetMode) {
+        const sections = new Set();
+        (macro.parameters || []).forEach(p => {
+          const sec = paramSection(p.name);
+          if (sec) sections.add(sec);
+        });
+        let mode = null;
+        if (sections.has('filter')) mode = 'filter';
+        else if (sections.has('amp')) mode = 'env1';
+        else if (sections.has('env')) mode = 'env2';
+        if (mode) window.driftVizSetMode(mode);
+      }
+      applyMacroVisuals();
+    });
   });
 
   applyMacroVisuals();

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -447,6 +447,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const dispEl = document.getElementById(dispId);
         if (dispEl) dispEl.textContent = formatDialValue(dial, value);
       }
+      const target = dial.dataset.target;
+      if (target) {
+        const hidden = document.querySelector(`input[name="${target}"]`);
+        if (hidden) {
+          hidden.value = value;
+          hidden.dispatchEvent(new Event('change'));
+        }
+      }
       return;
     }
     const select = item.querySelector('select.param-select');


### PR DESCRIPTION
## Summary
- broaden `paramSection` detection logic for filter, amp, and envelope parameters
- keep visualization switching via `driftVizSetMode`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684926be5fe48325898959e2c060205b