### PR TITLE
Fix melodic sampler envelope overlay z-index

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1178,6 +1178,7 @@ button#macro-add-param {
     width: 100%;
     height: 100%;
     pointer-events: none;
+    z-index: 11;
 }
 
 .lfo-canvas {


### PR DESCRIPTION
## Summary
- ensure ADSR overlays render above waveform

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9eb780b8832584e95f8703785f97