### PR TITLE
Improve melodic sampler playback preview

### DIFF
--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -122,6 +122,7 @@ window.driftSchema = {{ schema_json|safe }};
 </script>
 <script src="{{ host_prefix }}/static/melodic_sampler_macros.js"></script>
 <script src="https://unpkg.com/wavesurfer.js@6/dist/wavesurfer.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@6/dist/plugin/wavesurfer.regions.js"></script>
 <script src="{{ host_prefix }}/static/melodic_sampler_preview.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- highlight playback start/length on melodic sampler waveform
- adjust ADSR overlay to match region
- load Wavesurfer regions plugin for preview

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8f2d75848325be08390e2abc4501