### PR TITLE
Add LFO visualizer

### DIFF
--- a/core/lfo_visualizer.py
+++ b/core/lfo_visualizer.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Utility functions for the LFO visualizer."""
+
+from typing import Dict, Tuple, List
+import numpy as np
+
+
+def get_lfo_defaults() -> Dict[str, float | str]:
+    """Return default LFO parameter values."""
+    return {
+        "shape": "sine",
+        "rate": 1.0,
+        "offset": 0.0,
+        "amount": 1.0,
+        "attack": 0.0,
+    }
+
+
+def compute_lfo_cycle(
+    shape: str,
+    rate: float,
+    offset: float,
+    amount: float,
+    attack: float,
+    duration: float = 1.0,
+    n: int = 100,
+) -> Tuple[List[float], List[float]]:
+    """Generate an LFO cycle for visualization."""
+    t = np.linspace(0.0, duration, n)
+    phase = rate * t
+    s = shape.lower()
+    if s == "saw":
+        base = 2 * (phase % 1) - 1
+    elif s == "square":
+        base = np.where((phase % 1) < 0.5, 1.0, -1.0)
+    elif s == "triangle":
+        base = 1 - 4 * np.abs(np.round(phase - 0.25) - (phase - 0.25))
+    else:  # default to sine
+        base = np.sin(2 * np.pi * phase)
+
+    if attack > 0:
+        env = np.clip(t / attack, 0.0, 1.0)
+    else:
+        env = 1.0
+    y = offset + amount * env * base
+    return t.tolist(), y.tolist()

--- a/handlers/lfo_handler_class.py
+++ b/handlers/lfo_handler_class.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Handler for the LFO visualizer."""
+
+from handlers.base_handler import BaseHandler
+from core.lfo_visualizer import get_lfo_defaults
+
+
+class LFOHandler(BaseHandler):
+    """Provide default values for the LFO page."""
+
+    def handle_get(self):
+        return {
+            "defaults": get_lfo_defaults(),
+            "message": "Adjust parameters to shape the LFO",
+            "message_type": "info",
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -42,6 +42,7 @@ from handlers.filter_viz_handler_class import FilterVizHandler
 from handlers.update_handler_class import UpdateHandler, REPO
 from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
+from handlers.lfo_handler_class import LFOHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -129,6 +130,7 @@ filter_viz_handler = FilterVizHandler()
 update_handler = UpdateHandler()
 adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
+lfo_handler = LFOHandler()
 
 
 @app.before_request
@@ -360,6 +362,21 @@ def cyc_env_route():
         message_type=message_type,
         defaults=defaults,
         active_tab="cyc-env",
+    )
+
+
+@app.route("/lfo", methods=["GET"])
+def lfo_route():
+    result = lfo_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    defaults = result.get("defaults", {})
+    return render_template(
+        "lfo.html",
+        message=message,
+        message_type=message_type,
+        defaults=defaults,
+        active_tab="lfo",
     )
 
 

--- a/static/lfo.js
+++ b/static/lfo.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const shapeEl = document.getElementById('shape');
+  const rateEl = document.getElementById('rate');
+  const offsetEl = document.getElementById('offset');
+  const amountEl = document.getElementById('amount');
+  const attackEl = document.getElementById('attack');
+  const canvas = document.getElementById('lfo-canvas');
+  const ctx = canvas.getContext('2d');
+
+  function waveform(p, shape) {
+    if (shape === 'saw') return (2 * (p % 1)) - 1;
+    if (shape === 'square') return (p % 1) < 0.5 ? 1 : -1;
+    if (shape === 'triangle') return 1 - 4 * Math.abs(Math.round(p - 0.25) - (p - 0.25));
+    return Math.sin(2 * Math.PI * p);
+  }
+
+  function draw() {
+    const shape = shapeEl.value;
+    const rate = parseFloat(rateEl.value);
+    const offset = parseFloat(offsetEl.value);
+    const amount = parseFloat(amountEl.value);
+    const attack = parseFloat(attackEl.value);
+    const steps = 200;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.beginPath();
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const phase = rate * t;
+      const env = attack > 0 ? Math.min(1, t / attack) : 1;
+      const val = offset + amount * env * waveform(phase, shape);
+      const x = t * canvas.width;
+      const y = canvas.height - ((val + 1) / 2) * canvas.height;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+  }
+
+  [shapeEl, rateEl, offsetEl, amountEl, attackEl].forEach(el => el.addEventListener('input', draw));
+  draw();
+});

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -17,6 +17,7 @@
         <!-- <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a> -->
         <!-- <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a> -->
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
+        <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>

--- a/templates_jinja/lfo.html
+++ b/templates_jinja/lfo.html
@@ -1,0 +1,34 @@
+{% block content %}
+<h2>LFO Visualizer</h2>
+{% if message %}
+  <p class="{{ message_type }}">{{ message }}</p>
+{% endif %}
+<canvas id="lfo-canvas" width="300" height="150"></canvas>
+<div id="lfo-controls">
+  <label>Shape
+    <select id="shape">
+      <option value="sine">Sine</option>
+      <option value="triangle">Triangle</option>
+      <option value="square">Square</option>
+      <option value="saw">Saw</option>
+    </select>
+  </label>
+  <label>Rate
+    <input type="range" id="rate" class="input-knob" min="0.1" max="20" step="0.1" value="{{ defaults.rate }}">
+  </label>
+  <label>Offset
+    <input type="range" id="offset" class="input-knob" min="-1" max="1" step="0.01" value="{{ defaults.offset }}">
+  </label>
+  <label>Amount
+    <input type="range" id="amount" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.amount }}">
+  </label>
+  <label>Attack
+    <input type="range" id="attack" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.attack }}">
+  </label>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/shared.js"></script>
+<script src="{{ host_prefix }}/static/input-knobs.js"></script>
+<script src="{{ host_prefix }}/static/lfo.js"></script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -77,6 +77,27 @@ def test_cyc_env_get(client, monkeypatch):
     assert b'id="tilt"' in resp.data
     assert b'id="hold"' in resp.data
 
+
+def test_lfo_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'defaults': {
+                'shape': 'sine',
+                'rate': 1.0,
+                'offset': 0.0,
+                'amount': 1.0,
+                'attack': 0.0,
+            },
+            'message': 'hello',
+            'message_type': 'info',
+        }
+
+    monkeypatch.setattr(move_webserver.lfo_handler, 'handle_get', fake_get)
+    resp = client.get('/lfo')
+    assert resp.status_code == 200
+    assert b'LFO Visualizer' in resp.data
+    assert b'id="rate"' in resp.data
+
 def test_restore_get(client, monkeypatch):
     def fake_get():
         return {'options': '<option value="1">1</option>', 'pad_grid': '<div class="pad-grid"></div>', 'message': ''}

--- a/tests/test_lfo_visualizer.py
+++ b/tests/test_lfo_visualizer.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.lfo_visualizer import compute_lfo_cycle
+
+
+def test_sine_cycle():
+    t, y = compute_lfo_cycle('sine', 1.0, 0.0, 1.0, 0.0, n=5, duration=1.0)
+    assert len(t) == 5 and len(y) == 5
+    # quarter cycle at index 1 (~0.25s)
+    assert abs(y[1] - 1.0) < 1e-6
+    # half cycle should return near 0
+    assert abs(y[2]) < 1e-6
+
+
+def test_attack_scaling():
+    _, y = compute_lfo_cycle('sine', 1.0, 0.0, 1.0, 0.5, n=3, duration=0.5)
+    # final value should have reached full amplitude
+    assert abs(y[-1]) > abs(y[0])


### PR DESCRIPTION
## Summary
- visualize LFO cycles in the web UI
- implement `compute_lfo_cycle` for generating LFO data
- provide `/lfo` route and page
- add frontend drawing code
- test new core logic and route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684946fb6b4083258c2b03447ed1eeff