### PR TITLE
Adjust opacity for macros and mapped parameters

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1186,3 +1186,14 @@ button#macro-add-param {
     width: 200px;
     height: 88px;
 }
+
+/* Page-specific opacity rules */
+.page-synth-params .macro-knob,
+.page-wavetable-params .macro-knob {
+    opacity: 1;
+}
+
+.page-synth-params .param-item.param-mapped,
+.page-wavetable-params .param-item.param-mapped {
+    opacity: 0.6;
+}

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -6,7 +6,7 @@
     <title>Move - Extended</title>
     <link rel="stylesheet" href="{{ host_prefix }}/static/style.css">
 </head>
-<body>
+<body class="page-{{ active_tab }}">
     <h1 id="header">Move - Extended</h1>
     <nav class="tab">
         <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>


### PR DESCRIPTION
## Summary
- add a page-specific class to the `<body>` tag
- tweak CSS so Drift and Wavetable show macro knobs at full opacity and dim mapped params

## Testing
- `pip install -q -r requirements.txt` *(fails: WARNING message/no output)*
- `pytest -q` *(fails to run: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a787c49c08325821886c2db7019e0