### PR TITLE
Add drumRack and set schema generator

### DIFF
--- a/static/schemas/abl_set_schema.json
+++ b/static/schemas/abl_set_schema.json
@@ -1,0 +1,4293 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "stepEditorResolution": {
+      "type": "string"
+    },
+    "tempo": {
+      "type": "number"
+    },
+    "globalGrooveAmount": {
+      "type": "number"
+    },
+    "rootNote": {
+      "type": "integer"
+    },
+    "scale": {
+      "type": "string"
+    },
+    "melodicLayout": {
+      "type": "string"
+    },
+    "tracks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "integer"
+          },
+          "isSelected": {
+            "type": "boolean"
+          },
+          "clipSlots": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "hasStop": {
+                  "type": "boolean"
+                },
+                "clip": {
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "isPlaying": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "color": {
+                          "type": "integer"
+                        },
+                        "isEnabled": {
+                          "type": "boolean"
+                        },
+                        "region": {
+                          "type": "object",
+                          "properties": {
+                            "start": {
+                              "type": "number"
+                            },
+                            "end": {
+                              "type": "number"
+                            },
+                            "loop": {
+                              "type": "object",
+                              "properties": {
+                                "start": {
+                                  "type": "number"
+                                },
+                                "end": {
+                                  "type": "number"
+                                },
+                                "isEnabled": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "end",
+                                "isEnabled",
+                                "start"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "end",
+                            "loop",
+                            "start"
+                          ]
+                        },
+                        "grooveId": {
+                          "type": "integer"
+                        },
+                        "notes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "noteNumber": {
+                                "type": "integer"
+                              },
+                              "startTime": {
+                                "type": "number"
+                              },
+                              "duration": {
+                                "type": "number"
+                              },
+                              "velocity": {
+                                "type": "number"
+                              },
+                              "offVelocity": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "duration",
+                              "noteNumber",
+                              "offVelocity",
+                              "startTime",
+                              "velocity"
+                            ]
+                          }
+                        },
+                        "stepEditorScrollPosition": {
+                          "type": "number"
+                        },
+                        "envelopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "parameterId": {
+                                "type": "integer"
+                              },
+                              "breakpoints": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "time": {
+                                      "type": "number"
+                                    },
+                                    "value": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "time",
+                                    "value"
+                                  ]
+                                }
+                              },
+                              "region": {
+                                "type": "null"
+                              }
+                            },
+                            "required": [
+                              "breakpoints",
+                              "parameterId",
+                              "region"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "color",
+                        "envelopes",
+                        "grooveId",
+                        "isEnabled",
+                        "isPlaying",
+                        "name",
+                        "notes",
+                        "region",
+                        "stepEditorScrollPosition"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "clip",
+                "hasStop"
+              ]
+            }
+          },
+          "isNoteRepeatOn": {
+            "type": "boolean"
+          },
+          "noteRepeatRate": {
+            "type": "string"
+          },
+          "noteRepeatArpeggio": {
+            "type": "object",
+            "properties": {
+              "style": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "style"
+            ]
+          },
+          "uiOctaveIndex": {
+            "type": "integer"
+          },
+          "midiInputMode": {
+            "type": "string"
+          },
+          "midiOutputEndpoint": {
+            "type": "null"
+          },
+          "devices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "presetUri": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "lockId": {
+                  "type": "integer"
+                },
+                "lockSeal": {
+                  "type": "integer"
+                },
+                "parameters": {
+                  "type": "object",
+                  "properties": {
+                    "Enabled": {
+                      "type": "boolean"
+                    },
+                    "Macro0": {
+                      "type": "number"
+                    },
+                    "Macro1": {
+                      "type": "number"
+                    },
+                    "Macro2": {
+                      "type": "number"
+                    },
+                    "Macro3": {
+                      "type": "number"
+                    },
+                    "Macro4": {
+                      "type": "number"
+                    },
+                    "Macro5": {
+                      "type": "number"
+                    },
+                    "Macro6": {
+                      "type": "number"
+                    },
+                    "Macro7": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "Enabled",
+                    "Macro0",
+                    "Macro1",
+                    "Macro2",
+                    "Macro3",
+                    "Macro4",
+                    "Macro5",
+                    "Macro6",
+                    "Macro7"
+                  ]
+                },
+                "chains": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "integer"
+                      },
+                      "devices": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "presetUri": {
+                              "type": "null"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "lockId": {
+                              "type": "integer"
+                            },
+                            "lockSeal": {
+                              "type": "integer"
+                            },
+                            "parameters": {
+                              "type": "object",
+                              "properties": {
+                                "Enabled": {
+                                  "type": "boolean"
+                                },
+                                "Macro0": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro1": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        },
+                                        "presetValue": {
+                                          "type": "number"
+                                        },
+                                        "id": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro2": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro3": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro4": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro5": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro6": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Macro7": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        },
+                                        "customName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "customName",
+                                        "value"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "BaseDrive": {
+                                  "type": "number"
+                                },
+                                "BassShaperThreshold": {
+                                  "type": "number"
+                                },
+                                "ColorDepth": {
+                                  "type": "number"
+                                },
+                                "ColorFrequency": {
+                                  "type": "number"
+                                },
+                                "ColorOn": {
+                                  "type": "boolean"
+                                },
+                                "ColorWidth": {
+                                  "type": "number"
+                                },
+                                "DryWet": {
+                                  "type": "number"
+                                },
+                                "Oversampling": {
+                                  "type": "boolean"
+                                },
+                                "PostClip": {
+                                  "type": "string"
+                                },
+                                "PostDrive": {
+                                  "type": "number"
+                                },
+                                "PreDcFilter": {
+                                  "type": "boolean"
+                                },
+                                "PreDrive": {
+                                  "type": "number"
+                                },
+                                "Type": {
+                                  "type": "string"
+                                },
+                                "WsCurve": {
+                                  "type": "number"
+                                },
+                                "WsDamp": {
+                                  "type": "number"
+                                },
+                                "WsDepth": {
+                                  "type": "number"
+                                },
+                                "WsDrive": {
+                                  "type": "number"
+                                },
+                                "WsLin": {
+                                  "type": "number"
+                                },
+                                "WsPeriod": {
+                                  "type": "number"
+                                },
+                                "DelayLine_CompatibilityMode": {
+                                  "type": "string"
+                                },
+                                "DelayLine_Link": {
+                                  "type": "boolean"
+                                },
+                                "DelayLine_OffsetL": {
+                                  "type": "number"
+                                },
+                                "DelayLine_OffsetR": {
+                                  "type": "number"
+                                },
+                                "DelayLine_PingPong": {
+                                  "type": "boolean"
+                                },
+                                "DelayLine_PingPongDelayTimeL": {
+                                  "type": "number"
+                                },
+                                "DelayLine_PingPongDelayTimeR": {
+                                  "type": "number"
+                                },
+                                "DelayLine_SimpleDelayTimeL": {
+                                  "type": "number"
+                                },
+                                "DelayLine_SimpleDelayTimeR": {
+                                  "type": "number"
+                                },
+                                "DelayLine_SmoothingMode": {
+                                  "type": "string"
+                                },
+                                "DelayLine_SyncL": {
+                                  "type": "boolean"
+                                },
+                                "DelayLine_SyncR": {
+                                  "type": "boolean"
+                                },
+                                "DelayLine_SyncedSixteenthL": {
+                                  "type": "string"
+                                },
+                                "DelayLine_SyncedSixteenthR": {
+                                  "type": "string"
+                                },
+                                "DelayLine_TimeL": {
+                                  "type": "number"
+                                },
+                                "DelayLine_TimeR": {
+                                  "type": "number"
+                                },
+                                "DryWetMode": {
+                                  "type": "string"
+                                },
+                                "EcoProcessing": {
+                                  "type": "boolean"
+                                },
+                                "Feedback": {
+                                  "type": "number"
+                                },
+                                "Filter_Bandwidth": {
+                                  "type": "number"
+                                },
+                                "Filter_Frequency": {
+                                  "type": "number"
+                                },
+                                "Filter_On": {
+                                  "type": "boolean"
+                                },
+                                "Freeze": {
+                                  "type": "boolean"
+                                },
+                                "Modulation_AmountFilter": {
+                                  "type": "number"
+                                },
+                                "Modulation_AmountTime": {
+                                  "type": "number"
+                                },
+                                "Modulation_Frequency": {
+                                  "type": "number"
+                                },
+                                "Amount": {
+                                  "type": "number"
+                                },
+                                "HighpassEnabled": {
+                                  "type": "boolean"
+                                },
+                                "HighpassFrequency": {
+                                  "type": "number"
+                                },
+                                "InvertFeedback": {
+                                  "type": "boolean"
+                                },
+                                "Mode": {
+                                  "type": "string"
+                                },
+                                "OutputGain": {
+                                  "type": "number"
+                                },
+                                "Rate": {
+                                  "type": "number"
+                                },
+                                "Shaping": {
+                                  "type": "number"
+                                },
+                                "VibratoOffset": {
+                                  "type": "number"
+                                },
+                                "Warmth": {
+                                  "type": "number"
+                                },
+                                "Width": {
+                                  "type": "number"
+                                },
+                                "AllPassGain": {
+                                  "type": "number"
+                                },
+                                "AllPassSize": {
+                                  "type": "number"
+                                },
+                                "BandFreq": {
+                                  "type": "number"
+                                },
+                                "BandHighOn": {
+                                  "type": "boolean"
+                                },
+                                "BandLowOn": {
+                                  "type": "boolean"
+                                },
+                                "BandWidth": {
+                                  "type": "number"
+                                },
+                                "ChorusOn": {
+                                  "type": "boolean"
+                                },
+                                "CutOn": {
+                                  "type": "boolean"
+                                },
+                                "DecayTime": {
+                                  "type": "number"
+                                },
+                                "DiffuseDelay": {
+                                  "type": "number"
+                                },
+                                "EarlyReflectModDepth": {
+                                  "type": "number"
+                                },
+                                "EarlyReflectModFreq": {
+                                  "type": "number"
+                                },
+                                "FlatOn": {
+                                  "type": "boolean"
+                                },
+                                "FreezeOn": {
+                                  "type": "boolean"
+                                },
+                                "HighFilterType": {
+                                  "type": "string"
+                                },
+                                "MixDiffuse": {
+                                  "type": "number"
+                                },
+                                "MixDirect": {
+                                  "type": "number"
+                                },
+                                "MixReflect": {
+                                  "type": "number"
+                                },
+                                "PreDelay": {
+                                  "type": "number"
+                                },
+                                "RoomSize": {
+                                  "type": "number"
+                                },
+                                "RoomType": {
+                                  "type": "string"
+                                },
+                                "ShelfHiFreq": {
+                                  "type": "number"
+                                },
+                                "ShelfHiGain": {
+                                  "type": "number"
+                                },
+                                "ShelfHighOn": {
+                                  "type": "boolean"
+                                },
+                                "ShelfLoFreq": {
+                                  "type": "number"
+                                },
+                                "ShelfLoGain": {
+                                  "type": "number"
+                                },
+                                "ShelfLowOn": {
+                                  "type": "boolean"
+                                },
+                                "SizeModDepth": {
+                                  "type": "number"
+                                },
+                                "SizeModFreq": {
+                                  "type": "number"
+                                },
+                                "SizeSmoothing": {
+                                  "type": "string"
+                                },
+                                "SpinOn": {
+                                  "type": "boolean"
+                                },
+                                "StereoSeparation": {
+                                  "type": "number"
+                                },
+                                "CenterFrequency": {
+                                  "type": "number"
+                                },
+                                "DoublerDelayTime": {
+                                  "type": "number"
+                                },
+                                "FlangerDelayTime": {
+                                  "type": "number"
+                                },
+                                "InvertWet": {
+                                  "type": "boolean"
+                                },
+                                "ModulationBlend": {
+                                  "type": "number"
+                                },
+                                "Modulation_Amount": {
+                                  "type": "number"
+                                },
+                                "Modulation_DutyCycle": {
+                                  "type": "number"
+                                },
+                                "Modulation_EnvelopeAmount": {
+                                  "type": "number"
+                                },
+                                "Modulation_EnvelopeAttack": {
+                                  "type": "number"
+                                },
+                                "Modulation_EnvelopeEnabled": {
+                                  "type": "boolean"
+                                },
+                                "Modulation_EnvelopeRelease": {
+                                  "type": "number"
+                                },
+                                "Modulation_Frequency2": {
+                                  "type": "number"
+                                },
+                                "Modulation_LfoBlend": {
+                                  "type": "number"
+                                },
+                                "Modulation_PhaseOffset": {
+                                  "type": "number"
+                                },
+                                "Modulation_Spin": {
+                                  "type": "number"
+                                },
+                                "Modulation_SpinEnabled": {
+                                  "type": "boolean"
+                                },
+                                "Modulation_Sync": {
+                                  "type": "boolean"
+                                },
+                                "Modulation_Sync2": {
+                                  "type": "boolean"
+                                },
+                                "Modulation_SyncedRate": {
+                                  "type": "integer"
+                                },
+                                "Modulation_SyncedRate2": {
+                                  "type": "integer"
+                                },
+                                "Modulation_Waveform": {
+                                  "type": "string"
+                                },
+                                "Notches": {
+                                  "type": "integer"
+                                },
+                                "SafeBassFrequency": {
+                                  "type": "number"
+                                },
+                                "Spread": {
+                                  "type": "number"
+                                },
+                                "Voice_AmplitudeEnvelope_Attack": {
+                                  "type": "number"
+                                },
+                                "Voice_AmplitudeEnvelope_Decay": {
+                                  "type": "number"
+                                },
+                                "Voice_AmplitudeEnvelope_Release": {
+                                  "type": "number"
+                                },
+                                "Voice_AmplitudeEnvelope_Sustain": {
+                                  "type": "number"
+                                },
+                                "Voice_AmplitudeEnvelope_SustainMode": {
+                                  "type": "string"
+                                },
+                                "Voice_Detune": {
+                                  "type": "number"
+                                },
+                                "Voice_FilterEnvelope_Attack": {
+                                  "type": "number"
+                                },
+                                "Voice_FilterEnvelope_Decay": {
+                                  "type": "number"
+                                },
+                                "Voice_FilterEnvelope_On": {
+                                  "type": "boolean"
+                                },
+                                "Voice_FilterEnvelope_Release": {
+                                  "type": "number"
+                                },
+                                "Voice_FilterEnvelope_Sustain": {
+                                  "type": "number"
+                                },
+                                "Voice_Filter_Frequency": {
+                                  "type": "number"
+                                },
+                                "Voice_Filter_FrequencyModulationAmounts_EnvelopeAmount": {
+                                  "type": "integer"
+                                },
+                                "Voice_Filter_FrequencyModulationAmounts_LfoAmount": {
+                                  "type": "number"
+                                },
+                                "Voice_Filter_On": {
+                                  "type": "boolean"
+                                },
+                                "Voice_Filter_Resonance": {
+                                  "type": "number"
+                                },
+                                "Voice_Filter_Slope": {
+                                  "type": "string"
+                                },
+                                "Voice_Filter_Type": {
+                                  "type": "string"
+                                },
+                                "Voice_Gain": {
+                                  "type": "number"
+                                },
+                                "Voice_Lfo_On": {
+                                  "type": "boolean"
+                                },
+                                "Voice_Lfo_Rate": {
+                                  "type": "number"
+                                },
+                                "Voice_Lfo_Type": {
+                                  "type": "string"
+                                },
+                                "Voice_PlaybackLength": {
+                                  "type": "number"
+                                },
+                                "Voice_PlaybackStart": {
+                                  "type": "number"
+                                },
+                                "Voice_Transpose": {
+                                  "type": "integer"
+                                },
+                                "Voice_VelocityToVolume": {
+                                  "type": "number"
+                                },
+                                "Volume": {
+                                  "type": "number"
+                                },
+                                "Gain": {
+                                  "type": "number"
+                                },
+                                "HighShelfGain": {
+                                  "type": "number"
+                                },
+                                "HighpassOn": {
+                                  "type": "boolean"
+                                },
+                                "LowShelfGain": {
+                                  "type": "number"
+                                },
+                                "MidFrequency": {
+                                  "type": "number"
+                                },
+                                "MidGain": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "Enabled"
+                              ]
+                            },
+                            "chains": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "color": {
+                                    "type": "integer"
+                                  },
+                                  "devices": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "presetUri": {
+                                          "type": "null"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "Effect_EightBitFilterDecay": {
+                                              "type": "number"
+                                            },
+                                            "Effect_EightBitResamplingRate": {
+                                              "type": "number"
+                                            },
+                                            "Effect_FmAmount": {
+                                              "type": "number"
+                                            },
+                                            "Effect_FmFrequency": {
+                                              "type": "number"
+                                            },
+                                            "Effect_LoopLength": {
+                                              "type": "number"
+                                            },
+                                            "Effect_LoopOffset": {
+                                              "type": "number"
+                                            },
+                                            "Effect_NoiseAmount": {
+                                              "type": "number"
+                                            },
+                                            "Effect_NoiseFrequency": {
+                                              "type": "number"
+                                            },
+                                            "Effect_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Effect_PitchEnvelopeAmount": {
+                                              "type": "number"
+                                            },
+                                            "Effect_PitchEnvelopeDecay": {
+                                              "type": "number"
+                                            },
+                                            "Effect_PunchAmount": {
+                                              "type": "number"
+                                            },
+                                            "Effect_PunchTime": {
+                                              "type": "number"
+                                            },
+                                            "Effect_RingModAmount": {
+                                              "type": "number"
+                                            },
+                                            "Effect_RingModFrequency": {
+                                              "type": "number"
+                                            },
+                                            "Effect_StretchFactor": {
+                                              "type": "number"
+                                            },
+                                            "Effect_StretchGrainSize": {
+                                              "type": "number"
+                                            },
+                                            "Effect_SubOscAmount": {
+                                              "type": "number"
+                                            },
+                                            "Effect_SubOscFrequency": {
+                                              "type": "number"
+                                            },
+                                            "Effect_Type": {
+                                              "type": "string"
+                                            },
+                                            "Enabled": {
+                                              "type": "boolean"
+                                            },
+                                            "NotePitchBend": {
+                                              "type": "boolean"
+                                            },
+                                            "Pan": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Detune": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Envelope_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Envelope_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Envelope_Hold": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Envelope_Mode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter_Frequency": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Filter_PeakGain": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter_Resonance": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter_Type": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Gain": {
+                                              "type": "number"
+                                            },
+                                            "Voice_ModulationAmount": {
+                                              "type": "number"
+                                            },
+                                            "Voice_ModulationSource": {
+                                              "type": "string"
+                                            },
+                                            "Voice_ModulationTarget": {
+                                              "type": "string"
+                                            },
+                                            "Voice_PitchToEnvelopeModulation": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_PlaybackLength": {
+                                              "type": "number"
+                                            },
+                                            "Voice_PlaybackStart": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "id": {
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Transpose": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "integer"
+                                                    },
+                                                    "id": {
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_VelocityToVolume": {
+                                              "type": "number"
+                                            },
+                                            "Volume": {
+                                              "type": "number"
+                                            },
+                                            "HiQ": {
+                                              "type": "boolean"
+                                            },
+                                            "MonoPoly": {
+                                              "type": "string"
+                                            },
+                                            "PolyVoices": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter1_CircuitBpNoMo": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter1_CircuitLpHp": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter1_Drive": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter1_Frequency": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Filter1_Morph": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter1_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Filter1_Resonance": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Filter1_Slope": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter1_Type": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter2_CircuitBpNoMo": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter2_CircuitLpHp": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter2_Drive": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter2_Frequency": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter2_Morph": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter2_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Filter2_Resonance": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Filter2_Slope": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Filter2_Type": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Global_FilterRouting": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Global_Glide": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Global_Transpose": {
+                                              "type": "integer"
+                                            },
+                                            "Voice_Modulators_Amount": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_LoopMode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Slopes_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Slopes_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Slopes_Release": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Sustain": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Times_Attack": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Times_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_AmpEnvelope_Times_Release": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_Envelope2_LoopMode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_Envelope2_Slopes_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope2_Slopes_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope2_Slopes_Release": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope2_Times_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope2_Times_Decay": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_Envelope2_Times_Release": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_Envelope2_Values_Final": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope2_Values_Initial": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope2_Values_Peak": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_Envelope2_Values_Sustain": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_LoopMode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_Envelope3_Slopes_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Slopes_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Slopes_Release": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Times_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Times_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Times_Release": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Values_Final": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Values_Initial": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Values_Peak": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Envelope3_Values_Sustain": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo1_Retrigger": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Modulators_Lfo1_Shape_Amount": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Modulators_Lfo1_Shape_PhaseOffset": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo1_Shape_Shaping": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo1_Shape_Type": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_Lfo1_Time_AttackTime": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo1_Time_Rate": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo1_Time_Sync": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_Lfo1_Time_SyncedRate": {
+                                              "type": "integer"
+                                            },
+                                            "Voice_Modulators_Lfo2_Retrigger": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Modulators_Lfo2_Shape_Amount": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo2_Shape_PhaseOffset": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo2_Shape_Shaping": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo2_Shape_Type": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_Lfo2_Time_AttackTime": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo2_Time_Rate": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Modulators_Lfo2_Time_Sync": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Modulators_Lfo2_Time_SyncedRate": {
+                                              "type": "integer"
+                                            },
+                                            "Voice_Modulators_TimeScale": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Oscillator1_Effects_Effect1": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator1_Effects_Effect2": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator1_Effects_EffectMode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Oscillator1_Gain": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Oscillator1_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Oscillator1_Pan": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Oscillator1_Pitch_Detune": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Oscillator1_Pitch_Transpose": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "integer"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator1_Wavetables_WavePosition": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator2_Effects_Effect1": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator2_Effects_Effect2": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator2_Effects_EffectMode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Oscillator2_Gain": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Oscillator2_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_Oscillator2_Pan": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Oscillator2_Pitch_Detune": {
+                                              "type": "number"
+                                            },
+                                            "Voice_Oscillator2_Pitch_Transpose": {
+                                              "type": "integer"
+                                            },
+                                            "Voice_Oscillator2_Wavetables_WavePosition": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_SubOscillator_Gain": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_SubOscillator_On": {
+                                              "type": "boolean"
+                                            },
+                                            "Voice_SubOscillator_Tone": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_SubOscillator_Transpose": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Unison_Amount": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Voice_Unison_Mode": {
+                                              "type": "string"
+                                            },
+                                            "Voice_Unison_VoiceCount": {
+                                              "type": "integer"
+                                            },
+                                            "CyclingEnvelope_Hold": {
+                                              "type": "number"
+                                            },
+                                            "CyclingEnvelope_MidPoint": {
+                                              "type": "number"
+                                            },
+                                            "CyclingEnvelope_Mode": {
+                                              "type": "string"
+                                            },
+                                            "CyclingEnvelope_Rate": {
+                                              "type": "number"
+                                            },
+                                            "CyclingEnvelope_Ratio": {
+                                              "type": "number"
+                                            },
+                                            "CyclingEnvelope_SyncedRate": {
+                                              "type": "integer"
+                                            },
+                                            "CyclingEnvelope_Time": {
+                                              "type": "number"
+                                            },
+                                            "Envelope1_Attack": {
+                                              "type": "object",
+                                              "properties": {
+                                                "value": {
+                                                  "type": "number"
+                                                },
+                                                "macroMapping": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "macroIndex": {
+                                                      "type": "integer"
+                                                    },
+                                                    "rangeMin": {
+                                                      "type": "number"
+                                                    },
+                                                    "rangeMax": {
+                                                      "type": "number"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroIndex",
+                                                    "rangeMax",
+                                                    "rangeMin"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "macroMapping",
+                                                "value"
+                                              ]
+                                            },
+                                            "Envelope1_Decay": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Envelope1_Release": {
+                                              "type": "object",
+                                              "properties": {
+                                                "value": {
+                                                  "type": "number"
+                                                },
+                                                "macroMapping": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "macroIndex": {
+                                                      "type": "integer"
+                                                    },
+                                                    "rangeMin": {
+                                                      "type": "number"
+                                                    },
+                                                    "rangeMax": {
+                                                      "type": "number"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroIndex",
+                                                    "rangeMax",
+                                                    "rangeMin"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "macroMapping",
+                                                "value"
+                                              ]
+                                            },
+                                            "Envelope1_Sustain": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Envelope2_Attack": {
+                                              "type": "number"
+                                            },
+                                            "Envelope2_Decay": {
+                                              "type": "number"
+                                            },
+                                            "Envelope2_Release": {
+                                              "type": "number"
+                                            },
+                                            "Envelope2_Sustain": {
+                                              "type": "number"
+                                            },
+                                            "Filter_Frequency": {
+                                              "type": "object",
+                                              "properties": {
+                                                "value": {
+                                                  "type": "number"
+                                                },
+                                                "macroMapping": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "macroIndex": {
+                                                      "type": "integer"
+                                                    },
+                                                    "rangeMin": {
+                                                      "type": "number"
+                                                    },
+                                                    "rangeMax": {
+                                                      "type": "number"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroIndex",
+                                                    "rangeMax",
+                                                    "rangeMin"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "macroMapping",
+                                                "value"
+                                              ]
+                                            },
+                                            "Filter_HiPassFrequency": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Filter_ModAmount1": {
+                                              "type": "number"
+                                            },
+                                            "Filter_ModAmount2": {
+                                              "type": "number"
+                                            },
+                                            "Filter_ModSource1": {
+                                              "type": "string"
+                                            },
+                                            "Filter_ModSource2": {
+                                              "type": "string"
+                                            },
+                                            "Filter_NoiseThrough": {
+                                              "type": "boolean"
+                                            },
+                                            "Filter_OscillatorThrough1": {
+                                              "type": "boolean"
+                                            },
+                                            "Filter_OscillatorThrough2": {
+                                              "type": "boolean"
+                                            },
+                                            "Filter_Resonance": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Filter_Tracking": {
+                                              "type": "number"
+                                            },
+                                            "Filter_Type": {
+                                              "type": "string"
+                                            },
+                                            "Global_DriftDepth": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Global_Envelope2Mode": {
+                                              "type": "string"
+                                            },
+                                            "Global_Glide": {
+                                              "type": "number"
+                                            },
+                                            "Global_HiQuality": {
+                                              "type": "boolean"
+                                            },
+                                            "Global_Legato": {
+                                              "type": "boolean"
+                                            },
+                                            "Global_MonoVoiceDepth": {
+                                              "type": "number"
+                                            },
+                                            "Global_NotePitchBend": {
+                                              "type": "boolean"
+                                            },
+                                            "Global_PitchBendRange": {
+                                              "type": "integer"
+                                            },
+                                            "Global_PolyVoiceDepth": {
+                                              "type": "number"
+                                            },
+                                            "Global_ResetOscillatorPhase": {
+                                              "type": "boolean"
+                                            },
+                                            "Global_SerialNumber": {
+                                              "type": "integer"
+                                            },
+                                            "Global_StereoVoiceDepth": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Global_Transpose": {
+                                              "type": "integer"
+                                            },
+                                            "Global_UnisonVoiceDepth": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Global_VoiceCount": {
+                                              "type": "string"
+                                            },
+                                            "Global_VoiceMode": {
+                                              "type": "string"
+                                            },
+                                            "Global_VolVelMod": {
+                                              "type": "number"
+                                            },
+                                            "Global_Volume": {
+                                              "type": "number"
+                                            },
+                                            "Lfo_Amount": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Lfo_ModAmount": {
+                                              "type": "number"
+                                            },
+                                            "Lfo_ModSource": {
+                                              "type": "string"
+                                            },
+                                            "Lfo_Mode": {
+                                              "type": "string"
+                                            },
+                                            "Lfo_Rate": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Lfo_Ratio": {
+                                              "type": "number"
+                                            },
+                                            "Lfo_Retrigger": {
+                                              "type": "boolean"
+                                            },
+                                            "Lfo_Shape": {
+                                              "type": "string"
+                                            },
+                                            "Lfo_SyncedRate": {
+                                              "type": "integer"
+                                            },
+                                            "Lfo_Time": {
+                                              "type": "number"
+                                            },
+                                            "Mixer_NoiseLevel": {
+                                              "type": "number"
+                                            },
+                                            "Mixer_NoiseOn": {
+                                              "type": "boolean"
+                                            },
+                                            "Mixer_OscillatorGain1": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Mixer_OscillatorGain2": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Mixer_OscillatorOn1": {
+                                              "type": "boolean"
+                                            },
+                                            "Mixer_OscillatorOn2": {
+                                              "type": "boolean"
+                                            },
+                                            "ModulationMatrix_Amount1": {
+                                              "type": "number"
+                                            },
+                                            "ModulationMatrix_Amount2": {
+                                              "type": "number"
+                                            },
+                                            "ModulationMatrix_Amount3": {
+                                              "type": "number"
+                                            },
+                                            "ModulationMatrix_Source1": {
+                                              "type": "string"
+                                            },
+                                            "ModulationMatrix_Source2": {
+                                              "type": "string"
+                                            },
+                                            "ModulationMatrix_Source3": {
+                                              "type": "string"
+                                            },
+                                            "ModulationMatrix_Target1": {
+                                              "type": "string"
+                                            },
+                                            "ModulationMatrix_Target2": {
+                                              "type": "string"
+                                            },
+                                            "ModulationMatrix_Target3": {
+                                              "type": "string"
+                                            },
+                                            "Oscillator1_Shape": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "number"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        },
+                                                        "rangeMin": {
+                                                          "type": "number"
+                                                        },
+                                                        "rangeMax": {
+                                                          "type": "number"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex",
+                                                        "rangeMax",
+                                                        "rangeMin"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Oscillator1_ShapeMod": {
+                                              "type": "number"
+                                            },
+                                            "Oscillator1_ShapeModSource": {
+                                              "type": "string"
+                                            },
+                                            "Oscillator1_Transpose": {
+                                              "type": "integer"
+                                            },
+                                            "Oscillator1_Type": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "Oscillator2_Detune": {
+                                              "type": "number"
+                                            },
+                                            "Oscillator2_Transpose": {
+                                              "type": "integer"
+                                            },
+                                            "Oscillator2_Type": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "macroMapping": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "macroIndex": {
+                                                          "type": "integer"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "macroIndex"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "macroMapping",
+                                                    "value"
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "PitchModulation_Amount1": {
+                                              "type": "number"
+                                            },
+                                            "PitchModulation_Amount2": {
+                                              "type": "number"
+                                            },
+                                            "PitchModulation_Source1": {
+                                              "type": "string"
+                                            },
+                                            "PitchModulation_Source2": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "Enabled"
+                                          ]
+                                        },
+                                        "deviceData": {
+                                          "type": "object",
+                                          "properties": {
+                                            "sampleUri": {
+                                              "type": "string"
+                                            },
+                                            "spriteUri1": {
+                                              "type": "string"
+                                            },
+                                            "spriteUri2": {
+                                              "type": "string"
+                                            },
+                                            "modulations": {
+                                              "type": "object",
+                                              "properties": {
+                                                "Voice_Filter1_Frequency": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Filter1_Resonance": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Filter2_Frequency": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Global_AmpModulation": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Global_Glide": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Global_PitchModulation": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Modulators_Envelope2_Times_Attack": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Oscillator1_Pan": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Oscillator1_Wavetables_WavePosition": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Modulators_Lfo1_Time_UnifiedRateModulation": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Oscillator2_Wavetables_WavePosition": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Modulators_Lfo1_Shape_Amount": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Modulators_Lfo2_Shape_Amount": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Modulators_Lfo2_Time_UnifiedRateModulation": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Oscillator1_Effects_Effect1": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Oscillator1_Effects_Effect2": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "Voice_Unison_Amount": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number"
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "Voice_Filter1_Frequency",
+                                                "Voice_Global_AmpModulation",
+                                                "Voice_Global_PitchModulation"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "deviceData",
+                                        "kind",
+                                        "name",
+                                        "parameters",
+                                        "presetUri"
+                                      ]
+                                    }
+                                  },
+                                  "mixer": {
+                                    "type": "object",
+                                    "properties": {
+                                      "pan": {
+                                        "type": "number"
+                                      },
+                                      "solo-cue": {
+                                        "type": "boolean"
+                                      },
+                                      "speakerOn": {
+                                        "type": "boolean"
+                                      },
+                                      "volume": {
+                                        "type": "number"
+                                      },
+                                      "sends": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "isEnabled": {
+                                              "type": "boolean"
+                                            },
+                                            "amount": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "amount",
+                                            "isEnabled"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "pan",
+                                      "sends",
+                                      "solo-cue",
+                                      "speakerOn",
+                                      "volume"
+                                    ]
+                                  },
+                                  "drumZoneSettings": {
+                                    "type": "object",
+                                    "properties": {
+                                      "receivingNote": {
+                                        "type": "integer"
+                                      },
+                                      "sendingNote": {
+                                        "type": "integer"
+                                      },
+                                      "chokeGroup": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "chokeGroup",
+                                      "receivingNote",
+                                      "sendingNote"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "color",
+                                  "devices",
+                                  "mixer",
+                                  "name"
+                                ]
+                              }
+                            },
+                            "returnChains": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "color": {
+                                    "type": "integer"
+                                  },
+                                  "devices": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "presetUri": {
+                                          "type": "null"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "AllPassGain": {
+                                              "type": "number"
+                                            },
+                                            "AllPassSize": {
+                                              "type": "number"
+                                            },
+                                            "BandFreq": {
+                                              "type": "number"
+                                            },
+                                            "BandHighOn": {
+                                              "type": "boolean"
+                                            },
+                                            "BandLowOn": {
+                                              "type": "boolean"
+                                            },
+                                            "BandWidth": {
+                                              "type": "number"
+                                            },
+                                            "ChorusOn": {
+                                              "type": "boolean"
+                                            },
+                                            "CutOn": {
+                                              "type": "boolean"
+                                            },
+                                            "DecayTime": {
+                                              "type": "number"
+                                            },
+                                            "DiffuseDelay": {
+                                              "type": "number"
+                                            },
+                                            "EarlyReflectModDepth": {
+                                              "type": "number"
+                                            },
+                                            "EarlyReflectModFreq": {
+                                              "type": "number"
+                                            },
+                                            "Enabled": {
+                                              "type": "boolean"
+                                            },
+                                            "FlatOn": {
+                                              "type": "boolean"
+                                            },
+                                            "FreezeOn": {
+                                              "type": "boolean"
+                                            },
+                                            "HighFilterType": {
+                                              "type": "string"
+                                            },
+                                            "MixDiffuse": {
+                                              "type": "number"
+                                            },
+                                            "MixDirect": {
+                                              "type": "number"
+                                            },
+                                            "MixReflect": {
+                                              "type": "number"
+                                            },
+                                            "PreDelay": {
+                                              "type": "number"
+                                            },
+                                            "RoomSize": {
+                                              "type": "number"
+                                            },
+                                            "RoomType": {
+                                              "type": "string"
+                                            },
+                                            "ShelfHiFreq": {
+                                              "type": "number"
+                                            },
+                                            "ShelfHiGain": {
+                                              "type": "number"
+                                            },
+                                            "ShelfHighOn": {
+                                              "type": "boolean"
+                                            },
+                                            "ShelfLoFreq": {
+                                              "type": "number"
+                                            },
+                                            "ShelfLoGain": {
+                                              "type": "number"
+                                            },
+                                            "ShelfLowOn": {
+                                              "type": "boolean"
+                                            },
+                                            "SizeModDepth": {
+                                              "type": "number"
+                                            },
+                                            "SizeModFreq": {
+                                              "type": "number"
+                                            },
+                                            "SizeSmoothing": {
+                                              "type": "string"
+                                            },
+                                            "SpinOn": {
+                                              "type": "boolean"
+                                            },
+                                            "StereoSeparation": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "AllPassGain",
+                                            "AllPassSize",
+                                            "BandFreq",
+                                            "BandHighOn",
+                                            "BandLowOn",
+                                            "BandWidth",
+                                            "ChorusOn",
+                                            "CutOn",
+                                            "DecayTime",
+                                            "DiffuseDelay",
+                                            "EarlyReflectModDepth",
+                                            "EarlyReflectModFreq",
+                                            "Enabled",
+                                            "FlatOn",
+                                            "FreezeOn",
+                                            "HighFilterType",
+                                            "MixDiffuse",
+                                            "MixDirect",
+                                            "MixReflect",
+                                            "PreDelay",
+                                            "RoomSize",
+                                            "RoomType",
+                                            "ShelfHiFreq",
+                                            "ShelfHiGain",
+                                            "ShelfHighOn",
+                                            "ShelfLoFreq",
+                                            "ShelfLoGain",
+                                            "ShelfLowOn",
+                                            "SizeModDepth",
+                                            "SizeModFreq",
+                                            "SizeSmoothing",
+                                            "SpinOn",
+                                            "StereoSeparation"
+                                          ]
+                                        },
+                                        "deviceData": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "deviceData",
+                                        "kind",
+                                        "name",
+                                        "parameters",
+                                        "presetUri"
+                                      ]
+                                    }
+                                  },
+                                  "mixer": {
+                                    "type": "object",
+                                    "properties": {
+                                      "pan": {
+                                        "type": "number"
+                                      },
+                                      "solo-cue": {
+                                        "type": "boolean"
+                                      },
+                                      "speakerOn": {
+                                        "type": "boolean"
+                                      },
+                                      "volume": {
+                                        "type": "number"
+                                      },
+                                      "sends": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "isEnabled": {
+                                              "type": "boolean"
+                                            },
+                                            "amount": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "amount",
+                                            "isEnabled"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "pan",
+                                      "sends",
+                                      "solo-cue",
+                                      "speakerOn",
+                                      "volume"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "color",
+                                  "devices",
+                                  "mixer",
+                                  "name"
+                                ]
+                              }
+                            },
+                            "deviceData": {
+                              "type": "object",
+                              "properties": {
+                                "sampleUri": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name",
+                            "parameters",
+                            "presetUri"
+                          ]
+                        }
+                      },
+                      "mixer": {
+                        "type": "object",
+                        "properties": {
+                          "pan": {
+                            "type": "number"
+                          },
+                          "solo-cue": {
+                            "type": "boolean"
+                          },
+                          "speakerOn": {
+                            "type": "boolean"
+                          },
+                          "volume": {
+                            "type": "number"
+                          },
+                          "sends": {
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "pan",
+                          "sends",
+                          "solo-cue",
+                          "speakerOn",
+                          "volume"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "color",
+                      "devices",
+                      "mixer",
+                      "name"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "chains",
+                "kind",
+                "lockId",
+                "lockSeal",
+                "name",
+                "parameters",
+                "presetUri"
+              ]
+            }
+          },
+          "mixer": {
+            "type": "object",
+            "properties": {
+              "pan": {
+                "type": "number"
+              },
+              "solo-cue": {
+                "type": "boolean"
+              },
+              "speakerOn": {
+                "type": "boolean"
+              },
+              "volume": {
+                "type": "number"
+              },
+              "sends": {
+                "type": "array"
+              }
+            },
+            "required": [
+              "pan",
+              "sends",
+              "solo-cue",
+              "speakerOn",
+              "volume"
+            ]
+          }
+        },
+        "required": [
+          "clipSlots",
+          "color",
+          "devices",
+          "isNoteRepeatOn",
+          "isSelected",
+          "kind",
+          "midiInputMode",
+          "midiOutputEndpoint",
+          "mixer",
+          "name",
+          "noteRepeatArpeggio",
+          "noteRepeatRate",
+          "uiOctaveIndex"
+        ]
+      }
+    },
+    "returnTracks": {
+      "type": "array"
+    },
+    "masterTrack": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "integer"
+        },
+        "isSelected": {
+          "type": "boolean"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "presetUri": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "lockId": {
+                "type": "integer"
+              },
+              "lockSeal": {
+                "type": "integer"
+              },
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "Enabled": {
+                    "type": "boolean"
+                  },
+                  "Macro0": {
+                    "type": "number"
+                  },
+                  "Macro1": {
+                    "type": "number"
+                  },
+                  "Macro2": {
+                    "type": "number"
+                  },
+                  "Macro3": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "number"
+                      },
+                      "customName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "customName",
+                      "value"
+                    ]
+                  },
+                  "Macro4": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "number"
+                      },
+                      "customName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "customName",
+                      "value"
+                    ]
+                  },
+                  "Macro5": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "number"
+                      },
+                      "presetValue": {
+                        "type": "number"
+                      },
+                      "customName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "customName",
+                      "presetValue",
+                      "value"
+                    ]
+                  },
+                  "Macro6": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "number"
+                      },
+                      "presetValue": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "presetValue",
+                      "value"
+                    ]
+                  },
+                  "Macro7": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "number"
+                      },
+                      "customName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "customName",
+                      "value"
+                    ]
+                  },
+                  "BaseDrive": {
+                    "type": "number"
+                  },
+                  "BassShaperThreshold": {
+                    "type": "number"
+                  },
+                  "ColorDepth": {
+                    "type": "number"
+                  },
+                  "ColorFrequency": {
+                    "type": "number"
+                  },
+                  "ColorOn": {
+                    "type": "boolean"
+                  },
+                  "ColorWidth": {
+                    "type": "number"
+                  },
+                  "DryWet": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "number"
+                      },
+                      "presetValue": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "presetValue",
+                      "value"
+                    ]
+                  },
+                  "Oversampling": {
+                    "type": "boolean"
+                  },
+                  "PostClip": {
+                    "type": "string"
+                  },
+                  "PostDrive": {
+                    "type": "number"
+                  },
+                  "PreDcFilter": {
+                    "type": "boolean"
+                  },
+                  "PreDrive": {
+                    "type": "number"
+                  },
+                  "Type": {
+                    "type": "string"
+                  },
+                  "WsCurve": {
+                    "type": "number"
+                  },
+                  "WsDamp": {
+                    "type": "number"
+                  },
+                  "WsDepth": {
+                    "type": "number"
+                  },
+                  "WsDrive": {
+                    "type": "number"
+                  },
+                  "WsLin": {
+                    "type": "number"
+                  },
+                  "WsPeriod": {
+                    "type": "number"
+                  },
+                  "AutoRelease": {
+                    "type": "boolean"
+                  },
+                  "Ceiling": {
+                    "type": "number"
+                  },
+                  "Gain": {
+                    "type": "number"
+                  },
+                  "LegacySmoothing": {
+                    "type": "boolean"
+                  },
+                  "LinkAmount": {
+                    "type": "number"
+                  },
+                  "LinkAmountMidSide": {
+                    "type": "number"
+                  },
+                  "Lookahead": {
+                    "type": "string"
+                  },
+                  "Maximize": {
+                    "type": "boolean"
+                  },
+                  "MaximizeOutput": {
+                    "type": "number"
+                  },
+                  "MaximizeThreshold": {
+                    "type": "number"
+                  },
+                  "Mode": {
+                    "type": "string"
+                  },
+                  "Release": {
+                    "type": "number"
+                  },
+                  "Routing": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "Enabled"
+                ]
+              },
+              "chains": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "color": {
+                      "type": "integer"
+                    },
+                    "devices": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "presetUri": {
+                            "type": "null"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "Enabled": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "boolean"
+                                      },
+                                      "macroMapping": {
+                                        "type": "object",
+                                        "properties": {
+                                          "macroIndex": {
+                                            "type": "integer"
+                                          },
+                                          "rangeMin": {
+                                            "type": "number"
+                                          },
+                                          "rangeMax": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "macroIndex",
+                                          "rangeMax",
+                                          "rangeMin"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "macroMapping",
+                                      "value"
+                                    ]
+                                  }
+                                ]
+                              },
+                              "Gain": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "number"
+                                      },
+                                      "macroMapping": {
+                                        "type": "object",
+                                        "properties": {
+                                          "macroIndex": {
+                                            "type": "integer"
+                                          },
+                                          "rangeMin": {
+                                            "type": "number"
+                                          },
+                                          "rangeMax": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "macroIndex",
+                                          "rangeMax",
+                                          "rangeMin"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "macroMapping",
+                                      "value"
+                                    ]
+                                  }
+                                ]
+                              },
+                              "HighShelfGain": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              },
+                              "HighpassOn": {
+                                "type": "boolean"
+                              },
+                              "LowShelfGain": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              },
+                              "MidFrequency": {
+                                "type": "number"
+                              },
+                              "MidGain": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              },
+                              "Attack": {
+                                "type": "number"
+                              },
+                              "AutoReleaseControlOnOff": {
+                                "type": "boolean"
+                              },
+                              "DryWet": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              },
+                              "ExpansionRatio": {
+                                "type": "number"
+                              },
+                              "GainCompensation": {
+                                "type": "boolean"
+                              },
+                              "Knee": {
+                                "type": "number"
+                              },
+                              "LogEnvelope": {
+                                "type": "boolean"
+                              },
+                              "Model": {
+                                "type": "string"
+                              },
+                              "Ratio": {
+                                "type": "number"
+                              },
+                              "Release": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              },
+                              "SideChainEq_Freq": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              },
+                              "SideChainEq_Gain": {
+                                "type": "number"
+                              },
+                              "SideChainEq_Mode": {
+                                "type": "string"
+                              },
+                              "SideChainEq_On": {
+                                "type": "boolean"
+                              },
+                              "SideChainEq_Q": {
+                                "type": "number"
+                              },
+                              "Threshold": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  },
+                                  "macroMapping": {
+                                    "type": "object",
+                                    "properties": {
+                                      "macroIndex": {
+                                        "type": "integer"
+                                      },
+                                      "rangeMin": {
+                                        "type": "number"
+                                      },
+                                      "rangeMax": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "macroIndex",
+                                      "rangeMax",
+                                      "rangeMin"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "macroMapping",
+                                  "value"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "Enabled",
+                              "Gain"
+                            ]
+                          },
+                          "deviceData": {
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "deviceData",
+                          "kind",
+                          "name",
+                          "parameters",
+                          "presetUri"
+                        ]
+                      }
+                    },
+                    "mixer": {
+                      "type": "object",
+                      "properties": {
+                        "pan": {
+                          "type": "number"
+                        },
+                        "solo-cue": {
+                          "type": "boolean"
+                        },
+                        "speakerOn": {
+                          "type": "boolean"
+                        },
+                        "volume": {
+                          "type": "number"
+                        },
+                        "sends": {
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "pan",
+                        "sends",
+                        "solo-cue",
+                        "speakerOn",
+                        "volume"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "color",
+                    "devices",
+                    "mixer",
+                    "name"
+                  ]
+                }
+              },
+              "deviceData": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "kind",
+              "name",
+              "parameters",
+              "presetUri"
+            ]
+          }
+        },
+        "mixer": {
+          "type": "object",
+          "properties": {
+            "pan": {
+              "type": "number"
+            },
+            "volume": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "pan",
+            "volume"
+          ]
+        }
+      },
+      "required": [
+        "color",
+        "devices",
+        "isSelected",
+        "mixer"
+      ]
+    },
+    "scenes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "null"
+          }
+        },
+        "required": [
+          "color",
+          "name"
+        ]
+      }
+    },
+    "grooves": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "base": {
+            "type": "string"
+          },
+          "loop": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "number"
+              },
+              "end": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "end",
+              "start"
+            ]
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "time": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "time"
+              ]
+            }
+          }
+        },
+        "required": [
+          "base",
+          "events",
+          "id",
+          "loop",
+          "name"
+        ]
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "usedFeatures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "usedFeatures"
+      ]
+    }
+  },
+  "required": [
+    "$schema",
+    "globalGrooveAmount",
+    "grooves",
+    "masterTrack",
+    "melodicLayout",
+    "metadata",
+    "returnTracks",
+    "rootNote",
+    "scale",
+    "scenes",
+    "stepEditorResolution",
+    "tempo",
+    "tracks"
+  ]
+}

--- a/static/schemas/drumRack_schema.json
+++ b/static/schemas/drumRack_schema.json
@@ -1,0 +1,251 @@
+{
+  "Effect_EightBitFilterDecay": {
+    "type": "number",
+    "min": 5.0,
+    "max": 5.0,
+    "options": []
+  },
+  "Effect_EightBitResamplingRate": {
+    "type": "number",
+    "min": 14080.0,
+    "max": 14080.0,
+    "options": []
+  },
+  "Effect_FmAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_FmFrequency": {
+    "type": "number",
+    "min": 999.9998779296875,
+    "max": 999.9998779296875,
+    "options": []
+  },
+  "Effect_LoopLength": {
+    "type": "number",
+    "min": 0.30000001192092896,
+    "max": 0.30000001192092896,
+    "options": []
+  },
+  "Effect_LoopOffset": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_NoiseAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_NoiseFrequency": {
+    "type": "number",
+    "min": 10000.0009765625,
+    "max": 10000.0009765625,
+    "options": []
+  },
+  "Effect_On": {
+    "type": "boolean",
+    "options": []
+  },
+  "Effect_PitchEnvelopeAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_PitchEnvelopeDecay": {
+    "type": "number",
+    "min": 0.29999998211860657,
+    "max": 0.29999998211860657,
+    "options": []
+  },
+  "Effect_PunchAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_PunchTime": {
+    "type": "number",
+    "min": 0.12015999853610992,
+    "max": 0.12015999853610992,
+    "options": []
+  },
+  "Effect_RingModAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_RingModFrequency": {
+    "type": "number",
+    "min": 999.9998168945312,
+    "max": 999.9998168945312,
+    "options": []
+  },
+  "Effect_StretchFactor": {
+    "type": "number",
+    "min": 1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Effect_StretchGrainSize": {
+    "type": "number",
+    "min": 0.09999999403953552,
+    "max": 0.09999999403953552,
+    "options": []
+  },
+  "Effect_SubOscAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Effect_SubOscFrequency": {
+    "type": "number",
+    "min": 59.99999237060547,
+    "max": 59.99999237060547,
+    "options": []
+  },
+  "Effect_Type": {
+    "type": "enum",
+    "options": [
+      "Stretch"
+    ]
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "NotePitchBend": {
+    "type": "boolean",
+    "options": []
+  },
+  "Pan": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_Detune": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_Envelope_Attack": {
+    "type": "number",
+    "min": 0.0010000000474974513,
+    "max": 0.0010000000474974513,
+    "options": []
+  },
+  "Voice_Envelope_Decay": {
+    "type": "number",
+    "min": 0.0010000000474974513,
+    "max": 0.05000000074505806,
+    "options": []
+  },
+  "Voice_Envelope_Hold": {
+    "type": "number",
+    "min": 0.6000000238418579,
+    "max": 60.0,
+    "options": []
+  },
+  "Voice_Envelope_Mode": {
+    "type": "enum",
+    "options": [
+      "A-H-D",
+      "A-S-R"
+    ]
+  },
+  "Voice_Filter_Frequency": {
+    "type": "number",
+    "min": 21999.990234375,
+    "max": 21999.990234375,
+    "options": []
+  },
+  "Voice_Filter_On": {
+    "type": "boolean",
+    "options": []
+  },
+  "Voice_Filter_PeakGain": {
+    "type": "number",
+    "min": 1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_Filter_Resonance": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_Filter_Type": {
+    "type": "enum",
+    "options": [
+      "Lowpass"
+    ]
+  },
+  "Voice_Gain": {
+    "type": "number",
+    "min": 1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_ModulationAmount": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_ModulationSource": {
+    "type": "enum",
+    "options": [
+      "Velocity"
+    ]
+  },
+  "Voice_ModulationTarget": {
+    "type": "enum",
+    "options": [
+      "Filter"
+    ]
+  },
+  "Voice_PitchToEnvelopeModulation": {
+    "type": "boolean",
+    "options": []
+  },
+  "Voice_PlaybackLength": {
+    "type": "number",
+    "min": 1.0,
+    "max": 1.0,
+    "options": []
+  },
+  "Voice_PlaybackStart": {
+    "type": "number",
+    "min": 0.0,
+    "max": 0.0,
+    "options": []
+  },
+  "Voice_Transpose": {
+    "type": "number",
+    "min": 0,
+    "max": 0,
+    "options": []
+  },
+  "Voice_VelocityToVolume": {
+    "type": "number",
+    "min": 0.3499999940395355,
+    "max": 0.3499999940395355,
+    "options": []
+  },
+  "Volume": {
+    "type": "number",
+    "min": -11.999999046325684,
+    "max": -11.999999046325684,
+    "options": []
+  }
+}

--- a/utility-scripts/generate_additional_schemas.py
+++ b/utility-scripts/generate_additional_schemas.py
@@ -1,0 +1,71 @@
+import json
+import glob
+import collections
+from genson import SchemaBuilder
+
+
+def generate_drumrack_schema(preset_paths, out_path):
+    params = collections.defaultdict(lambda: {"type": None, "min": None, "max": None, "options": set()})
+
+    def update(name, value):
+        entry = params[name]
+        if isinstance(value, bool):
+            entry["type"] = "boolean"
+        elif isinstance(value, (int, float)):
+            entry["type"] = "number"
+            entry["min"] = value if entry["min"] is None else min(entry["min"], value)
+            entry["max"] = value if entry["max"] is None else max(entry["max"], value)
+        elif isinstance(value, str):
+            if entry["type"] not in ("enum", "string"):
+                entry["type"] = "enum"
+            entry["options"].add(value)
+
+    def traverse(obj):
+        if isinstance(obj, dict):
+            if obj.get("kind") == "drumCell":
+                for k, v in obj.get("parameters", {}).items():
+                    update(k, v)
+            for v in obj.values():
+                traverse(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                traverse(item)
+
+    for path in preset_paths:
+        with open(path) as f:
+            traverse(json.load(f))
+
+    schema = {}
+    for name, info in sorted(params.items()):
+        if info["type"] == "enum":
+            schema[name] = {"type": "enum", "options": sorted(info["options"])}
+        elif info["type"] == "boolean":
+            schema[name] = {"type": "boolean", "options": []}
+        else:
+            schema[name] = {"type": "number", "min": info["min"], "max": info["max"], "options": []}
+
+    with open(out_path, "w") as f:
+        json.dump(schema, f, indent=2)
+    return len(schema)
+
+
+def generate_set_schema(set_paths, out_path):
+    builder = SchemaBuilder()
+    for path in set_paths:
+        with open(path) as f:
+            builder.add_object(json.load(f))
+    with open(out_path, "w") as f:
+        json.dump(builder.to_schema(), f, indent=2)
+
+
+def main():
+    drum_paths = glob.glob('examples/Track Presets/drumRack/*.json')
+    set_paths = glob.glob('examples/Sets/*.abl')
+    drum_count = generate_drumrack_schema(drum_paths, 'static/schemas/drumRack_schema.json')
+    generate_set_schema(set_paths, 'static/schemas/abl_set_schema.json')
+    print(f'Generated drumRack schema with {drum_count} parameters')
+    print('Generated set schema from', len(set_paths), 'example sets')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- generate JSON schemas for drumRack presets and for Ableton Live `.abl` set files
- provide a helper script to regenerate these schemas

## Testing
- `pytest -q`
- `python3 utility-scripts/generate_additional_schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb08ab9088325a1f36371eb209381