### PR TITLE
Fix version equality check in install scripts

### DIFF
--- a/utility-scripts/install-on-move.sh
+++ b/utility-scripts/install-on-move.sh
@@ -59,14 +59,34 @@ REMOTE_HOST="move.local"
 # Version check: ensure Move version is within tested range
 HIGHEST_TESTED_VERSION="1.5.0"
 INSTALLED_VERSION=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" "/opt/move/Move -v" | awk '{print $3}')
-# Determine if installed version exceeds highest tested
-LATEST_VERSION=$(printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V | tail -n1)
-if [ "$LATEST_VERSION" != "$HIGHEST_TESTED_VERSION" ]; then
+
+# Compare versions with Python's packaging module so beta versions sort correctly
+COMPARISON=$(INST="$INSTALLED_VERSION" HIGH="$HIGHEST_TESTED_VERSION" python3 - <<'PY'
+import os
+try:
+    from packaging.version import Version
+except Exception:
+    from distutils.version import LooseVersion as Version
+v1 = Version(os.getenv('INST'))
+v2 = Version(os.getenv('HIGH'))
+if v1 > v2:
+    print('gt')
+elif v1 < v2:
+    print('lt')
+else:
+    print('eq')
+PY
+)
+
+if [ "$COMPARISON" = "gt" ]; then
     read -p "Warning: Installed Move version ($INSTALLED_VERSION) is newer than highest tested ($HIGHEST_TESTED_VERSION). Continue? [y/N] " confirm
-    if [[ ! $confirm =~ ^[Yy]$ ]]; then
-        echo "Aborting installation."
-        exit 1
-    fi
+elif [ "$COMPARISON" = "lt" ]; then
+    read -p "Warning: Installed Move version ($INSTALLED_VERSION) is older than highest tested ($HIGHEST_TESTED_VERSION). Continue? [y/N] " confirm
+fi
+
+if [ "$COMPARISON" != "eq" ] && [[ ! $confirm =~ ^[Yy]$ ]]; then
+    echo "Aborting installation."
+    exit 1
 fi
 
 echo "Running remote setup commands on ${REMOTE_HOST} as ${REMOTE_USER}..."

--- a/utility-scripts/update-on-move.sh
+++ b/utility-scripts/update-on-move.sh
@@ -41,12 +41,34 @@ REMOTE_DIR="/data/UserData/extending-move"
 # --- Version check: ensure Move version is within tested range ---
 HIGHEST_TESTED_VERSION="1.5.0"
 INSTALLED_VERSION=$(ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "/opt/move/Move -v" | awk '{print $3}')
-if ! printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V | head -n1 | grep -qx "$HIGHEST_TESTED_VERSION"; then
+
+# Compare versions with Python's packaging module so beta versions sort correctly
+COMPARISON=$(INST="$INSTALLED_VERSION" HIGH="$HIGHEST_TESTED_VERSION" python3 - <<'PY'
+import os
+try:
+    from packaging.version import Version
+except Exception:
+    from distutils.version import LooseVersion as Version
+v1 = Version(os.getenv('INST'))
+v2 = Version(os.getenv('HIGH'))
+if v1 > v2:
+    print('gt')
+elif v1 < v2:
+    print('lt')
+else:
+    print('eq')
+PY
+)
+
+if [ "$COMPARISON" = "gt" ]; then
   read -p "Warning: Installed Move ($INSTALLED_VERSION) > tested ($HIGHEST_TESTED_VERSION). Continue? [y/N] " confirm
-  if [[ ! $confirm =~ ^[Yy]$ ]]; then
-    echo "Aborting."
-    exit 1
-  fi
+elif [ "$COMPARISON" = "lt" ]; then
+  read -p "Warning: Installed Move ($INSTALLED_VERSION) < tested ($HIGHEST_TESTED_VERSION). Continue? [y/N] " confirm
+fi
+
+if [ "$COMPARISON" != "eq" ] && [[ ! $confirm =~ ^[Yy]$ ]]; then
+  echo "Aborting."
+  exit 1
 fi
 
 # --- Ensure remote directory exists ---


### PR DESCRIPTION
## Summary
- avoid false warnings when Move version matches the highest tested version
- show warnings if the installed version is older or newer
- handle beta version comparisons correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6849c2914c48832594538c5b9431475b