### PR TITLE
Update LFO visualization scaling

### DIFF
--- a/static/drift_lfo_viz.js
+++ b/static/drift_lfo_viz.js
@@ -78,7 +78,13 @@ export function initDriftLfoViz() {
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
-    const duration = 1;
+    const minCycles = 2;
+    const maxCycles = 10;
+    const minRate = 0.17; // matches standalone LFO viz
+    const maxRate = 1700;
+    const rateNorm = Math.max(0, Math.min(1, (rate - minRate) / (maxRate - minRate)));
+    const cycles = minCycles + (maxCycles - minCycles) * rateNorm;
+    const duration = rate > 0 ? cycles / rate : 0;
     for (let i = 0; i <= w; i++) {
       const t = (i / w) * duration;
       const ph = rate * t;

--- a/static/lfo.js
+++ b/static/lfo.js
@@ -33,7 +33,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
-    const duration = 1; // seconds shown
+    const minCycles = 2;
+    const maxCycles = 10;
+    const minRate = parseFloat(rateEl.min || '0');
+    const maxRate = parseFloat(rateEl.max || '1');
+    const rateNorm = Math.max(0, Math.min(1, (rate - minRate) / (maxRate - minRate)));
+    const cycles = minCycles + (maxCycles - minCycles) * rateNorm;
+    const duration = rate > 0 ? cycles / rate : 0; // seconds shown for chosen cycles
     for (let i = 0; i <= w; i++) {
       const t = (i / w) * duration;
       let amp = amount;


### PR DESCRIPTION
## Summary
- scale LFO visualization to display 2–10 cycles depending on the rate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495afb3d548325bfe0299bd3b99722