### PR TITLE
Add wavesurfer preview to melodic sampler

### DIFF
--- a/core/melodic_sampler_handler.py
+++ b/core/melodic_sampler_handler.py
@@ -44,10 +44,20 @@ def get_melodic_sampler_sample(preset_path):
                 "sample_path": None,
             }
 
-        # Get filename from URI
+        # Get filename from URI and convert to local path if needed
         name_part = sample_uri.rsplit("/", 1)[-1]
         sample_name = urllib.parse.unquote(name_part)
-        sample_path = urllib.parse.unquote(sample_uri)
+        if sample_uri.startswith("ableton:/user-library/Samples/"):
+            sample_path = sample_uri.replace(
+                "ableton:/user-library/Samples/",
+                "/data/UserData/UserLibrary/Samples/",
+                1,
+            )
+        elif sample_uri.startswith("file://"):
+            sample_path = sample_uri.split("file://", 1)[1]
+        else:
+            sample_path = sample_uri
+        sample_path = urllib.parse.unquote(sample_path)
 
         return {
             "success": True,

--- a/handlers/melodic_sampler_param_editor_handler_class.py
+++ b/handlers/melodic_sampler_param_editor_handler_class.py
@@ -305,6 +305,10 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
 
         sample_name = sample_info.get('sample_name') if sample_info.get('success', False) else None
         sample_path = sample_info.get('sample_path') if sample_info.get('success', False) else None
+        sample_web_path = ''
+        base_prefix = '/data/UserData/UserLibrary/Samples/'
+        if sample_path and sample_path.startswith(base_prefix):
+            sample_web_path = sample_path[len(base_prefix):]
 
         if values['success']:
             params_html = self.generate_params_html(values['parameters'], mapped_params)
@@ -346,6 +350,7 @@ class MelodicSamplerParamEditorHandler(BaseHandler):
             'param_paths_json': param_paths_json,
             'sample_name': sample_name or '',
             'sample_path': sample_info.get('sample_path', '') if sample_info.get('success', False) else '',
+            'sample_web_path': sample_web_path,
         }
 
     def _build_param_item(self, idx, name, value, meta, label=None, hide_label=False, slider=False, extra_classes=""):

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -729,35 +729,12 @@ def chord():
     return render_template("chord.html", active_tab="chord")
 
 
-@app.route("/file/<path:filepath>", methods=["GET", "OPTIONS"])
-def serve_file_path(filepath):
-    """Serve arbitrary files from allowed directories with CORS headers."""
-    from urllib.parse import unquote
-
-    decoded = unquote(filepath)
-    allowed_bases = ["/data/UserData", "examples"]
-    for base in allowed_bases:
-        full = os.path.join(base, decoded)
-        base_real = os.path.realpath(base)
-        file_real = os.path.realpath(full)
-        if file_real.startswith(base_real) and os.path.exists(file_real):
-            if request.method == "OPTIONS":
-                resp = app.make_response("")
-            else:
-                resp = send_file(file_real)
-            resp.headers["Access-Control-Allow-Origin"] = "*"
-            resp.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
-            resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
-            return resp
-    return ("File not found", 404)
-
-
 @app.route("/samples/<path:sample_path>", methods=["GET", "OPTIONS"])
 def serve_sample(sample_path):
     """Serve sample audio files with CORS headers."""
     from urllib.parse import unquote
 
-    base_dir = "/data/UserData/UserLibrary/Samples/Preset Samples"
+    base_dir = "/data/UserData/UserLibrary/Samples"
     decoded_path = unquote(sample_path)
     full_path = os.path.join(base_dir, decoded_path)
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -729,6 +729,29 @@ def chord():
     return render_template("chord.html", active_tab="chord")
 
 
+@app.route("/file/<path:filepath>", methods=["GET", "OPTIONS"])
+def serve_file_path(filepath):
+    """Serve arbitrary files from allowed directories with CORS headers."""
+    from urllib.parse import unquote
+
+    decoded = unquote(filepath)
+    allowed_bases = ["/data/UserData", "examples"]
+    for base in allowed_bases:
+        full = os.path.join(base, decoded)
+        base_real = os.path.realpath(base)
+        file_real = os.path.realpath(full)
+        if file_real.startswith(base_real) and os.path.exists(file_real):
+            if request.method == "OPTIONS":
+                resp = app.make_response("")
+            else:
+                resp = send_file(file_real)
+            resp.headers["Access-Control-Allow-Origin"] = "*"
+            resp.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+            resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+            return resp
+    return ("File not found", 404)
+
+
 @app.route("/samples/<path:sample_path>", methods=["GET", "OPTIONS"])
 def serve_sample(sample_path):
     """Serve sample audio files with CORS headers."""

--- a/static/melodic_sampler_waveform.js
+++ b/static/melodic_sampler_waveform.js
@@ -1,0 +1,26 @@
+function initMelodicSamplerPreview() {
+    const container = document.getElementById('melodicSampleWaveform');
+    if (!container) return;
+    const audioPath = container.dataset.audioPath;
+    if (!audioPath) return;
+    const ws = WaveSurfer.create({
+        container: container,
+        waveColor: 'violet',
+        progressColor: 'purple',
+        height: 64,
+        responsive: true,
+        normalize: true,
+        hideScrollbar: true,
+        interact: false
+    });
+    container.wavesurfer = ws;
+    ws.load(audioPath);
+    container.addEventListener('click', function(e) {
+        e.stopPropagation();
+        ws.stop();
+        ws.seekTo(0);
+        requestAnimationFrame(() => ws.play(0));
+    });
+}
+
+export { initMelodicSamplerPreview };

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -82,7 +82,11 @@
     <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
     {% if sample_path %}
     <p class="current-sample-path">Path: {{ sample_path }}</p>
-    <div id="melodicSampleWaveform" class="waveform-container" data-audio-path="{{ host_prefix }}/file/{{ sample_path|urlencode }}"></div>
+    {% if sample_web_path %}
+    <div id="melodicSampleWaveform" class="waveform-container" data-audio-path="{{ host_prefix }}/samples/{{ sample_web_path|urlencode }}"></div>
+    {% else %}
+    <div id="melodicSampleWaveform" class="waveform-container hidden"></div>
+    {% endif %}
     {% else %}
     <div id="melodicSampleWaveform" class="waveform-container hidden"></div>
     {% endif %}

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -82,6 +82,9 @@
     <p class="current-sample">Sample: {{ sample_name if sample_name else 'None' }}</p>
     {% if sample_path %}
     <p class="current-sample-path">Path: {{ sample_path }}</p>
+    <div id="melodicSampleWaveform" class="waveform-container" data-audio-path="{{ host_prefix }}/file/{{ sample_path|urlencode }}"></div>
+    {% else %}
+    <div id="melodicSampleWaveform" class="waveform-container hidden"></div>
     {% endif %}
     <div class="replace-sample">
         <label><input type="checkbox" name="replace_sample" id="replace-sample-checkbox"> Replace sample</label>
@@ -116,6 +119,12 @@
 window.driftSchema = {{ schema_json|safe }};
 </script>
 <script src="{{ host_prefix }}/static/melodic_sampler_macros.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
+<script type="module" src="{{ host_prefix }}/static/melodic_sampler_waveform.js"></script>
+<script type="module">
+import { initMelodicSamplerPreview } from '{{ host_prefix }}/static/melodic_sampler_waveform.js';
+document.addEventListener('DOMContentLoaded', initMelodicSamplerPreview);
+</script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -487,7 +487,7 @@ def test_samples_route(client, tmp_path, monkeypatch):
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
 
-    base = '/data/UserData/UserLibrary/Samples/Preset Samples'
+    base = '/data/UserData/UserLibrary/Samples'
 
     def fake_join(a, *rest):
         if a == base:
@@ -511,7 +511,7 @@ def test_samples_route(client, tmp_path, monkeypatch):
 def test_samples_route_not_found(client, tmp_path, monkeypatch):
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
-    base = '/data/UserData/UserLibrary/Samples/Preset Samples'
+    base = '/data/UserData/UserLibrary/Samples'
 
     def fake_join(a, *rest):
         if a == base:


### PR DESCRIPTION
## Summary
- support serving arbitrary files from `/file/<path>`
- preview Melodic Sampler sample with WaveSurfer
- add JS module to load the waveform

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8274ae0c83259ab039e9adf88e41