### PR TITLE
Fix env2 auto-switch when using macros

### DIFF
--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -504,6 +504,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!item) return;
     const dial = item.querySelector('input.param-dial');
     if (dial) {
+      if (parseFloat(dial.value) === parseFloat(value)) return;
       dial.value = value;
       dial.setAttribute('value', value);
       if (dial.inputKnobs && typeof dial.redraw === 'function') dial.redraw(true);
@@ -525,6 +526,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const select = item.querySelector('select.param-select');
     if (select) {
+      if (select.value === String(value)) return;
       select.value = value;
       const hid = item.querySelector('input[type="hidden"][name$="_value"]');
       if (hid) hid.value = value;
@@ -537,20 +539,27 @@ document.addEventListener('DOMContentLoaded', () => {
       const trueVal = toggle.dataset.trueValue ?? '1';
       const falseVal = toggle.dataset.falseValue ?? '0';
       const isOn = String(value) === trueVal || (!isNaN(value) && parseFloat(value) >= 1);
-      toggle.checked = isOn;
-      if (hid) {
-        hid.value = isOn ? trueVal : falseVal;
-        hid.dispatchEvent(new Event('change'));
+      if (toggle.checked !== isOn) {
+        toggle.checked = isOn;
+        if (hid) {
+          hid.value = isOn ? trueVal : falseVal;
+          hid.dispatchEvent(new Event('change'));
+        }
+        toggle.dispatchEvent(new Event('change'));
       }
-      toggle.dispatchEvent(new Event('change'));
       return;
     }
     const slider = item.querySelector('.rect-slider');
     if (slider) {
-      if (typeof slider._sliderUpdate === 'function') {
-        slider._sliderUpdate(value);
+      const targetId = slider.dataset.target;
+      const target = targetId ? document.querySelector(`#${targetId}, input[name="${targetId}"]`) : null;
+      const curVal = target ? parseFloat(target.value) : NaN;
+      if (isNaN(curVal) || curVal !== parseFloat(value)) {
+        if (typeof slider._sliderUpdate === 'function') {
+          slider._sliderUpdate(value);
+        }
+        slider.dispatchEvent(new Event('input'));
       }
-      slider.dispatchEvent(new Event('input'));
     }
   }
 

--- a/static/macro_sidebar.js
+++ b/static/macro_sidebar.js
@@ -563,7 +563,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function applyMacroVisuals() {
+  function applyMacroVisuals(changedIdx = null) {
     const macroValues = {};
     document.querySelectorAll('input[name^="macro_"][name$="_value"]').forEach(h => {
       const m = h.name.match(/macro_(\d+)_value/);
@@ -574,25 +574,24 @@ document.addEventListener('DOMContentLoaded', () => {
     macros.forEach(m => {
       const mval = macroValues[m.index] ?? 0;
       (m.parameters || []).forEach(p => {
+        mappedNow.add(p.name);
+        if (changedIdx !== null && m.index !== changedIdx) return;
         const info = paramInfo[p.name] || {};
         if (info.type === 'enum' && Array.isArray(info.options)) {
           const opts = info.options;
           const idx = Math.min(Math.floor((mval / 127) * opts.length), opts.length - 1);
           const val = opts[idx];
           updateParamVisual(p.name, val);
-          mappedNow.add(p.name);
           return;
         } else if (info.type === 'boolean') {
           const val = mval >= 64 ? 1 : 0;
           updateParamVisual(p.name, val);
-          mappedNow.add(p.name);
           return;
         }
         let min = p.rangeMin !== undefined ? parseFloat(p.rangeMin) : (info.min !== undefined ? parseFloat(info.min) : 0);
         let max = p.rangeMax !== undefined ? parseFloat(p.rangeMax) : (info.max !== undefined ? parseFloat(info.max) : 127);
         const val = min + (max - min) * (mval / 127);
         updateParamVisual(p.name, val);
-        mappedNow.add(p.name);
       });
     });
 
@@ -619,8 +618,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (macro) {
         const sections = macroSections(macro);
         activateViz(sections);
+        applyMacroVisuals(idx);
+      } else {
+        applyMacroVisuals();
       }
-      applyMacroVisuals();
     });
   });
 


### PR DESCRIPTION
## Summary
- prevent redundant parameter events when value hasn't changed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6849681ad3388325bbcca961d5949e7e