### PR TITLE
Add LFO cycle visualizer

### DIFF
--- a/core/lfo_handler.py
+++ b/core/lfo_handler.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Defaults for the LFO visualizer."""
+
+from typing import Dict
+
+
+def get_lfo_defaults() -> Dict[str, float | str]:
+    """Return default values for the LFO visualizer."""
+    return {
+        "shape": "sine",
+        "rate": 1.0,
+        "offset": 0.0,
+        "amount": 1.0,
+        "attack": 0.0,
+    }

--- a/handlers/lfo_handler_class.py
+++ b/handlers/lfo_handler_class.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Handler for the LFO cycle visualizer."""
+
+from handlers.base_handler import BaseHandler
+from core.lfo_handler import get_lfo_defaults
+
+
+class LfoHandler(BaseHandler):
+    """Provide default values for the LFO visualizer."""
+
+    def handle_get(self):
+        """Return default LFO settings."""
+        return {
+            "defaults": get_lfo_defaults(),
+            "message": "Adjust parameters to shape the LFO",
+            "message_type": "info",
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -42,6 +42,7 @@ from handlers.filter_viz_handler_class import FilterVizHandler
 from handlers.update_handler_class import UpdateHandler, REPO
 from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
+from handlers.lfo_handler_class import LfoHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -129,6 +130,7 @@ filter_viz_handler = FilterVizHandler()
 update_handler = UpdateHandler()
 adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
+lfo_handler = LfoHandler()
 
 
 @app.before_request
@@ -360,6 +362,21 @@ def cyc_env_route():
         message_type=message_type,
         defaults=defaults,
         active_tab="cyc-env",
+    )
+
+
+@app.route("/lfo", methods=["GET"])
+def lfo_route():
+    result = lfo_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    defaults = result.get("defaults", {})
+    return render_template(
+        "lfo.html",
+        message=message,
+        message_type=message_type,
+        defaults=defaults,
+        active_tab="lfo",
     )
 
 

--- a/static/lfo.js
+++ b/static/lfo.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const shapeEl = document.getElementById('shape');
+  const rateEl = document.getElementById('rate');
+  const attackEl = document.getElementById('attack');
+  const offsetEl = document.getElementById('offset');
+  const amountEl = document.getElementById('amount');
+  const canvas = document.getElementById('lfo-canvas');
+  const ctx = canvas.getContext('2d');
+
+  function wave(shape, phase) {
+    const p = phase % 1;
+    switch(shape) {
+      case 'sine':
+        return Math.sin(2 * Math.PI * p);
+      case 'square':
+        return p < 0.5 ? 1 : -1;
+      case 'triangle':
+        return 1 - 4 * Math.abs(Math.round(p - 0.25) - (p - 0.25));
+      case 'saw':
+        return 2 * p - 1;
+      default:
+        return 0;
+    }
+  }
+
+  function draw() {
+    const rate = parseFloat(rateEl.value);
+    const attack = parseFloat(attackEl.value);
+    const offset = parseFloat(offsetEl.value);
+    const amount = parseFloat(amountEl.value);
+    const shape = shapeEl.value;
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    ctx.beginPath();
+    const duration = 1; // seconds shown
+    for (let i = 0; i <= w; i++) {
+      const t = (i / w) * duration;
+      let amp = amount;
+      if (attack > 0 && t < attack) {
+        amp = amount * t / attack;
+      }
+      const ph = rate * t + offset;
+      const val = wave(shape, ph) * amp * 0.5 + 0.5;
+      const y = h - val * h;
+      if (i === 0) ctx.moveTo(i, y); else ctx.lineTo(i, y);
+    }
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+  }
+
+  [shapeEl, rateEl, attackEl, offsetEl, amountEl].forEach(el => el.addEventListener('input', draw));
+  draw();
+});

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -19,7 +19,7 @@
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
-        <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a>
+        <!-- <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a> -->
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
         <a href="{{ host_prefix }}/update" class="{% if active_tab == 'update' %}active{% endif %} right">Update</a>
     </nav>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -19,6 +19,7 @@
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
+        <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a>
         <a href="{{ host_prefix }}/midi-upload" class="{% if active_tab == 'midi-upload' %}active{% endif %}">MIDI</a>
         <a href="{{ host_prefix }}/update" class="{% if active_tab == 'update' %}active{% endif %} right">Update</a>
     </nav>

--- a/templates_jinja/lfo.html
+++ b/templates_jinja/lfo.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>LFO Cycle Visualizer</h2>
+{% if message %}
+  <p class="{{ message_type }}">{{ message }}</p>
+{% endif %}
+<canvas id="lfo-canvas" width="300" height="150"></canvas>
+<div id="lfo-controls">
+  <label>Shape
+    <select id="shape">
+      <option value="sine" {% if defaults.shape == 'sine' %}selected{% endif %}>Sine</option>
+      <option value="square" {% if defaults.shape == 'square' %}selected{% endif %}>Square</option>
+      <option value="triangle" {% if defaults.shape == 'triangle' %}selected{% endif %}>Triangle</option>
+      <option value="saw" {% if defaults.shape == 'saw' %}selected{% endif %}>Saw</option>
+    </select>
+  </label>
+  <label>Rate
+    <input type="range" id="rate" class="input-knob" min="0.1" max="10" step="0.1" value="{{ defaults.rate }}">
+  </label>
+  <label>Attack
+    <input type="range" id="attack" class="input-knob" min="0" max="2" step="0.01" value="{{ defaults.attack }}">
+  </label>
+  <label>Offset
+    <input type="range" id="offset" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.offset }}">
+  </label>
+  <label>Amount
+    <input type="range" id="amount" class="input-knob" min="0" max="1" step="0.01" value="{{ defaults.amount }}">
+  </label>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/shared.js"></script>
+<script src="{{ host_prefix }}/static/input-knobs.js"></script>
+<script src="{{ host_prefix }}/static/lfo.js"></script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -77,6 +77,30 @@ def test_cyc_env_get(client, monkeypatch):
     assert b'id="tilt"' in resp.data
     assert b'id="hold"' in resp.data
 
+def test_lfo_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'defaults': {
+                'shape': 'sine',
+                'rate': 1.0,
+                'offset': 0.0,
+                'amount': 1.0,
+                'attack': 0.0,
+            },
+            'message': 'hello',
+            'message_type': 'info',
+        }
+
+    monkeypatch.setattr(move_webserver.lfo_handler, 'handle_get', fake_get)
+    resp = client.get('/lfo')
+    assert resp.status_code == 200
+    assert b'LFO Cycle Visualizer' in resp.data
+    assert b'id="shape"' in resp.data
+    assert b'id="rate"' in resp.data
+    assert b'id="offset"' in resp.data
+    assert b'id="amount"' in resp.data
+    assert b'id="attack"' in resp.data
+
 def test_restore_get(client, monkeypatch):
     def fake_get():
         return {'options': '<option value="1">1</option>', 'pad_grid': '<div class="pad-grid"></div>', 'message': ''}


### PR DESCRIPTION
## Summary
- add defaults for an LFO visualizer
- wire up new LFO handler and route
- build frontend JS and template for LFO waveform display
- expose navigation link for the new visualizer
- test the new route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684948c28e988325adc5d4d1ef6dd4a4