### PR TITLE
Add Set Inspector tool

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -1,0 +1,41 @@
+import json
+import os
+from typing import Any, Dict, List
+
+
+def list_clips(set_path: str) -> Dict[str, Any]:
+    """Return list of clips in the set."""
+    try:
+        with open(set_path, "r") as f:
+            song = json.load(f)
+        clips = []
+        tracks = song.get("tracks", [])
+        for ti, track in enumerate(tracks):
+            for ci, slot in enumerate(track.get("clipSlots", [])):
+                clip = slot.get("clip")
+                if clip:
+                    name = clip.get("name", f"Track {ti+1} Clip {ci+1}")
+                    clips.append({"track": ti, "clip": ci, "name": name})
+        return {"success": True, "message": "Clips loaded", "clips": clips}
+    except Exception as e:
+        return {"success": False, "message": f"Failed to read set: {e}"}
+
+
+def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
+    """Return notes and envelopes for the specified clip."""
+    try:
+        with open(set_path, "r") as f:
+            song = json.load(f)
+        clip_obj = song["tracks"][track]["clipSlots"][clip]["clip"]
+        notes = clip_obj.get("notes", [])
+        envelopes = clip_obj.get("envelopes", [])
+        region = clip_obj.get("region", {}).get("end", 4.0)
+        return {
+            "success": True,
+            "message": "Clip loaded",
+            "notes": notes,
+            "envelopes": envelopes,
+            "region": region,
+        }
+    except Exception as e:
+        return {"success": False, "message": f"Failed to read clip: {e}"}

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -1,0 +1,95 @@
+from handlers.base_handler import BaseHandler
+from core.file_browser import generate_dir_html
+from core.set_inspector_handler import list_clips, get_clip_data
+import os
+
+class SetInspectorHandler(BaseHandler):
+    def handle_get(self):
+        base_dir = "/data/UserData/UserLibrary/Sets"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
+            base_dir = "examples/Sets"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            "/set-inspector",
+            "set_path",
+            "select_set",
+        )
+        return {
+            "file_browser_html": browser_html,
+            "message": "Select a set to inspect",
+            "message_type": "info",
+            "selected_set": None,
+            "clip_options": "",
+            "selected_clip": None,
+            "notes": [],
+            "envelopes": [],
+            "region": 4.0,
+            "browser_root": base_dir,
+        }
+
+    def handle_post(self, form):
+        action = form.getvalue("action")
+        if action == "select_set":
+            set_path = form.getvalue("set_path")
+            if not set_path:
+                return self.format_error_response("No set selected")
+            result = list_clips(set_path)
+            if not result.get("success"):
+                return self.format_error_response(result.get("message"))
+            options = "".join(
+                f'<option value="{c["track"]}:{c["clip"]}">{c["name"]}</option>'
+                for c in result.get("clips", [])
+            )
+            options = '<option value="" disabled selected>-- Select Clip --</option>' + options
+            base_dir = "/data/UserData/UserLibrary/Sets"
+            if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
+                base_dir = "examples/Sets"
+            browser_html = generate_dir_html(
+                base_dir,
+                "",
+                "/set-inspector",
+                "set_path",
+                "select_set",
+            )
+            return {
+                "file_browser_html": browser_html,
+                "message": result.get("message"),
+                "message_type": "success",
+                "selected_set": set_path,
+                "clip_options": options,
+                "selected_clip": None,
+                "notes": [],
+                "envelopes": [],
+                "region": 4.0,
+                "browser_root": base_dir,
+            }
+        elif action == "show_clip":
+            set_path = form.getvalue("set_path")
+            clip_val = form.getvalue("clip_select")
+            if not set_path or not clip_val:
+                return self.format_error_response("Missing parameters")
+            track_idx, clip_idx = map(int, clip_val.split(":"))
+            result = get_clip_data(set_path, track_idx, clip_idx)
+            if not result.get("success"):
+                return self.format_error_response(result.get("message"))
+            envelopes = result.get("envelopes", [])
+            env_opts = "".join(
+                f'<option value="{e.get("parameterId")}">{e.get("parameterId")}</option>'
+                for e in envelopes
+            )
+            env_opts = '<option value="" disabled selected>-- Select Envelope --</option>' + env_opts
+            return {
+                "file_browser_html": None,
+                "message": result.get("message"),
+                "message_type": "success",
+                "selected_set": set_path,
+                "clip_options": env_opts,
+                "selected_clip": clip_val,
+                "notes": result.get("notes", []),
+                "envelopes": envelopes,
+                "region": result.get("region", 4.0),
+                "browser_root": None,
+            }
+        else:
+            return self.format_error_response("Unknown action")

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -46,6 +46,7 @@ from handlers.update_handler_class import UpdateHandler, REPO
 from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
+from handlers.set_inspector_handler_class import SetInspectorHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -135,6 +136,7 @@ update_handler = UpdateHandler()
 adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
+set_inspector_handler = SetInspectorHandler()
 
 
 @app.before_request
@@ -313,6 +315,33 @@ def reverse():
         browser_root=browser_root,
         browser_filter=browser_filter,
         active_tab="reverse",
+    )
+
+
+@app.route("/set-inspector", methods=["GET", "POST"])
+def set_inspector_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = set_inspector_handler.handle_post(form)
+    else:
+        result = set_inspector_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    return render_template(
+        "set_inspector.html",
+        message=message,
+        success=success,
+        message_type=message_type,
+        file_browser_html=result.get("file_browser_html"),
+        selected_set=result.get("selected_set"),
+        clip_options=result.get("clip_options"),
+        selected_clip=result.get("selected_clip"),
+        notes=result.get("notes"),
+        envelopes=result.get("envelopes"),
+        region=result.get("region"),
+        browser_root=result.get("browser_root"),
+        active_tab="set-inspector",
     )
 
 

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -1,0 +1,66 @@
+export function initSetInspector() {
+  const dataDiv = document.getElementById('clipData');
+  if (!dataDiv) return;
+  const notes = JSON.parse(dataDiv.dataset.notes || '[]');
+  const envelopes = JSON.parse(dataDiv.dataset.envelopes || '[]');
+  const region = parseFloat(dataDiv.dataset.region || '4');
+  const canvas = document.getElementById('clipCanvas');
+  const ctx = canvas.getContext('2d');
+  const envSelect = document.getElementById('envelope_select');
+
+  function drawGrid() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = '#ddd';
+    for (let b = 0; b <= region; b++) {
+      const x = (b / region) * canvas.width;
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, canvas.height);
+      ctx.stroke();
+    }
+    for (let n = 0; n <= 127; n += 12) {
+      const y = canvas.height - (n / 127) * canvas.height;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvas.width, y);
+      ctx.stroke();
+    }
+  }
+
+  function drawNotes() {
+    const h = canvas.height / 128;
+    ctx.fillStyle = '#0074D9';
+    notes.forEach(n => {
+      const x = (n.startTime / region) * canvas.width;
+      const w = (n.duration / region) * canvas.width;
+      const y = canvas.height - (n.noteNumber + 1) * h;
+      ctx.fillRect(x, y, w, h);
+    });
+  }
+
+  function drawEnvelope() {
+    if (!envSelect || !envSelect.value) return;
+    const param = parseInt(envSelect.value);
+    const env = envelopes.find(e => e.parameterId === param);
+    if (!env) return;
+    ctx.strokeStyle = '#FF4136';
+    ctx.beginPath();
+    env.breakpoints.forEach((bp, i) => {
+      const x = (bp.time / region) * canvas.width;
+      const y = canvas.height - bp.value * canvas.height;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  }
+
+  function draw() {
+    drawGrid();
+    drawNotes();
+    drawEnvelope();
+  }
+
+  if (envSelect) envSelect.addEventListener('change', draw);
+  draw();
+}
+
+document.addEventListener('DOMContentLoaded', initSetInspector);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -18,6 +18,7 @@
         <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a>
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
+        <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
         <!-- <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a> -->

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Set Inspector</h2>
+{% if message %}
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+{% if not selected_set %}
+  <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/set-inspector" data-field="set_path" data-value="select_set">
+    {{ file_browser_html | safe }}
+  </div>
+{% elif not selected_clip %}
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+    <input type="hidden" name="action" value="show_clip">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <label for="clip_select">Clip:</label>
+    <select name="clip_select" id="clip_select">{{ clip_options | safe }}</select>
+    <button type="submit">Load Clip</button>
+  </form>
+  <form method="get" action="{{ host_prefix }}/set-inspector">
+    <button type="submit">Choose Another Set</button>
+  </form>
+{% else %}
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+    <input type="hidden" name="action" value="select_set">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <button type="submit">Choose Another Clip</button>
+  </form>
+  <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
+    <button type="submit">Choose Another Set</button>
+  </form>
+  <div style="margin-top:1rem;">
+    <label for="envelope_select">Envelope:</label>
+    <select id="envelope_select">{{ clip_options | safe }}</select>
+  </div>
+  <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+{% endif %}
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
+<script type="module" src="{{ host_prefix }}/static/set_inspector.js"></script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -688,4 +688,39 @@ def test_files_route_not_found(client, tmp_path, monkeypatch):
     assert resp.status_code == 404
 
 
+def test_set_inspector_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'file_browser_html': '<ul></ul>',
+            'message': '',
+            'message_type': 'info',
+            'selected_set': None,
+            'browser_root': '/tmp'
+        }
+    monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_get', fake_get)
+    resp = client.get('/set-inspector')
+    assert resp.status_code == 200
+    assert b'class="file-browser"' in resp.data
+
+
+def test_set_inspector_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'message': 'ok',
+            'message_type': 'success',
+            'file_browser_html': None,
+            'selected_set': '/tmp/a.abl',
+            'clip_options': '<option>1</option>',
+            'selected_clip': '0:0',
+            'notes': [],
+            'envelopes': [],
+            'region': 4.0,
+            'browser_root': None,
+        }
+    monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_post', fake_post)
+    resp = client.post('/set-inspector', data={'action': 'select_set', 'set_path': 'x'})
+    assert resp.status_code == 200
+    assert b'ok' in resp.data
+
+
 


### PR DESCRIPTION
## Summary
- create core/SetInspector to load clip data
- add handler and template for new Set Inspector interface
- add navigation link in base.html
- implement client-side drawing of notes and envelopes
- expose /set-inspector route
- test new route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb226d03c832583f214c3a89820eb