### PR TITLE
Fix startup wait time for Move webserver

### DIFF
--- a/utility-scripts/restart-webserver.sh
+++ b/utility-scripts/restart-webserver.sh
@@ -89,7 +89,11 @@ if ! ps -p "$NEW_PID" > /dev/null; then
 fi
 
 # Wait for the server to respond on configured port (allow time for warm-up)
-for i in {1..30}; do
+# The webserver performs an extensive warm-up that can take close to a minute
+# on first start. The original timeout of 30 seconds was not sufficient,
+# causing false negatives. Increase the wait time to 90 seconds to accommodate
+# the warm-up process.
+for i in {1..90}; do
     if command -v curl >/dev/null 2>&1; then
         if curl -sf http://localhost:${PORT}/ > /dev/null; then
             PORT_READY=true


### PR DESCRIPTION
## Summary
- increase waiting period in `restart-webserver.sh` so the update script doesn't exit early while the server warms up

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b64000308325b56027192a3848d8