### PR TITLE
Center filter visualizations around 0dB

### DIFF
--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -152,7 +152,7 @@ export function initDriftCombinedViz() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.beginPath();
     const minDb = -60;
-    const maxDb = 0;
+    const maxDb = 60;
     const logMin = Math.log10(10);
     const logMax = Math.log10(20000);
     for (let i = 0; i < freq.length; i++) {

--- a/static/drift_filter_viz.js
+++ b/static/drift_filter_viz.js
@@ -86,7 +86,7 @@ export function initDriftFilterViz() {
   function drawLine(freq, mag, color) {
     ctx.beginPath();
     const minDb = -60;
-    const maxDb = 0;
+    const maxDb = 60;
     const logMin = Math.log10(10);
     const logMax = Math.log10(20000);
     for (let i = 0; i < freq.length; i++) {

--- a/static/filter_viz.js
+++ b/static/filter_viz.js
@@ -22,7 +22,7 @@ export function initFilterViz() {
   function drawLine(freq, mag, color) {
     ctx.beginPath();
     const minDb = -60;
-    const maxDb = 0;
+    const maxDb = 60;
     const logMin = Math.log10(10);
     const logMax = Math.log10(20000);
     for (let i = 0; i < freq.length; i++) {

--- a/static/wavetable_filter_viz.js
+++ b/static/wavetable_filter_viz.js
@@ -138,7 +138,7 @@ export function initWavetableFilterViz() {
   function drawLine(freq, mag, color) {
     ctx.beginPath();
     const minDb = -60;
-    const maxDb = 0;
+    const maxDb = 60;
     const logMin = Math.log10(10);
     const logMax = Math.log10(20000);
     for (let i = 0; i < freq.length; i++) {


### PR DESCRIPTION
## Summary
- center y-axis in filter visualizations on 0 dB for clearer resonance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684929df5d888325ac396d78d8d9a101