### PR TITLE
Skip pan, volume and gain

### DIFF
--- a/handlers/melodic_sampler_param_editor_handler_class.py
+++ b/handlers/melodic_sampler_param_editor_handler_class.py
@@ -47,7 +47,11 @@ CORE_LIBRARY_DIR = "/data/CoreLibrary/Track Presets"
 
 logger = logging.getLogger(__name__)
 
-EXCLUDED_MACRO_PARAMS = set()
+EXCLUDED_MACRO_PARAMS = {
+    "Volume",
+    "Voice_Gain",
+    "Voice_VelocityToVolume",
+}
 
 DEFAULT_MACRO_NAMES = ["Transpose", "Playback Start", "Attack", "Decay", "Release", "Filter Frequency", "Filter Resonance", "Filter LFO"]
 DEFAULT_MACRO_PARAMS = [

--- a/handlers/synth_param_editor_handler_class.py
+++ b/handlers/synth_param_editor_handler_class.py
@@ -90,6 +90,9 @@ EXCLUDED_MACRO_PARAMS = {
     "Oscillator1_ShapeModSource",
     "PitchModulation_Source1",
     "PitchModulation_Source2",
+    "Global_Volume",
+    "Mixer_OscillatorGain1",
+    "Mixer_OscillatorGain2",
 }
 
 

--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -87,6 +87,13 @@ EXCLUDED_MACRO_PARAMS = {
     "Voice_Oscillator2_Effects_EffectMode",
     "Voice_Unison_Mode",
     "Voice_Unison_VoiceCount",
+    "Volume",
+    "Global_Volume",
+    "Voice_Oscillator1_Gain",
+    "Voice_Oscillator2_Gain",
+    "Voice_SubOscillator_Gain",
+    "Mixer_OscillatorGain1",
+    "Mixer_OscillatorGain2",
 }
 
 

--- a/static/synth_params.js
+++ b/static/synth_params.js
@@ -15,6 +15,15 @@ function initNewPresetModal() {
 
 function randomizeParams() {
   document.querySelectorAll('.param-item').forEach(item => {
+    const name = (item.dataset.name || '').toLowerCase();
+    // Skip panning, volume, and gain controls for all synth editors
+    if (
+      name === 'pan' ||
+      name.endsWith('_pan') ||
+      name === 'volume' ||
+      name.includes('gain')
+    ) return;
+
     const dial = item.querySelector('input.param-dial');
     const select = item.querySelector('select.param-select');
     const toggle = item.querySelector('input.param-toggle');


### PR DESCRIPTION
## Summary
- stop randomizing pan, volume and gain values in the editor
- exclude gain and volume parameters from macro automation lists for Wavetable, Drift and MelodicSampler editors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b064efc78832588df457415b3be65