### PR TITLE
Add LFO2 visualization for Wavetable editor

### DIFF
--- a/static/wavetable_lfo_viz.js
+++ b/static/wavetable_lfo_viz.js
@@ -1,29 +1,4 @@
 export function initWavetableLfoViz() {
-  const canvas = document.getElementById('lfo1-canvas');
-  if (!canvas) return;
-  const ctx = canvas.getContext('2d');
-
-  const qRange = name => {
-    const item = document.querySelector(`.param-item[data-name="${name}"]`);
-    if (!item) return null;
-    return item.querySelector('input[type="range"]');
-  };
-  const qSelect = name => {
-    const item = document.querySelector(`.param-item[data-name="${name}"]`);
-    return item ? item.querySelector('select') : null;
-  };
-
-  const rateEl = qRange('Voice_Modulators_Lfo1_Time_Rate');
-  const syncRateEl = qRange('Voice_Modulators_Lfo1_Time_SyncedRate');
-  const syncSel = qSelect('Voice_Modulators_Lfo1_Time_Sync');
-  const shapeSel = qSelect('Voice_Modulators_Lfo1_Shape_Type');
-  const amountEl = qRange('Voice_Modulators_Lfo1_Shape_Amount');
-  const attackEl = qRange('Voice_Modulators_Lfo1_Time_AttackTime');
-  const offsetEl = qRange('Voice_Modulators_Lfo1_Shape_PhaseOffset');
-
-  const rateItem = document.querySelector('.param-item[data-name="Voice_Modulators_Lfo1_Time_Rate"]');
-  const syncRateItem = document.querySelector('.param-item[data-name="Voice_Modulators_Lfo1_Time_SyncedRate"]');
-
   const SYNC_RATES = [
     8, 6, 4, 3, 2, 1.5, 1, 0.75, 0.5, 0.375, 1/3, 5/16,
     0.25, 3/16, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48,
@@ -57,64 +32,93 @@ export function initWavetableLfoViz() {
     }
   }
 
-  function getRateHz() {
-    if (syncSel && syncSel.value === 'Tempo' && syncRateEl) {
-      const idx = parseInt(syncRateEl.value || '0', 10);
-      const bars = SYNC_RATES[idx] || 1;
-      const beats = bars * 4;
-      const sec = (60 / BPM) * beats;
-      return sec > 0 ? 1 / sec : 0;
+  function setupLfo(idx) {
+    const canvas = document.getElementById(`lfo${idx}-canvas`);
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+
+    const qRange = name => {
+      const item = document.querySelector(`.param-item[data-name="${name}"]`);
+      if (!item) return null;
+      return item.querySelector('input[type="range"]');
+    };
+    const qSelect = name => {
+      const item = document.querySelector(`.param-item[data-name="${name}"]`);
+      return item ? item.querySelector('select') : null;
+    };
+
+    const rateEl = qRange(`Voice_Modulators_Lfo${idx}_Time_Rate`);
+    const syncRateEl = qRange(`Voice_Modulators_Lfo${idx}_Time_SyncedRate`);
+    const syncSel = qSelect(`Voice_Modulators_Lfo${idx}_Time_Sync`);
+    const shapeSel = qSelect(`Voice_Modulators_Lfo${idx}_Shape_Type`);
+    const amountEl = qRange(`Voice_Modulators_Lfo${idx}_Shape_Amount`);
+    const attackEl = qRange(`Voice_Modulators_Lfo${idx}_Time_AttackTime`);
+    const offsetEl = qRange(`Voice_Modulators_Lfo${idx}_Shape_PhaseOffset`);
+
+    const rateItem = document.querySelector(`.param-item[data-name="Voice_Modulators_Lfo${idx}_Time_Rate"]`);
+    const syncRateItem = document.querySelector(`.param-item[data-name="Voice_Modulators_Lfo${idx}_Time_SyncedRate"]`);
+
+    function getRateHz() {
+      if (syncSel && syncSel.value === 'Tempo' && syncRateEl) {
+        const sidx = parseInt(syncRateEl.value || '0', 10);
+        const bars = SYNC_RATES[sidx] || 1;
+        const beats = bars * 4;
+        const sec = (60 / BPM) * beats;
+        return sec > 0 ? 1 / sec : 0;
+      }
+      return parseFloat(rateEl?.value || '0');
     }
-    return parseFloat(rateEl?.value || '0');
+
+    function draw() {
+      const rate = getRateHz();
+      const shape = shapeSel ? shapeSel.value : 'Sine';
+      const amount = parseFloat(amountEl?.value || '1');
+      const attack = parseFloat(attackEl?.value || '0');
+      const offset = parseFloat(offsetEl?.value || '0') / 360;
+      const w = canvas.width;
+      const h = canvas.height;
+      ctx.clearRect(0, 0, w, h);
+      ctx.beginPath();
+      let ratio = 0;
+      if (syncSel && syncSel.value === 'Tempo' && syncRateEl) {
+        ratio = knobRatio(syncRateEl, SYNC_RATES.length - 1);
+      } else if (rateEl) {
+        ratio = knobRatio(rateEl);
+      }
+      const cycles = 2 + ratio * 8;
+      const duration = rate > 0 ? cycles / rate : 1;
+      for (let i = 0; i <= w; i++) {
+        const t = (i / w) * duration;
+        let amp = amount;
+        if (attack > 0 && t < attack) amp = amount * t / attack;
+        const ph = rate * t + offset;
+        const val = wave(shape, ph) * amp * 0.5 + 0.5;
+        const y = h - val * h;
+        if (i === 0) ctx.moveTo(i, y); else ctx.lineTo(i, y);
+      }
+      ctx.strokeStyle = '#f00';
+      ctx.stroke();
+    }
+
+    function updateRateDisplay() {
+      if (!syncSel) return;
+      const tempo = syncSel.value === 'Tempo';
+      if (rateItem) rateItem.classList.toggle('hidden', tempo);
+      if (syncRateItem) syncRateItem.classList.toggle('hidden', !tempo);
+    }
+
+    [rateEl, syncRateEl, syncSel, shapeSel, amountEl, attackEl, offsetEl].forEach(el => {
+      if (!el) return;
+      const evt = el.tagName === 'SELECT' ? 'change' : 'input';
+      el.addEventListener(evt, () => { draw(); });
+      if (evt === 'input') el.addEventListener('change', draw);
+    });
+    if (syncSel) syncSel.addEventListener('change', updateRateDisplay);
+    updateRateDisplay();
+    draw();
   }
 
-  function draw() {
-    const rate = getRateHz();
-    const shape = shapeSel ? shapeSel.value : 'Sine';
-    const amount = parseFloat(amountEl?.value || '1');
-    const attack = parseFloat(attackEl?.value || '0');
-    const offset = parseFloat(offsetEl?.value || '0') / 360;
-    const w = canvas.width;
-    const h = canvas.height;
-    ctx.clearRect(0, 0, w, h);
-    ctx.beginPath();
-    let ratio = 0;
-    if (syncSel && syncSel.value === 'Tempo' && syncRateEl) {
-      ratio = knobRatio(syncRateEl, SYNC_RATES.length - 1);
-    } else if (rateEl) {
-      ratio = knobRatio(rateEl);
-    }
-    const cycles = 2 + ratio * 8;
-    const duration = rate > 0 ? cycles / rate : 1;
-    for (let i = 0; i <= w; i++) {
-      const t = (i / w) * duration;
-      let amp = amount;
-      if (attack > 0 && t < attack) amp = amount * t / attack;
-      const ph = rate * t + offset;
-      const val = wave(shape, ph) * amp * 0.5 + 0.5;
-      const y = h - val * h;
-      if (i === 0) ctx.moveTo(i, y); else ctx.lineTo(i, y);
-    }
-    ctx.strokeStyle = '#f00';
-    ctx.stroke();
-  }
-
-  function updateRateDisplay() {
-    if (!syncSel) return;
-    const tempo = syncSel.value === 'Tempo';
-    if (rateItem) rateItem.classList.toggle('hidden', tempo);
-    if (syncRateItem) syncRateItem.classList.toggle('hidden', !tempo);
-  }
-
-  [rateEl, syncRateEl, syncSel, shapeSel, amountEl, attackEl, offsetEl].forEach(el => {
-    if (!el) return;
-    const evt = el.tagName === 'SELECT' ? 'change' : 'input';
-    el.addEventListener(evt, () => { draw(); });
-    if (evt === 'input') el.addEventListener('change', draw);
-  });
-  if (syncSel) syncSel.addEventListener('change', updateRateDisplay);
-  updateRateDisplay();
-  draw();
+  [1, 2].forEach(setupLfo);
 }
 
 document.addEventListener('DOMContentLoaded', initWavetableLfoViz);


### PR DESCRIPTION
## Summary
- extend wavetable LFO visualizer to support both LFO1 and LFO2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497e1b8a14832597d918fa40393671