### PR TITLE
Enable macro knobs to control toggles

### DIFF
--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -448,6 +448,19 @@ document.addEventListener('DOMContentLoaded', () => {
       if (hid) hid.value = value;
       return;
     }
+    const toggle = item.querySelector('input.param-toggle');
+    if (toggle) {
+      const hid = item.querySelector('input[type="hidden"][name$="_value"]');
+      const trueVal = toggle.dataset.trueValue ?? '1';
+      const falseVal = toggle.dataset.falseValue ?? '0';
+      const isOn = String(value) === trueVal || (!isNaN(value) && parseFloat(value) >= 1);
+      toggle.checked = isOn;
+      if (hid) {
+        hid.value = isOn ? trueVal : falseVal;
+        hid.dispatchEvent(new Event('change'));
+      }
+      return;
+    }
     const slider = item.querySelector('.rect-slider');
     if (slider) {
       if (typeof slider._sliderUpdate === 'function') {
@@ -472,6 +485,11 @@ document.addEventListener('DOMContentLoaded', () => {
           const opts = info.options;
           const idx = Math.min(Math.floor((mval / 127) * opts.length), opts.length - 1);
           const val = opts[idx];
+          updateParamVisual(p.name, val);
+          mappedNow.add(p.name);
+          return;
+        } else if (info.type === 'boolean') {
+          const val = mval >= 64 ? 1 : 0;
           updateParamVisual(p.name, val);
           mappedNow.add(p.name);
           return;


### PR DESCRIPTION
## Summary
- allow macro knob visuals to update toggle inputs
- interpret boolean parameters in macro mappings using 0-63 as off and 64-127 as on

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492b97a7a883259b72d5d7f75dbef3