### PR TITLE
Modify melodic sampler macro handling

### DIFF
--- a/static/melodic_sampler_macros.js
+++ b/static/melodic_sampler_macros.js
@@ -37,6 +37,36 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
     if (name && val !== null) baseParamValues[name] = val;
+
+    function getCurrent() {
+      let cur = null;
+      const hid = item.querySelector('input[type="hidden"][name$="_value"]');
+      if (hid) {
+        const num = parseFloat(hid.value);
+        cur = isNaN(num) ? hid.value : num;
+      } else {
+        const sl = item.querySelector('.rect-slider');
+        if (sl) {
+          cur = parseFloat(sl.dataset.value || '0');
+        } else {
+          const sel = item.querySelector('select.param-select');
+          if (sel) cur = sel.value;
+        }
+      }
+      return cur;
+    }
+
+    function updateBase() {
+      const v = getCurrent();
+      if (v !== null) baseParamValues[name] = v;
+    }
+
+    item.querySelectorAll(
+      'input.param-dial, input.param-slider, input.param-toggle, select.param-select, .rect-slider'
+    ).forEach(ctrl => {
+      ctrl.addEventListener('input', updateBase);
+      ctrl.addEventListener('change', updateBase);
+    });
   });
 
   function formatDialValue(dial, v) {

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Melodic Sampler Preset Editor</h2>
-<p><em>Edit parameter values and assign macros. Note that Macro assignments override other values.</em></p>
+<p><em>Edit parameters and tweak the macros. The preset values remain active; macros simply adjust them up or down.</em></p>
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- keep preset parameter values active when macros are loaded
- treat macro dials as relative encoders instead of absolute overrides
- clarify UI text about macro behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5800a7e883259d2c56cf354ba154