### PR TITLE
Apply tilt curve to Drift cyc env

### DIFF
--- a/static/drift_combined_viz.js
+++ b/static/drift_combined_viz.js
@@ -211,7 +211,14 @@ export function initDriftCombinedViz() {
       } else {
         const denom = 1 - fallStart;
         const p = denom === 0 ? 0 : (phase - fallStart) / denom;
-        y = denom === 0 ? 1 : 1 - p;
+        let linear = denom === 0 ? 1 : 1 - p;
+        if (mid < 0.2 && denom !== 0) {
+          const t = (0.2 - mid) / 0.2;
+          const k = 5;
+          const curve = (1 / (1 + (k - 1) * p) - 1 / k) / (1 - 1 / k);
+          linear = linear * (1 - t) + curve * t;
+        }
+        y = linear;
       }
       const x = (phase * duration / maxTime) * w;
       const yPix = h - y * h;


### PR DESCRIPTION
## Summary
- use same curve logic as `/cyc-env` when Mid point < 0.2 for Drift's cycling envelope visualizer

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496c11e2c08325972b6dc502468960