### PR TITLE
Fix LFO Hz range

### DIFF
--- a/templates_jinja/lfo.html
+++ b/templates_jinja/lfo.html
@@ -15,7 +15,7 @@
     </select>
   </label>
   <label>Rate
-    <input type="range" id="rate" class="input-knob" min="0.1" max="10" step="0.1" value="{{ defaults.rate }}">
+    <input type="range" id="rate" class="input-knob" min="0.17" max="1700" step="0.01" value="{{ defaults.rate }}">
   </label>
   <label>Attack
     <input type="range" id="attack" class="input-knob" min="0" max="2" step="0.01" value="{{ defaults.attack }}">


### PR DESCRIPTION
## Summary
- adjust the rate slider in the LFO visualizer template to allow 0.17Hz–1.7kHz

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494d6f51848325a950c54ce3ced315