### PR TITLE
Add macro highlighting for melodic sampler

### DIFF
--- a/handlers/melodic_sampler_param_editor_handler_class.py
+++ b/handlers/melodic_sampler_param_editor_handler_class.py
@@ -306,6 +306,19 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             available_params_json = json.dumps(params)
             param_paths_json = json.dumps(paths)
 
+            if macro_info['success'] and not mapped_params:
+                macros_for_json = [
+                    {
+                        'index': i,
+                        'name': DEFAULT_MACRO_NAMES[i],
+                        'value': next((m.get('value', 0.0) for m in macro_info['macros'] if m.get('index') == i), 0.0),
+                        'parameters': [{'name': DEFAULT_MACRO_PARAMS[i], 'path': paths.get(DEFAULT_MACRO_PARAMS[i])}],
+                    }
+                    for i in range(8)
+                ]
+                macros_json = json.dumps(macros_for_json)
+                mapped_params = {DEFAULT_MACRO_PARAMS[i]: {'macro_index': i} for i in range(8)}
+
         sample_name = sample_info.get('sample_name') if sample_info.get('success', False) else None
         sample_path = sample_info.get('sample_path') if sample_info.get('success', False) else None
 

--- a/static/melodic_sampler_macros.js
+++ b/static/melodic_sampler_macros.js
@@ -1,0 +1,205 @@
+// Lightweight macro highlight and control for the melodic sampler editor
+// Reuses the macro visualization logic from macro_sidebar.js without the
+// sidebar UI. Intended for presets where macros have fixed parameter targets.
+
+document.addEventListener('DOMContentLoaded', () => {
+  const macrosInput = document.getElementById('macros-data-input');
+  if (!macrosInput) return;
+
+  let macros = [];
+  try { macros = JSON.parse(macrosInput.value || '[]'); } catch (e) {}
+
+  const paramInfo = window.driftSchema || {};
+  const baseParamValues = {};
+
+  document.querySelectorAll('.param-item').forEach(item => {
+    const name = item.dataset.name;
+    let val = null;
+    const hid = item.querySelector('input[type="hidden"][name$="_value"]');
+    if (hid) {
+      const num = parseFloat(hid.value);
+      val = isNaN(num) ? hid.value : num;
+    } else {
+      const sl = item.querySelector('.rect-slider');
+      if (sl) {
+        val = parseFloat(sl.dataset.value || '0');
+      } else {
+        const sel = item.querySelector('select.param-select');
+        if (sel) val = sel.value;
+      }
+    }
+    if (name && val !== null) baseParamValues[name] = val;
+  });
+
+  function formatDialValue(dial, v) {
+    if (isNaN(v)) return 'not set';
+    const valueLabels = dial.dataset.values ? dial.dataset.values.split(',') : null;
+    if (valueLabels) {
+      const idx = Math.round(v);
+      if (idx >= 0 && idx < valueLabels.length) return valueLabels[idx];
+    }
+    const unit = dial.dataset.unit || '';
+    const decimals = parseInt(dial.dataset.decimals || '2', 10);
+    const min = parseFloat(dial.min || '0');
+    const max = parseFloat(dial.max || '0');
+    const oscGain = unit === 'dB' && !isNaN(min) && !isNaN(max) && min === 0 && max <= 2;
+    const shouldScale = (unit === '%' || unit === 'ct') && Math.abs(max) <= 1 && Math.abs(min) <= 1;
+    const displayDecimalsDefault = (unit === '%' || unit === 'ct') ? 0 : decimals;
+    const getDisplayDecimals = val => window.getPercentDecimals(val, unit, displayDecimalsDefault, shouldScale);
+
+    let displayVal = shouldScale ? v * 100 : v;
+    let unitLabel = unit;
+    if (unit === 'Hz') {
+      displayVal = Number(displayVal);
+      if (displayVal >= 1000) {
+        displayVal = displayVal / 1000;
+        unitLabel = 'kHz';
+      }
+      return displayVal.toFixed(1) + ' ' + unitLabel;
+    } else if (unit === 's') {
+      if (displayVal < 1) return (displayVal * 1000).toFixed(0) + ' ms';
+      return Number(displayVal).toFixed(getDisplayDecimals(v)) + ' s';
+    } else if (oscGain) {
+      if (v <= 0) return '-inf dB';
+      const oscValToDb = val => {
+        if (val <= 0) return -Infinity;
+        if (val <= 1) return val * 64 - 64;
+        return (val - 1) * 6;
+      };
+      const db = oscValToDb(v);
+      return db.toFixed(1) + ' dB';
+    }
+    return Number(displayVal).toFixed(getDisplayDecimals(v)) + (unit ? ' ' + unitLabel : '');
+  }
+
+  function updateParamVisual(name, value) {
+    const item = document.querySelector(`.param-item[data-name="${name}"]`);
+    if (!item) return;
+    const dial = item.querySelector('input.param-dial');
+    if (dial) {
+      dial.value = value;
+      dial.setAttribute('value', value);
+      if (dial.inputKnobs && typeof dial.redraw === 'function') dial.redraw(true);
+      const dispId = dial.dataset.display;
+      if (dispId) {
+        const dispEl = document.getElementById(dispId);
+        if (dispEl) dispEl.textContent = formatDialValue(dial, value);
+      }
+      const target = dial.dataset.target;
+      if (target) {
+        const hidden = document.querySelector(`input[name="${target}"]`);
+        if (hidden) {
+          hidden.value = value;
+          hidden.dispatchEvent(new Event('change'));
+        }
+      }
+      dial.dispatchEvent(new Event('input'));
+      return;
+    }
+    const select = item.querySelector('select.param-select');
+    if (select) {
+      select.value = value;
+      const hid = item.querySelector('input[type="hidden"][name$="_value"]');
+      if (hid) hid.value = value;
+      select.dispatchEvent(new Event('change'));
+      return;
+    }
+    const toggle = item.querySelector('input.param-toggle');
+    if (toggle) {
+      const hid = item.querySelector('input[type="hidden"][name$="_value"]');
+      const trueVal = toggle.dataset.trueValue ?? '1';
+      const falseVal = toggle.dataset.falseValue ?? '0';
+      const isOn = String(value) === trueVal || (!isNaN(value) && parseFloat(value) >= 1);
+      toggle.checked = isOn;
+      if (hid) {
+        hid.value = isOn ? trueVal : falseVal;
+        hid.dispatchEvent(new Event('change'));
+      }
+      toggle.dispatchEvent(new Event('change'));
+      return;
+    }
+    const slider = item.querySelector('.rect-slider');
+    if (slider && typeof slider._sliderUpdate === 'function') {
+      slider._sliderUpdate(value);
+      slider.dispatchEvent(new Event('input'));
+    }
+  }
+
+  function applyMacroVisuals(targetIndices = null) {
+    const indicesToProcess = new Set();
+    if (targetIndices !== null) {
+      (Array.isArray(targetIndices) ? targetIndices : [targetIndices]).forEach(i => indicesToProcess.add(i));
+    }
+
+    const macroValues = {};
+    document.querySelectorAll('input[name^="macro_"][name$="_value"]').forEach(h => {
+      const m = h.name.match(/macro_(\d+)_value/);
+      if (m) macroValues[parseInt(m[1], 10)] = parseFloat(h.value);
+    });
+
+    const mappedNow = new Set();
+    macros.forEach(m => {
+      if (indicesToProcess.size && !indicesToProcess.has(m.index)) return;
+      const mval = macroValues[m.index] ?? 0;
+      (m.parameters || []).forEach(p => {
+        const info = paramInfo[p.name] || {};
+        if (info.type === 'enum' && Array.isArray(info.options)) {
+          const opts = info.options;
+          const idx = Math.min(Math.floor((mval / 127) * opts.length), opts.length - 1);
+          const val = opts[idx];
+          updateParamVisual(p.name, val);
+          mappedNow.add(p.name);
+          return;
+        } else if (info.type === 'boolean') {
+          const val = mval >= 64 ? 1 : 0;
+          updateParamVisual(p.name, val);
+          mappedNow.add(p.name);
+          return;
+        }
+        let min = p.rangeMin !== undefined ? parseFloat(p.rangeMin) : (info.min !== undefined ? parseFloat(info.min) : 0);
+        let max = p.rangeMax !== undefined ? parseFloat(p.rangeMax) : (info.max !== undefined ? parseFloat(info.max) : 127);
+        const val = min + (max - min) * (mval / 127);
+        updateParamVisual(p.name, val);
+        mappedNow.add(p.name);
+      });
+    });
+
+    if (!indicesToProcess.size) {
+      Object.keys(baseParamValues).forEach(name => {
+        if (!mappedNow.has(name)) updateParamVisual(name, baseParamValues[name]);
+      });
+    }
+  }
+
+  function updateHighlights() {
+    const mapped = {};
+    macros.forEach(m => m.parameters.forEach(p => { mapped[p.name] = m.index; }));
+
+    document.querySelectorAll('.param-item').forEach(item => {
+      const name = item.dataset.name;
+      const idx = mapped[name];
+      item.classList.remove('param-mapped', ...Array.from({ length: 8 }, (_, i) => 'macro-' + i));
+      if (idx !== undefined) {
+        item.classList.add('param-mapped');
+        item.classList.add('macro-' + idx);
+      }
+    });
+
+    document.querySelectorAll('.macro-knob').forEach(knob => {
+      const idx = parseInt(knob.dataset.index, 10);
+      const active = (macros.find(m => m.index === idx)?.parameters.length || 0) > 0;
+      knob.classList.toggle('macro-' + idx, active);
+    });
+  }
+
+  document.querySelectorAll('.macro-dial').forEach(d => {
+    d.addEventListener('input', () => {
+      const m = d.dataset.target.match(/macro_(\d+)_value/);
+      const idx = m ? parseInt(m[1], 10) : NaN;
+      applyMacroVisuals(idx);
+    });
+  });
+
+  applyMacroVisuals();
+  updateHighlights();
+});

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -110,6 +110,7 @@
 <script>
 window.driftSchema = {{ schema_json|safe }};
 </script>
+<script src="{{ host_prefix }}/static/melodic_sampler_macros.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');


### PR DESCRIPTION
## Summary
- add lightweight JS to highlight macro-controlled parameters in melodic sampler editor
- show the JS in the melodic sampler template
- fallback to default macro mappings when none exist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and flask)*

------
https://chatgpt.com/codex/tasks/task_e_684a52aaa86083259bedb7f37d5f04ec