### PR TITLE
Show filter ADSR overlay on melodic sampler

### DIFF
--- a/static/melodic_sampler_preview.js
+++ b/static/melodic_sampler_preview.js
@@ -93,7 +93,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const ctx = filterOverlay.getContext('2d');
     const a = parseFloat(fAttack?.value || '0');
     const d = parseFloat(fDecay?.value || '0');
-    const s = parseFloat(fSustain?.value || '0');
+    let s = parseFloat(fSustain?.value || '0');
+    if (s > 1) s /= 100; // convert percent to 0..1 range
     const r = parseFloat(fRelease?.value || '0');
 
     const startPct = parseFloat(pbStart?.value || '0');

--- a/static/melodic_sampler_preview.js
+++ b/static/melodic_sampler_preview.js
@@ -94,7 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const a = parseFloat(fAttack?.value || '0');
     const d = parseFloat(fDecay?.value || '0');
     let s = parseFloat(fSustain?.value || '0');
-    if (s > 1) s /= 100; // convert percent to 0..1 range
+    const sMax = parseFloat(fSustain?.max || '1');
+    if (sMax > 1) s /= sMax; // convert percent to 0..1 range based on max
     const r = parseFloat(fRelease?.value || '0');
 
     const startPct = parseFloat(pbStart?.value || '0');

--- a/templates_jinja/melodic_sampler_params.html
+++ b/templates_jinja/melodic_sampler_params.html
@@ -84,6 +84,7 @@
     {% if sample_path %}
     <div id="sample-waveform" class="waveform-container">
         <canvas id="adsr-overlay" class="adsr-overlay"></canvas>
+        <canvas id="filter-adsr-overlay" class="adsr-overlay"></canvas>
     </div>
     <input type="hidden" id="sample-path-hidden" value="{{ sample_path }}">
     {% endif %}


### PR DESCRIPTION
## Summary
- show filter envelope overlay on the melodic sampler waveform
- draw the filter ADSR in light blue when filter env is enabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a987d07548325aa00923abc346369