### PR TITLE
Display melodic sampler sample name

### DIFF
--- a/core/melodic_sampler_handler.py
+++ b/core/melodic_sampler_handler.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Utilities for MelodicSampler presets."""
+import json
+import urllib.parse
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_melodic_sampler_sample(preset_path):
+    """Return the sample name and path for a MelodicSampler preset."""
+    try:
+        with open(preset_path, "r") as f:
+            preset_data = json.load(f)
+
+        sample_uri = None
+
+        def find_sampler(data):
+            nonlocal sample_uri
+            if sample_uri is not None:
+                return
+            if isinstance(data, dict):
+                if data.get("kind") == "melodicSampler":
+                    sample_uri = data.get("deviceData", {}).get("sampleUri")
+                else:
+                    for v in data.values():
+                        if sample_uri is None:
+                            find_sampler(v)
+            elif isinstance(data, list):
+                for item in data:
+                    if sample_uri is None:
+                        find_sampler(item)
+
+        find_sampler(preset_data)
+
+        if not sample_uri:
+            return {
+                "success": True,
+                "message": "No sample loaded",
+                "sample_name": None,
+                "sample_path": None,
+            }
+
+        # Get filename from URI
+        name_part = sample_uri.rsplit("/", 1)[-1]
+        sample_name = urllib.parse.unquote(name_part)
+        sample_path = urllib.parse.unquote(sample_uri)
+
+        return {
+            "success": True,
+            "message": "Found sample",
+            "sample_name": sample_name,
+            "sample_path": sample_path,
+        }
+
+    except Exception as exc:
+        logger.warning("Error reading melodic sampler preset: %s", exc)
+        return {
+            "success": False,
+            "message": f"Error reading preset: {exc}",
+            "sample_name": None,
+            "sample_path": None,
+        }

--- a/handlers/melodic_sampler_param_editor_handler_class.py
+++ b/handlers/melodic_sampler_param_editor_handler_class.py
@@ -74,6 +74,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             'params_html': '',
             'selected_preset': None,
             'sample_name': '',
+            'sample_path': '',
             'param_count': 0,
             'browser_root': base_dir,
             'browser_filter': 'melodicsampler',
@@ -265,6 +266,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             param_paths_json = json.dumps(paths)
 
         sample_name = sample_info.get('sample_name') if sample_info.get('success', False) else None
+        sample_path = sample_info.get('sample_path') if sample_info.get('success', False) else None
 
         if values['success']:
             params_html = self.generate_params_html(values['parameters'], mapped_params)
@@ -305,6 +307,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             'available_params_json': available_params_json,
             'param_paths_json': param_paths_json,
             'sample_name': sample_name or '',
+            'sample_path': sample_info.get('sample_path', '') if sample_info.get('success', False) else '',
         }
 
     def _build_param_item(self, idx, name, value, meta, label=None, hide_label=False, slider=False, extra_classes=""):

--- a/handlers/melodic_sampler_param_editor_handler_class.py
+++ b/handlers/melodic_sampler_param_editor_handler_class.py
@@ -19,6 +19,7 @@ from core.synth_param_editor_handler import (
     update_parameter_values,
     update_macro_values,
 )
+from core.melodic_sampler_handler import get_melodic_sampler_sample
 from core.refresh_handler import refresh_library
 
 DEFAULT_PRESET = os.path.join(
@@ -72,6 +73,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             'file_browser_html': browser_html,
             'params_html': '',
             'selected_preset': None,
+            'sample_name': '',
             'param_count': 0,
             'browser_root': base_dir,
             'browser_filter': 'melodicsampler',
@@ -255,11 +257,14 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             device_types=("melodicSampler",),
             schema_loader=load_melodic_sampler_schema,
         )
+        sample_info = get_melodic_sampler_sample(preset_path)
         if param_info['success']:
             params = [p for p in param_info['parameters'] if p not in EXCLUDED_MACRO_PARAMS]
             paths = {k: v for k, v in param_info.get('parameter_paths', {}).items() if k not in EXCLUDED_MACRO_PARAMS}
             available_params_json = json.dumps(params)
             param_paths_json = json.dumps(paths)
+
+        sample_name = sample_info.get('sample_name') if sample_info.get('success', False) else None
 
         if values['success']:
             params_html = self.generate_params_html(values['parameters'], mapped_params)
@@ -299,6 +304,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             'macros_json': macros_json,
             'available_params_json': available_params_json,
             'param_paths_json': param_paths_json,
+            'sample_name': sample_name or '',
         }
 
     def _build_param_item(self, idx, name, value, meta, label=None, hide_label=False, slider=False, extra_classes=""):

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -693,6 +693,7 @@ def melodic_sampler_params():
     available_params_json = result.get("available_params_json", "[]")
     param_paths_json = result.get("param_paths_json", "{}")
     schema_json = result.get("schema_json", "{}")
+    sample_name = result.get("sample_name", "")
     preset_selected = bool(selected_preset)
     return render_template(
         "melodic_sampler_params.html",
@@ -713,6 +714,7 @@ def melodic_sampler_params():
         available_params_json=available_params_json,
         param_paths_json=param_paths_json,
         schema_json=schema_json,
+        sample_name=sample_name,
         active_tab="melodic-sampler",
     )
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -694,6 +694,7 @@ def melodic_sampler_params():
     param_paths_json = result.get("param_paths_json", "{}")
     schema_json = result.get("schema_json", "{}")
     sample_name = result.get("sample_name", "")
+    sample_path = result.get("sample_path", "")
     preset_selected = bool(selected_preset)
     return render_template(
         "melodic_sampler_params.html",
@@ -715,6 +716,7 @@ def melodic_sampler_params():
         param_paths_json=param_paths_json,
         schema_json=schema_json,
         sample_name=sample_name,
+        sample_path=sample_path,
         active_tab="melodic-sampler",
     )
 

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -80,6 +80,9 @@
         {{ macro_knobs_html | safe }}
     </div>
     <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
+    {% if sample_path %}
+    <p class="current-sample-path">Path: {{ sample_path }}</p>
+    {% endif %}
     <input type="hidden" name="macros_data" id="macros-data-input" value='{{ macros_json }}'>
     <input type="hidden" id="available-params-input" value='{{ available_params_json }}'>
     <input type="hidden" id="param-paths-input" value='{{ param_paths_json }}'>

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -58,6 +58,7 @@
         {% set _display = '/' + selected_preset.split('examples/Track Presets',1)[1] %}
     {% endif %}
     <p class="current-preset">Editing: {{ _display }}</p>
+    <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
     {% set _basename = selected_preset.split('/')[-1] %}
     {% if _basename.endswith('.json') or _basename.endswith('.ablpreset') %}
         {% set _prefill = _basename.rsplit('.', 1)[0] %}

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -58,7 +58,6 @@
         {% set _display = '/' + selected_preset.split('examples/Track Presets',1)[1] %}
     {% endif %}
     <p class="current-preset">Editing: {{ _display }}</p>
-    <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
     {% set _basename = selected_preset.split('/')[-1] %}
     {% if _basename.endswith('.json') or _basename.endswith('.ablpreset') %}
         {% set _prefill = _basename.rsplit('.', 1)[0] %}
@@ -80,6 +79,7 @@
         <h3>Macros</h3>
         {{ macro_knobs_html | safe }}
     </div>
+    <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
     <input type="hidden" name="macros_data" id="macros-data-input" value='{{ macros_json }}'>
     <input type="hidden" id="available-params-input" value='{{ available_params_json }}'>
     <input type="hidden" id="param-paths-input" value='{{ param_paths_json }}'>

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -236,3 +236,27 @@ def test_remove_macro_name(tmp_path):
         data = json.load(f)
     assert "customName" not in data["chains"][0]["devices"][0]["parameters"]["Macro0"]
 
+
+def test_get_melodic_sampler_sample(tmp_path):
+    preset_path = tmp_path / "preset.json"
+    preset = {
+        "kind": "instrumentRack",
+        "chains": [
+            {
+                "devices": [
+                    {
+                        "kind": "melodicSampler",
+                        "deviceData": {"sampleUri": "ableton:/user-library/Samples/test%20sample.wav"},
+                    }
+                ]
+            }
+        ],
+    }
+    preset_path.write_text(json.dumps(preset))
+
+    from core.melodic_sampler_handler import get_melodic_sampler_sample
+
+    info = get_melodic_sampler_sample(str(preset_path))
+    assert info["success"], info.get("message")
+    assert info["sample_name"] == "test sample.wav"
+

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -259,4 +259,5 @@ def test_get_melodic_sampler_sample(tmp_path):
     info = get_melodic_sampler_sample(str(preset_path))
     assert info["success"], info.get("message")
     assert info["sample_name"] == "test sample.wav"
+    assert info["sample_path"].endswith("test sample.wav")
 


### PR DESCRIPTION
## Summary
- add helper `get_melodic_sampler_sample` for finding sample info
- show melodic sampler sample name in param editor
- display sample name in template
- test sample extraction

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4bb724708325b4f92bbc85c70afe