### PR TITLE
Adjust LFO visualization scaling

### DIFF
--- a/static/lfo.js
+++ b/static/lfo.js
@@ -33,7 +33,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
-    const duration = 1; // seconds shown
+
+    const minRate = parseFloat(rateEl.min || '0');
+    const maxRate = parseFloat(rateEl.max || '1');
+    const ratio = Math.min(Math.max((rate - minRate) / (maxRate - minRate), 0), 1);
+    const cycles = 1 + ratio * 9;
+    const duration = cycles / (rate || 1); // seconds shown
     for (let i = 0; i <= w; i++) {
       const t = (i / w) * duration;
       let amp = amount;


### PR DESCRIPTION
## Summary
- allow the generic LFO plot to show 1--10 cycles based on rate knob
- scale Drift LFO visualization with the active knob

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495f8b4fe48325b2fa4d723fa148f3