### PR TITLE
Add sample preview in melodic sampler

### DIFF
--- a/static/melodic_sampler_preview.js
+++ b/static/melodic_sampler_preview.js
@@ -6,9 +6,14 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!container || !hidden || !hidden.value) return;
 
   function toFilesUrl(path) {
+    // Convert a sample URI or absolute path to the /files route.
     if (path.startsWith('ableton:/user-library/')) {
       const rel = path.replace('ableton:/user-library/', 'user-library/');
       return '/files/' + encodeURI(rel);
+    }
+    const packMatch = path.match(/^ableton:\/packs\/[^/]+\/(.+)$/);
+    if (packMatch) {
+      return '/files/core-library/' + encodeURI(packMatch[1]);
     }
     if (path.startsWith('/data/UserData/UserLibrary/')) {
       const rel = path.replace('/data/UserData/UserLibrary/', 'user-library/');

--- a/static/melodic_sampler_preview.js
+++ b/static/melodic_sampler_preview.js
@@ -1,0 +1,45 @@
+// Load and play the current melodic sampler sample
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('sample-waveform');
+  const hidden = document.getElementById('sample-path-hidden');
+  if (!container || !hidden || !hidden.value) return;
+
+  function toFilesUrl(path) {
+    if (path.startsWith('ableton:/user-library/')) {
+      const rel = path.replace('ableton:/user-library/', 'user-library/');
+      return '/files/' + encodeURI(rel);
+    }
+    if (path.startsWith('/data/UserData/UserLibrary/')) {
+      const rel = path.replace('/data/UserData/UserLibrary/', 'user-library/');
+      return '/files/' + encodeURI(rel);
+    }
+    if (path.startsWith('/data/CoreLibrary/')) {
+      const rel = path.replace('/data/CoreLibrary/', 'core-library/');
+      return '/files/' + encodeURI(rel);
+    }
+    return null;
+  }
+
+  const fileUrl = toFilesUrl(hidden.value.trim());
+  if (!fileUrl) return;
+
+  const ws = WaveSurfer.create({
+    container: container,
+    waveColor: '#888',
+    progressColor: '#555',
+    height: 64,
+    responsive: true,
+    normalize: true,
+    cursorWidth: 0,
+    hideScrollbar: true
+  });
+
+  ws.load(fileUrl);
+  container.addEventListener('click', (e) => {
+    e.stopPropagation();
+    ws.stop();
+    ws.seekTo(0);
+    requestAnimationFrame(() => ws.play(0));
+  });
+});

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -81,6 +81,10 @@
     </div>
 
     <p class="current-sample-path">Sample:  {{ sample_path if sample_path else 'None' }}</p>
+    {% if sample_path %}
+    <div id="sample-waveform" class="waveform-container"></div>
+    <input type="hidden" id="sample-path-hidden" value="{{ sample_path }}">
+    {% endif %}
 
     <div class="replace-sample">
         <label><input type="checkbox" name="replace_sample" id="replace-sample-checkbox"> Replace sample</label>
@@ -115,6 +119,8 @@
 window.driftSchema = {{ schema_json|safe }};
 </script>
 <script src="{{ host_prefix }}/static/melodic_sampler_macros.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
+<script src="{{ host_prefix }}/static/melodic_sampler_preview.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const cb = document.getElementById('rename-checkbox');


### PR DESCRIPTION
## Summary
- display current sample waveform when editing melodic sampler presets
- load sample via `/files` and initialize WaveSurfer player

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a878e03f0832580496b92c93490a6