### PR TITLE
Fix sample path display

### DIFF
--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -79,9 +79,8 @@
         <h3>Macros</h3>
         {{ macro_knobs_html | safe }}
     </div>
-    <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
     {% if sample_path %}
-    <p class="current-sample-path">Path: {{ sample_path }}</p>
+    <p class="current-sample-path">Sample: {{ sample_path }}</p>
     {% endif %}
     <div class="replace-sample">
         <label><input type="checkbox" name="replace_sample" id="replace-sample-checkbox"> Replace sample</label>

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -79,9 +79,9 @@
         <h3>Macros</h3>
         {{ macro_knobs_html | safe }}
     </div>
-    {% if sample_path %}
-    <p class="current-sample-path">Sample: {{ sample_path }}</p>
-    {% endif %}
+
+    <p class="current-sample-path">Sample:  {{ sample_path if sample_path else 'None' }}</p>
+
     <div class="replace-sample">
         <label><input type="checkbox" name="replace_sample" id="replace-sample-checkbox"> Replace sample</label>
         <input type="file" name="new_sample_file" id="new-sample-file" accept=".wav,.aif,.aiff" style="display:none;">


### PR DESCRIPTION
## Summary
- display full sample path as "Sample" label in melodic sampler editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a83215948832597805c47d7470837