### PR TITLE
Improve set inspector UI

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -1,6 +1,39 @@
 import json
 import os
 from typing import Any, Dict, List
+import subprocess
+
+def _get_xattr(path: str, attr: str) -> str:
+    """Return extended attribute value or "Unknown"."""
+    try:
+        return (
+            subprocess.check_output([
+                "getfattr",
+                "--only-values",
+                "-n",
+                attr,
+                path,
+            ], encoding="utf-8")
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        return "Unknown"
+
+
+def get_set_pad_info(set_path: str) -> Dict[str, Any]:
+    """Return pad index and color for the set if available."""
+    try:
+        parent = os.path.dirname(os.path.dirname(set_path))
+        if not os.path.isdir(parent):
+            return {"success": True, "pad": None, "color": None}
+
+        pad = _get_xattr(parent, "user.song-index")
+        color = _get_xattr(parent, "user.song-color")
+        pad_val = int(pad) if pad.isdigit() else None
+        color_val = int(color) if color.isdigit() else None
+        return {"success": True, "pad": pad_val, "color": color_val}
+    except Exception as e:
+        return {"success": False, "message": f"Failed to read attributes: {e}"}
 
 
 def list_clips(set_path: str) -> Dict[str, Any]:
@@ -39,3 +72,36 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
         }
     except Exception as e:
         return {"success": False, "message": f"Failed to read clip: {e}"}
+
+
+def build_clip_grid_html(clips: List[Dict[str, Any]], set_path: str) -> str:
+    """Return HTML for a 4x8 clip grid."""
+    grid: list[list[Dict[str, Any] | None]] = [[None for _ in range(8)] for _ in range(4)]
+    for c in clips:
+        ti = c.get("track")
+        ci = c.get("clip")
+        if 0 <= ti < 4 and 0 <= ci < 8:
+            grid[ti][ci] = c
+
+    html = '<div class="clip-grid">'
+    for row in range(3, -1, -1):
+        html += '<div class="clip-grid-row">'
+        for col in range(8):
+            clip = grid[row][col]
+            if clip:
+                val = f"{row}:{col}"
+                name = clip.get("name", "")
+                html += (
+                    '<div class="clip-cell">'
+                    f'<form method="post" action="/set-inspector">'
+                    '<input type="hidden" name="action" value="show_clip">'
+                    f'<input type="hidden" name="set_path" value="{set_path}">' \
+                    f'<input type="hidden" name="clip_select" value="{val}">' \
+                    f'<button type="submit">{name}</button>'
+                    '</form></div>'
+                )
+            else:
+                html += '<div class="clip-cell empty"></div>'
+        html += '</div>'
+    html += '</div>'
+    return html

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -1,6 +1,13 @@
 from handlers.base_handler import BaseHandler
 from core.file_browser import generate_dir_html
-from core.set_inspector_handler import list_clips, get_clip_data
+from core.set_inspector_handler import (
+    list_clips,
+    get_clip_data,
+    get_set_pad_info,
+    build_clip_grid_html,
+)
+from core.list_msets_handler import list_msets
+from core.pad_colors import rgb_string
 import os
 
 class SetInspectorHandler(BaseHandler):
@@ -21,6 +28,8 @@ class SetInspectorHandler(BaseHandler):
             "message_type": "info",
             "selected_set": None,
             "clip_options": "",
+            "clip_grid": None,
+            "pad_grid": None,
             "selected_clip": None,
             "notes": [],
             "envelopes": [],
@@ -37,11 +46,7 @@ class SetInspectorHandler(BaseHandler):
             result = list_clips(set_path)
             if not result.get("success"):
                 return self.format_error_response(result.get("message"))
-            options = "".join(
-                f'<option value="{c["track"]}:{c["clip"]}">{c["name"]}</option>'
-                for c in result.get("clips", [])
-            )
-            options = '<option value="" disabled selected>-- Select Clip --</option>' + options
+
             base_dir = "/data/UserData/UserLibrary/Sets"
             if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
                 base_dir = "examples/Sets"
@@ -52,12 +57,28 @@ class SetInspectorHandler(BaseHandler):
                 "set_path",
                 "select_set",
             )
+
+            clips = result.get("clips", [])
+            clip_grid = build_clip_grid_html(clips, set_path)
+
+            msets, ids = list_msets(return_free_ids=True)
+            color_map = {
+                int(m["mset_id"]): int(m["mset_color"])
+                for m in msets
+                if str(m["mset_color"]).isdigit()
+            }
+            pad_info = get_set_pad_info(set_path)
+            pad_index = pad_info.get("pad")
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, pad_index)
+
             return {
                 "file_browser_html": browser_html,
                 "message": result.get("message"),
                 "message_type": "success",
                 "selected_set": set_path,
-                "clip_options": options,
+                "clip_grid": clip_grid,
+                "pad_grid": pad_grid,
+                "clip_options": "",
                 "selected_clip": None,
                 "notes": [],
                 "envelopes": [],
@@ -79,6 +100,20 @@ class SetInspectorHandler(BaseHandler):
                 for e in envelopes
             )
             env_opts = '<option value="" disabled selected>-- Select Envelope --</option>' + env_opts
+            clips_res = list_clips(set_path)
+            clips = clips_res.get("clips", []) if clips_res.get("success") else []
+            clip_grid = build_clip_grid_html(clips, set_path)
+
+            msets, ids = list_msets(return_free_ids=True)
+            color_map = {
+                int(m["mset_id"]): int(m["mset_color"])
+                for m in msets
+                if str(m["mset_color"]).isdigit()
+            }
+            pad_info = get_set_pad_info(set_path)
+            pad_index = pad_info.get("pad")
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, pad_index)
+
             return {
                 "file_browser_html": None,
                 "message": result.get("message"),
@@ -86,6 +121,8 @@ class SetInspectorHandler(BaseHandler):
                 "selected_set": set_path,
                 "clip_options": env_opts,
                 "selected_clip": clip_val,
+                "clip_grid": clip_grid,
+                "pad_grid": pad_grid,
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
@@ -93,3 +130,21 @@ class SetInspectorHandler(BaseHandler):
             }
         else:
             return self.format_error_response("Unknown action")
+
+    def generate_pad_grid(self, used_ids, color_map, active=None):
+        """Return HTML pad grid with the active pad highlighted."""
+        cells = []
+        for row in range(4):
+            for col in range(8):
+                idx = (3 - row) * 8 + col
+                num = idx + 1
+                occupied = idx in used_ids
+                status = "occupied" if occupied else "free"
+                color_id = color_map.get(idx)
+                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
+                checked = " checked" if active is not None and idx == active else ""
+                cells.append(
+                    f'<input type="radio" id="insp_pad_{num}" name="pad" value="{num}" disabled{checked}>'
+                    f'<label for="insp_pad_{num}" class="pad-cell {status}"{style}></label>'
+                )
+        return '<div class="pad-grid">' + ''.join(cells) + '</div>'

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -337,6 +337,8 @@ def set_inspector_route():
         selected_set=result.get("selected_set"),
         clip_options=result.get("clip_options"),
         selected_clip=result.get("selected_clip"),
+        clip_grid=result.get("clip_grid"),
+        pad_grid=result.get("pad_grid"),
         notes=result.get("notes"),
         envelopes=result.get("envelopes"),
         region=result.get("region"),

--- a/static/style.css
+++ b/static/style.css
@@ -475,7 +475,37 @@ select {
 }
 
 .pad-grid label {
-	margin-bottom: 0;
+        margin-bottom: 0;
+}
+
+/* Clip grid styling for set inspector */
+.clip-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+.clip-grid-row {
+    display: flex;
+    gap: 0.5rem;
+}
+.clip-cell {
+    flex: 1 1 0;
+    text-align: center;
+}
+.clip-cell button {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #f5f5f5;
+    cursor: pointer;
+}
+.clip-cell.empty {
+    background: #f0f0f0;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.5rem;
 }
 
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -8,32 +8,29 @@
   <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/set-inspector" data-field="set_path" data-value="select_set">
     {{ file_browser_html | safe }}
   </div>
-{% elif not selected_clip %}
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
-    <input type="hidden" name="action" value="show_clip">
-    <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <label for="clip_select">Clip:</label>
-    <select name="clip_select" id="clip_select">{{ clip_options | safe }}</select>
-    <button type="submit">Load Clip</button>
-  </form>
-  <form method="get" action="{{ host_prefix }}/set-inspector">
-    <button type="submit">Choose Another Set</button>
-  </form>
 {% else %}
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
-    <input type="hidden" name="action" value="select_set">
-    <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <button type="submit">Choose Another Clip</button>
-  </form>
-  <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
-    <button type="submit">Choose Another Set</button>
-  </form>
-  <div style="margin-top:1rem;">
-    <label for="envelope_select">Envelope:</label>
-    <select id="envelope_select">{{ clip_options | safe }}</select>
-  </div>
-  <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+  {{ pad_grid | safe }}
+  {{ clip_grid | safe }}
+  {% if not selected_clip %}
+    <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+      <button type="submit">Choose Another Set</button>
+    </form>
+  {% else %}
+    <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+      <input type="hidden" name="action" value="select_set">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <button type="submit">Choose Another Clip</button>
+    </form>
+    <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
+      <button type="submit">Choose Another Set</button>
+    </form>
+    <div style="margin-top:1rem;">
+      <label for="envelope_select">Envelope:</label>
+      <select id="envelope_select">{{ clip_options | safe }}</select>
+    </div>
+    <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
+    <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+  {% endif %}
 {% endif %}
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- highlight the pad for the selected set using the same pad grid as restoration
- show available clips in a four-row grid for each track
- keep the waveform display for clip details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb4c935d4832581f56e990b825cea