### PR TITLE
Update melodic sampler macro behavior

### DIFF
--- a/handlers/melodic_sampler_param_editor_handler_class.py
+++ b/handlers/melodic_sampler_param_editor_handler_class.py
@@ -215,15 +215,6 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
                 return self.format_error_response(result['message'])
             preset_path = result['path']
 
-            macro_updates = {}
-            for i in range(8):
-                val = form.getvalue(f'macro_{i}_value')
-                if val is not None:
-                    macro_updates[i] = val
-            macro_result = update_macro_values(preset_path, macro_updates, preset_path)
-            if not macro_result['success']:
-                return self.format_error_response(macro_result['message'])
-
             name_updates = {i: DEFAULT_MACRO_NAMES[i] for i in range(8)}
             name_result = update_preset_macro_names(preset_path, name_updates)
             if not name_result['success']:
@@ -252,7 +243,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
                 if pname not in DEFAULT_MACRO_PARAMS:
                     delete_parameter_mapping(preset_path, info['path'])
 
-            message = result['message'] + "; " + macro_result['message']
+            message = result['message']
             if output_path:
                 message += f" Saved to {output_path}"
             refresh_success, refresh_message = refresh_library()
@@ -528,24 +519,15 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
 
 
     def generate_macro_knobs_html(self, macros):
-        values = {m.get('index'): m.get('value', 0.0) for m in (macros or [])}
         html = ['<div class="macro-knob-row">']
         for i in range(8):
-            val = values.get(i, 0.0)
-            try:
-                val = float(val)
-            except Exception:
-                val = 0.0
-            display_val = round(val, 1)
             name = DEFAULT_MACRO_NAMES[i]
             html.append(
                 f'<div class="macro-knob" data-index="{i}">' +
                 f'<span class="macro-label" data-index="{i}">{name}</span>' +
                 f'<input id="macro_{i}_dial" type="range" class="macro-dial input-knob" ' +
-                f'data-target="macro_{i}_value" data-display="macro_{i}_disp" ' +
-                f'value="{display_val}" min="0" max="127" step="0.1" data-decimals="1">' +
-                f'<span id="macro_{i}_disp" class="macro-number"></span>' +
-                f'<input type="hidden" name="macro_{i}_value" value="{display_val}">' +
+                f'value="0" min="0" max="127" step="0.1" disabled>' +
+                f'<input type="hidden" name="macro_{i}_value" value="0">' +
                 '</div>'
             )
         html.append('</div>')

--- a/static/melodic_sampler_macros.js
+++ b/static/melodic_sampler_macros.js
@@ -1,6 +1,5 @@
-// Lightweight macro highlight and control for the melodic sampler editor
-// Reuses the macro visualization logic from macro_sidebar.js without the
-// sidebar UI. Intended for presets where macros have fixed parameter targets.
+// Highlight macro assignments for the melodic sampler editor without applying
+// macro values to parameters. Macro knobs are disabled and serve only as labels.
 
 document.addEventListener('DOMContentLoaded', () => {
   const macrosInput = document.getElementById('macros-data-input');
@@ -9,176 +8,14 @@ document.addEventListener('DOMContentLoaded', () => {
   let macros = [];
   try { macros = JSON.parse(macrosInput.value || '[]'); } catch (e) {}
 
-  const paramInfo = window.driftSchema || {};
-  const baseParamValues = {};
-
-  document.querySelectorAll('.param-item').forEach(item => {
-    const name = item.dataset.name;
-    let val = null;
-    const hid = item.querySelector('input[type="hidden"][name$="_value"]');
-    if (hid) {
-      const num = parseFloat(hid.value);
-      val = isNaN(num) ? hid.value : num;
-    } else {
-      const sl = item.querySelector('.rect-slider');
-      if (sl) {
-        val = parseFloat(sl.dataset.value || '0');
-      } else {
-        const sel = item.querySelector('select.param-select');
-        if (sel) val = sel.value;
-      }
-    }
-    if (name && val !== null) baseParamValues[name] = val;
-  });
-
-  function formatDialValue(dial, v) {
-    if (isNaN(v)) return 'not set';
-    const valueLabels = dial.dataset.values ? dial.dataset.values.split(',') : null;
-    if (valueLabels) {
-      const idx = Math.round(v);
-      if (idx >= 0 && idx < valueLabels.length) return valueLabels[idx];
-    }
-    const unit = dial.dataset.unit || '';
-    const decimals = parseInt(dial.dataset.decimals || '2', 10);
-    const min = parseFloat(dial.min || '0');
-    const max = parseFloat(dial.max || '0');
-    const oscGain = unit === 'dB' && !isNaN(min) && !isNaN(max) && min === 0 && max <= 2;
-    const shouldScale = (unit === '%' || unit === 'ct') && Math.abs(max) <= 1 && Math.abs(min) <= 1;
-    const displayDecimalsDefault = (unit === '%' || unit === 'ct') ? 0 : decimals;
-    const getDisplayDecimals = val => window.getPercentDecimals(val, unit, displayDecimalsDefault, shouldScale);
-
-    let displayVal = shouldScale ? v * 100 : v;
-    let unitLabel = unit;
-    if (unit === 'Hz') {
-      displayVal = Number(displayVal);
-      if (displayVal >= 1000) {
-        displayVal = displayVal / 1000;
-        unitLabel = 'kHz';
-      }
-      return displayVal.toFixed(1) + ' ' + unitLabel;
-    } else if (unit === 's') {
-      if (displayVal < 1) return (displayVal * 1000).toFixed(0) + ' ms';
-      return Number(displayVal).toFixed(getDisplayDecimals(v)) + ' s';
-    } else if (oscGain) {
-      if (v <= 0) return '-inf dB';
-      const oscValToDb = val => {
-        if (val <= 0) return -Infinity;
-        if (val <= 1) return val * 64 - 64;
-        return (val - 1) * 6;
-      };
-      const db = oscValToDb(v);
-      return db.toFixed(1) + ' dB';
-    }
-    return Number(displayVal).toFixed(getDisplayDecimals(v)) + (unit ? ' ' + unitLabel : '');
-  }
-
-  function updateParamVisual(name, value) {
-    const item = document.querySelector(`.param-item[data-name="${name}"]`);
-    if (!item) return;
-    const dial = item.querySelector('input.param-dial');
-    if (dial) {
-      dial.value = value;
-      dial.setAttribute('value', value);
-      if (dial.inputKnobs && typeof dial.redraw === 'function') dial.redraw(true);
-      const dispId = dial.dataset.display;
-      if (dispId) {
-        const dispEl = document.getElementById(dispId);
-        if (dispEl) dispEl.textContent = formatDialValue(dial, value);
-      }
-      const target = dial.dataset.target;
-      if (target) {
-        const hidden = document.querySelector(`input[name="${target}"]`);
-        if (hidden) {
-          hidden.value = value;
-          hidden.dispatchEvent(new Event('change'));
-        }
-      }
-      dial.dispatchEvent(new Event('input'));
-      return;
-    }
-    const select = item.querySelector('select.param-select');
-    if (select) {
-      select.value = value;
-      const hid = item.querySelector('input[type="hidden"][name$="_value"]');
-      if (hid) hid.value = value;
-      select.dispatchEvent(new Event('change'));
-      return;
-    }
-    const toggle = item.querySelector('input.param-toggle');
-    if (toggle) {
-      const hid = item.querySelector('input[type="hidden"][name$="_value"]');
-      const trueVal = toggle.dataset.trueValue ?? '1';
-      const falseVal = toggle.dataset.falseValue ?? '0';
-      const isOn = String(value) === trueVal || (!isNaN(value) && parseFloat(value) >= 1);
-      toggle.checked = isOn;
-      if (hid) {
-        hid.value = isOn ? trueVal : falseVal;
-        hid.dispatchEvent(new Event('change'));
-      }
-      toggle.dispatchEvent(new Event('change'));
-      return;
-    }
-    const slider = item.querySelector('.rect-slider');
-    if (slider && typeof slider._sliderUpdate === 'function') {
-      slider._sliderUpdate(value);
-      slider.dispatchEvent(new Event('input'));
-    }
-  }
-
-  function applyMacroVisuals(targetIndices = null) {
-    const indicesToProcess = new Set();
-    if (targetIndices !== null) {
-      (Array.isArray(targetIndices) ? targetIndices : [targetIndices]).forEach(i => indicesToProcess.add(i));
-    }
-
-    const macroValues = {};
-    document.querySelectorAll('input[name^="macro_"][name$="_value"]').forEach(h => {
-      const m = h.name.match(/macro_(\d+)_value/);
-      if (m) macroValues[parseInt(m[1], 10)] = parseFloat(h.value);
-    });
-
-    const mappedNow = new Set();
-    macros.forEach(m => {
-      if (indicesToProcess.size && !indicesToProcess.has(m.index)) return;
-      const mval = macroValues[m.index] ?? 0;
-      (m.parameters || []).forEach(p => {
-        const info = paramInfo[p.name] || {};
-        if (info.type === 'enum' && Array.isArray(info.options)) {
-          const opts = info.options;
-          const idx = Math.min(Math.floor((mval / 127) * opts.length), opts.length - 1);
-          const val = opts[idx];
-          updateParamVisual(p.name, val);
-          mappedNow.add(p.name);
-          return;
-        } else if (info.type === 'boolean') {
-          const val = mval >= 64 ? 1 : 0;
-          updateParamVisual(p.name, val);
-          mappedNow.add(p.name);
-          return;
-        }
-        let min = p.rangeMin !== undefined ? parseFloat(p.rangeMin) : (info.min !== undefined ? parseFloat(info.min) : 0);
-        let max = p.rangeMax !== undefined ? parseFloat(p.rangeMax) : (info.max !== undefined ? parseFloat(info.max) : 127);
-        const val = min + (max - min) * (mval / 127);
-        updateParamVisual(p.name, val);
-        mappedNow.add(p.name);
-      });
-    });
-
-    if (!indicesToProcess.size) {
-      Object.keys(baseParamValues).forEach(name => {
-        if (!mappedNow.has(name)) updateParamVisual(name, baseParamValues[name]);
-      });
-    }
-  }
-
   function updateHighlights() {
     const mapped = {};
-    macros.forEach(m => m.parameters.forEach(p => { mapped[p.name] = m.index; }));
+    macros.forEach(m => (m.parameters || []).forEach(p => { mapped[p.name] = m.index; }));
 
     document.querySelectorAll('.param-item').forEach(item => {
       const name = item.dataset.name;
       const idx = mapped[name];
-      item.classList.remove('param-mapped', ...Array.from({ length: 8 }, (_, i) => 'macro-' + i));
+      item.classList.remove('param-mapped', ...Array.from({length:8},(_,i)=>'macro-'+i));
       if (idx !== undefined) {
         item.classList.add('param-mapped');
         item.classList.add('macro-' + idx);
@@ -189,17 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const idx = parseInt(knob.dataset.index, 10);
       const active = (macros.find(m => m.index === idx)?.parameters.length || 0) > 0;
       knob.classList.toggle('macro-' + idx, active);
+      const dial = knob.querySelector('.macro-dial');
+      if (dial) dial.disabled = true;
     });
   }
 
-  document.querySelectorAll('.macro-dial').forEach(d => {
-    d.addEventListener('input', () => {
-      const m = d.dataset.target.match(/macro_(\d+)_value/);
-      const idx = m ? parseInt(m[1], 10) : NaN;
-      applyMacroVisuals(idx);
-    });
-  });
-
-  applyMacroVisuals();
   updateHighlights();
 });

--- a/static/style.css
+++ b/static/style.css
@@ -800,6 +800,7 @@ select {
     align-items: center;
     cursor: default;
     padding: 0.375rem;
+    opacity: 0.6;
 }
 
 .macro-label {
@@ -910,10 +911,7 @@ select {
     border-radius: 4px;
 }
 
-/* Parameters controlled by macros */
-.param-item.param-mapped {
-    opacity: 0.6;
-}
+
 
 
 /* Rectangular slider component */

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Melodic Sampler Preset Editor</h2>
-<p><em>Edit parameter values and assign macros. Note that Macro assignments override other values.</em></p>
+<p><em>Edit parameter values and view macro assignments. Macro knob values are ignored.</em></p>
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- change instructions to note macro knob values are ignored
- disable macro knob values when rendering knob HTML
- remove macro value updates on save
- simplify melodic sampler macro JS to only highlight mappings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a59fa0d608325a150b63e8eecb056