### PR TITLE
Make melodic sampler waveform sticky

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -305,6 +305,15 @@ input[type="submit"]:disabled {
     margin-bottom: 1rem;
 }
 
+/* Sticky waveform for Melodic Sampler editor
+   Keeps the waveform visible below the macro knobs when scrolling
+   without affecting other pages that use .waveform-container */
+#sample-waveform {
+    position: sticky;
+    top: 5rem;
+    z-index: 9;
+}
+
 /* Success/Error messages */
 .success {
     color: #00a550;


### PR DESCRIPTION
## Summary
- make the waveform element stick below the macro knobs on the Melodic Sampler page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8f81515c8325ab2c98eeff6245f7