### PR TITLE
Support core library in drum rack inspector

### DIFF
--- a/core/drum_rack_inspector_handler.py
+++ b/core/drum_rack_inspector_handler.py
@@ -108,7 +108,18 @@ def get_drum_cell_samples(preset_path):
                         # Handle Ableton URI format
                         if sample_uri.startswith('ableton:/user-library/Samples/'):
                             # Convert ableton:/user-library/Samples/ to /data/UserData/UserLibrary/Samples/
-                            sample_path = sample_uri.replace('ableton:/user-library/Samples/', '/data/UserData/UserLibrary/Samples/')
+                            sample_path = sample_uri.replace(
+                                'ableton:/user-library/Samples/',
+                                '/data/UserData/UserLibrary/Samples/',
+                            )
+                        elif sample_uri.startswith('ableton:/packs/'):
+                            # Convert ableton:/packs/<pack>/ to /data/CoreLibrary/
+                            # Strip the 'ableton:/packs/<pack>/' prefix
+                            parts = sample_uri.split('/', 3)
+                            if len(parts) >= 4:
+                                sample_path = '/data/CoreLibrary/' + parts[3]
+                            else:
+                                sample_path = sample_uri.split('file://')[-1]
                         else:
                             # Fallback to original file:// handling
                             sample_path = sample_uri.split('file://')[-1]

--- a/handlers/drum_rack_inspector_handler_class.py
+++ b/handlers/drum_rack_inspector_handler_class.py
@@ -29,6 +29,13 @@ class DrumRackInspectorHandler(BaseHandler):
             'select_preset',
             filter_key='drumrack'
         )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith('</ul>'):
+            browser_html = browser_html[:-5] + core_li + '</ul>'
         return {
             'file_browser_html': browser_html,
             'message': '',
@@ -80,6 +87,13 @@ class DrumRackInspectorHandler(BaseHandler):
                 'select_preset',
                 filter_key='drumrack'
             )
+            core_li = (
+                '<li class="dir closed" data-path="Core Library">'
+                '<span>📁 Core Library</span>'
+                '<ul class="hidden"></ul></li>'
+            )
+            if browser_html.endswith('</ul>'):
+                browser_html = browser_html[:-5] + core_li + '</ul>'
 
             return {
                 'file_browser_html': browser_html,
@@ -114,8 +128,16 @@ class DrumRackInspectorHandler(BaseHandler):
                 pad_num = pad_index + 1
                 sample = grid[pad_index]
                 cell = '<div class="drum-cell">'
-                if sample and sample.get('path') and sample['path'].startswith('/data/UserData/UserLibrary/Samples/'):
-                    web_path = '/samples/' + sample['path'].replace('/data/UserData/UserLibrary/Samples/Preset Samples/', '', 1)
+                if sample and sample.get('path'):
+                    path = sample['path']
+                    if path.startswith('/data/UserData/UserLibrary/'):
+                        rel = path[len('/data/UserData/UserLibrary/') :]
+                        web_path = '/files/user-library/' + rel
+                    elif path.startswith('/data/CoreLibrary/'):
+                        rel = path[len('/data/CoreLibrary/') :]
+                        web_path = '/files/core-library/' + rel
+                    else:
+                        web_path = '/files/user-library/' + path.lstrip('/')
                     web_path = urllib.parse.quote(web_path)
                     wf_id = f'waveform-{pad_num}'
                     cell += f'''<div class="pad-info"><span class="pad-number">Pad {pad_num}</span></div>
@@ -197,6 +219,13 @@ class DrumRackInspectorHandler(BaseHandler):
                 'select_preset',
                 filter_key='drumrack'
             )
+            core_li = (
+                '<li class="dir closed" data-path="Core Library">'
+                '<span>📁 Core Library</span>'
+                '<ul class="hidden"></ul></li>'
+            )
+            if browser_html.endswith('</ul>'):
+                browser_html = browser_html[:-5] + core_li + '</ul>'
             return {
                 'file_browser_html': browser_html,
                 'message': '',
@@ -271,6 +300,13 @@ class DrumRackInspectorHandler(BaseHandler):
             'select_preset',
             filter_key='drumrack'
         )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith('</ul>'):
+            browser_html = browser_html[:-5] + core_li + '</ul>'
         return {
             'file_browser_html': browser_html,
             'message': f"Time-stretched sample created and loaded for pad {pad_number}! {ts_message} {update_message}",
@@ -344,6 +380,13 @@ class DrumRackInspectorHandler(BaseHandler):
                 'select_preset',
                 filter_key='drumrack'
             )
+            core_li = (
+                '<li class="dir closed" data-path="Core Library">'
+                '<span>📁 Core Library</span>'
+                '<ul class="hidden"></ul></li>'
+            )
+            if browser_html.endswith('</ul>'):
+                browser_html = browser_html[:-5] + core_li + '</ul>'
             return {
                 'file_browser_html': browser_html,
                 'message': message,
@@ -390,6 +433,13 @@ class DrumRackInspectorHandler(BaseHandler):
             'select_preset',
             filter_key='drumrack'
         )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith('</ul>'):
+            browser_html = browser_html[:-5] + core_li + '</ul>'
         return {
             'file_browser_html': browser_html,
             'message': 'Reverted to original sample',

--- a/handlers/drum_rack_inspector_handler_class.py
+++ b/handlers/drum_rack_inspector_handler_class.py
@@ -2,6 +2,9 @@
 import os
 import urllib.parse
 import logging
+
+# Base directory for factory drum rack presets that should never be modified
+CORE_LIBRARY_DIR = "/data/CoreLibrary/Track Presets"
 from core.file_browser import generate_dir_html
 from handlers.base_handler import BaseHandler
 from core.drum_rack_inspector_handler import (
@@ -74,7 +77,10 @@ class DrumRackInspectorHandler(BaseHandler):
                 return self.format_error_response(result['message'])
 
             logger.debug("Found samples: %s", result['samples'])
-            samples_html = self.generate_samples_html(result['samples'], preset_path)
+            is_core = preset_path.startswith(CORE_LIBRARY_DIR)
+            samples_html = self.generate_samples_html(
+                result['samples'], preset_path, editable=not is_core
+            )
 
             base_dir = "/data/UserData/UserLibrary/Track Presets"
             if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
@@ -95,9 +101,12 @@ class DrumRackInspectorHandler(BaseHandler):
             if browser_html.endswith('</ul>'):
                 browser_html = browser_html[:-5] + core_li + '</ul>'
 
+            msg = result['message']
+            if is_core:
+                msg += ' (preview only)'
             return {
                 'file_browser_html': browser_html,
-                'message': result['message'],
+                'message': msg,
                 'samples_html': samples_html,
                 'selected_preset': preset_path,
                 'browser_root': base_dir,
@@ -112,8 +121,13 @@ class DrumRackInspectorHandler(BaseHandler):
         """Deprecated dropdown helper."""
         return ''
 
-    def generate_samples_html(self, samples, preset_path):
-        """Build the drum pad grid HTML."""
+    def generate_samples_html(self, samples, preset_path, editable=True):
+        """Build the drum pad grid HTML.
+
+        ``editable`` controls whether actions like Reverse or Time Stretch are
+        displayed. Core Library presets are read-only, so we set this to
+        ``False`` when rendering those presets.
+        """
         html = '<div class="drum-grid">'
         grid = [None] * 16
         for s in samples:
@@ -162,14 +176,15 @@ class DrumRackInspectorHandler(BaseHandler):
                     cell += '''
                           </div>
                           <div class="sample-actions">'''
-                    cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
-                                <input type="hidden" name="action" value="reverse_sample">
-                                <input type="hidden" name="sample_path" value="{sample['path']}">
-                                <input type="hidden" name="preset_path" value="{preset_path}">
-                                <input type="hidden" name="pad_number" value="{pad_num}">
-                                <button type="submit" class="reverse-button">Reverse</button>
-                              </form>'''
-                    cell += f'''<button type="button" class="time-stretch-button" data-sample-path="{sample['path']}" data-preset-path="{preset_path}" data-pad-number="{pad_num}" onclick="var modal = document.getElementById('timeStretchModal'); document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path'); document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path'); document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number'); modal.classList.remove('hidden');">Time Stretch</button>'''
+                    if editable:
+                        cell += f'''<form method="POST" action="/drum-rack-inspector" style="display:inline;">
+                                    <input type="hidden" name="action" value="reverse_sample">
+                                    <input type="hidden" name="sample_path" value="{sample['path']}">
+                                    <input type="hidden" name="preset_path" value="{preset_path}">
+                                    <input type="hidden" name="pad_number" value="{pad_num}">
+                                    <button type="submit" class="reverse-button">Reverse</button>
+                                  </form>'''
+                        cell += f'''<button type="button" class="time-stretch-button" data-sample-path="{sample['path']}" data-preset-path="{preset_path}" data-pad-number="{pad_num}" onclick="var modal = document.getElementById('timeStretchModal'); document.getElementById('ts_sample_path').value = this.getAttribute('data-sample-path'); document.getElementById('ts_preset_path').value = this.getAttribute('data-preset-path'); document.getElementById('ts_pad_number').value = this.getAttribute('data-pad-number'); modal.classList.remove('hidden');">Time Stretch</button>'''
                     cell += '</div></div>'
                 elif sample:
                     cell += f'<div class="pad-info"><span class="pad-number">Pad {pad_num}</span><span>No sample</span></div>'
@@ -186,6 +201,9 @@ class DrumRackInspectorHandler(BaseHandler):
         sample_path = form.getvalue('sample_path')
         preset_path = form.getvalue('preset_path')
         pad_number = form.getvalue('pad_number')
+
+        if preset_path and preset_path.startswith(CORE_LIBRARY_DIR):
+            return self.format_error_response('Core Library presets are read-only')
         bpm = form.getvalue('bpm')
         measures = form.getvalue('measures')
         preserve_pitch = form.getvalue('preserve_pitch') is not None
@@ -287,7 +305,10 @@ class DrumRackInspectorHandler(BaseHandler):
         if not result['success']:
             return self.format_error_response(result['message'])
 
-        samples_html = self.generate_samples_html(result['samples'], preset_path)
+        is_core = preset_path.startswith(CORE_LIBRARY_DIR)
+        samples_html = self.generate_samples_html(
+            result['samples'], preset_path, editable=not is_core
+        )
 
         base_dir = "/data/UserData/UserLibrary/Track Presets"
         if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
@@ -320,6 +341,9 @@ class DrumRackInspectorHandler(BaseHandler):
         """Handle reversing a sample."""
         sample_path = form.getvalue('sample_path')
         preset_path = form.getvalue('preset_path')
+
+        if preset_path and preset_path.startswith(CORE_LIBRARY_DIR):
+            return self.format_error_response('Core Library presets are read-only')
 
         if not sample_path or not preset_path:
             return self.format_error_response("Missing sample or preset path")
@@ -367,7 +391,10 @@ class DrumRackInspectorHandler(BaseHandler):
             if not result['success']:
                 return self.format_error_response(result['message'])
 
-            samples_html = self.generate_samples_html(result['samples'], preset_path)
+            is_core = preset_path.startswith(CORE_LIBRARY_DIR)
+            samples_html = self.generate_samples_html(
+                result['samples'], preset_path, editable=not is_core
+            )
 
             base_dir = "/data/UserData/UserLibrary/Track Presets"
             if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):
@@ -405,6 +432,8 @@ class DrumRackInspectorHandler(BaseHandler):
         sample_path = form.getvalue('sample_path')
         preset_path = form.getvalue('preset_path')
         pad_number = form.getvalue('pad_number')
+        if preset_path and preset_path.startswith(CORE_LIBRARY_DIR):
+            return self.format_error_response('Core Library presets are read-only')
         if not sample_path or not preset_path or not pad_number:
             return self.format_error_response("Missing parameters")
 
@@ -420,7 +449,10 @@ class DrumRackInspectorHandler(BaseHandler):
         if not result['success']:
             return self.format_error_response(result['message'])
 
-        samples_html = self.generate_samples_html(result['samples'], preset_path)
+        is_core = preset_path.startswith(CORE_LIBRARY_DIR)
+        samples_html = self.generate_samples_html(
+            result['samples'], preset_path, editable=not is_core
+        )
 
         base_dir = "/data/UserData/UserLibrary/Track Presets"
         if not os.path.exists(base_dir) and os.path.exists("examples/Track Presets"):

--- a/tests/test_drum_rack_inspector_handler.py
+++ b/tests/test_drum_rack_inspector_handler.py
@@ -130,3 +130,20 @@ def test_get_samples_core_library_translation(tmp_path):
     sample = info["samples"][0]
     assert sample["path"].startswith("/data/CoreLibrary/")
     assert sample["path"].endswith("Snare 606.aif")
+
+
+def test_generate_samples_html_core_preview():
+    from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
+
+    handler = DrumRackInspectorHandler()
+    sample = {
+        "pad": 1,
+        "sample": "Kick",
+        "path": "/data/CoreLibrary/Samples/Kick.wav",
+        "playback_start": 0.0,
+        "playback_length": 1.0,
+    }
+
+    html = handler.generate_samples_html([sample], "/data/CoreLibrary/Track Presets/Kit.ablpreset", editable=False)
+    assert "reverse-button" not in html
+    assert "time-stretch-button" not in html

--- a/tests/test_drum_rack_inspector_handler.py
+++ b/tests/test_drum_rack_inspector_handler.py
@@ -115,3 +115,18 @@ def test_scan_for_drum_rack_presets(monkeypatch, tmp_path):
     monkeypatch.setattr(drih, "get_cache", lambda k: captured["data"])
     result_cached = drih.scan_for_drum_rack_presets()
     assert "cached" in result_cached["message"]
+
+
+def test_get_samples_core_library_translation(tmp_path):
+    preset = tmp_path / "preset.json"
+    uri = (
+        "ableton:/packs/abl-core-library/"
+        "Samples/Drums/Snare/Snare 606.aif"
+    )
+    create_simple_preset(preset, sample_uri=uri)
+
+    info = drih.get_drum_cell_samples(str(preset))
+    assert info["success"], info.get("message")
+    sample = info["samples"][0]
+    assert sample["path"].startswith("/data/CoreLibrary/")
+    assert sample["path"].endswith("Snare 606.aif")


### PR DESCRIPTION
## Summary
- integrate core library support into the drum rack inspector file browser
- use `/files` endpoint to serve audio samples for drum pads

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a87f14ab083259c5d96aa593de415