### PR TITLE
Improve set inspector UI

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -1,6 +1,42 @@
 import json
 import os
 from typing import Any, Dict, List
+import subprocess
+import html
+from core.config import MSETS_DIRECTORY
+from core.pad_colors import rgb_string
+
+def _get_xattr(path: str, attr: str) -> str:
+    """Return extended attribute value or "Unknown"."""
+    try:
+        return (
+            subprocess.check_output([
+                "getfattr",
+                "--only-values",
+                "-n",
+                attr,
+                path,
+            ], encoding="utf-8")
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        return "Unknown"
+
+
+def get_set_pad_info(set_path: str) -> Dict[str, Any]:
+    """Return pad index and color for the set if available."""
+    try:
+        parent = os.path.dirname(os.path.dirname(set_path))
+        if not os.path.isdir(parent):
+            return {"success": True, "pad": None, "color": None}
+
+        pad = _get_xattr(parent, "user.song-index")
+        color = _get_xattr(parent, "user.song-color")
+        pad_val = int(pad) if pad.isdigit() else None
+        color_val = int(color) if color.isdigit() else None
+        return {"success": True, "pad": pad_val, "color": color_val}
+    except Exception as e:
+        return {"success": False, "message": f"Failed to read attributes: {e}"}
 
 
 def list_clips(set_path: str) -> Dict[str, Any]:
@@ -39,3 +75,87 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
         }
     except Exception as e:
         return {"success": False, "message": f"Failed to read clip: {e}"}
+
+
+def build_clip_grid_html(clips: List[Dict[str, Any]], set_path: str) -> str:
+    """Return HTML for a 4x8 clip grid."""
+    grid: list[list[Dict[str, Any] | None]] = [[None for _ in range(8)] for _ in range(4)]
+    for c in clips:
+        ti = c.get("track")
+        ci = c.get("clip")
+        if 0 <= ti < 4 and 0 <= ci < 8:
+            grid[ti][ci] = c
+
+    html = '<div class="clip-grid">'
+    for row in range(3, -1, -1):
+        html += '<div class="clip-grid-row">'
+        for col in range(8):
+            clip = grid[row][col]
+            if clip:
+                val = f"{row}:{col}"
+                name = clip.get("name", "")
+                html += (
+                    '<div class="clip-cell">'
+                    f'<form method="post" action="/set-inspector">'
+                    '<input type="hidden" name="action" value="show_clip">'
+                    f'<input type="hidden" name="set_path" value="{set_path}">' \
+                    f'<input type="hidden" name="clip_select" value="{val}">' \
+                    f'<button type="submit">{name}</button>'
+                    '</form></div>'
+                )
+            else:
+                html += '<div class="clip-cell empty"></div>'
+        html += '</div>'
+    html += '</div>'
+    return html
+
+
+def build_set_selector_html(msets: List[Dict[str, Any]]) -> str:
+    """Return HTML pad grid for selecting a set."""
+    grid: list[dict | None] = [None] * 32
+    for m in msets:
+        idx = m.get("mset_id")
+        try:
+            idx_int = int(idx)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= idx_int < 32:
+            song_path = os.path.join(
+                MSETS_DIRECTORY,
+                m.get("uuid", ""),
+                m.get("mset_name", ""),
+                "Song.abl",
+            )
+            grid[idx_int] = {
+                "name": m.get("mset_name", f"Set {idx_int + 1}"),
+                "path": song_path,
+                "color": int(m.get("mset_color"))
+                if str(m.get("mset_color")).isdigit()
+                else None,
+            }
+
+    html_out = '<div class="pad-grid">'
+    for row in range(4):
+        for col in range(8):
+            idx = (3 - row) * 8 + col
+            pad_num = idx + 1
+            entry = grid[idx]
+            if entry:
+                style = (
+                    f' style="background-color: {rgb_string(entry["color"])}"'
+                    if entry.get("color")
+                    else ""
+                )
+                name = html.escape(entry["name"])
+                html_out += (
+                    '<div class="pad-cell">'
+                    '<form method="post" action="/set-inspector">'
+                    '<input type="hidden" name="action" value="select_set">'
+                    f'<input type="hidden" name="set_path" value="{entry["path"]}">' \
+                    f'<button type="submit"{style}>{name}</button>'
+                    '</form></div>'
+                )
+            else:
+                html_out += '<div class="pad-cell empty"></div>'
+    html_out += '</div>'
+    return html_out

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -1,31 +1,31 @@
 from handlers.base_handler import BaseHandler
-from core.file_browser import generate_dir_html
-from core.set_inspector_handler import list_clips, get_clip_data
-import os
+from core.set_inspector_handler import (
+    list_clips,
+    get_clip_data,
+    get_set_pad_info,
+    build_clip_grid_html,
+    build_set_selector_html,
+)
+from core.list_msets_handler import list_msets
+from core.pad_colors import rgb_string
+
 
 class SetInspectorHandler(BaseHandler):
     def handle_get(self):
-        base_dir = "/data/UserData/UserLibrary/Sets"
-        if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
-            base_dir = "examples/Sets"
-        browser_html = generate_dir_html(
-            base_dir,
-            "",
-            "/set-inspector",
-            "set_path",
-            "select_set",
-        )
+        msets, _ = list_msets(return_free_ids=True)
+        selector_html = build_set_selector_html(msets)
         return {
-            "file_browser_html": browser_html,
+            "set_selector": selector_html,
             "message": "Select a set to inspect",
             "message_type": "info",
             "selected_set": None,
             "clip_options": "",
+            "clip_grid": None,
+            "pad_grid": None,
             "selected_clip": None,
             "notes": [],
             "envelopes": [],
             "region": 4.0,
-            "browser_root": base_dir,
         }
 
     def handle_post(self, form):
@@ -37,32 +37,32 @@ class SetInspectorHandler(BaseHandler):
             result = list_clips(set_path)
             if not result.get("success"):
                 return self.format_error_response(result.get("message"))
-            options = "".join(
-                f'<option value="{c["track"]}:{c["clip"]}">{c["name"]}</option>'
-                for c in result.get("clips", [])
-            )
-            options = '<option value="" disabled selected>-- Select Clip --</option>' + options
-            base_dir = "/data/UserData/UserLibrary/Sets"
-            if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
-                base_dir = "examples/Sets"
-            browser_html = generate_dir_html(
-                base_dir,
-                "",
-                "/set-inspector",
-                "set_path",
-                "select_set",
-            )
+
+            clips = result.get("clips", [])
+            clip_grid = build_clip_grid_html(clips, set_path)
+
+            msets, ids = list_msets(return_free_ids=True)
+            color_map = {
+                int(m["mset_id"]): int(m["mset_color"])
+                for m in msets
+                if str(m["mset_color"]).isdigit()
+            }
+            pad_info = get_set_pad_info(set_path)
+            pad_index = pad_info.get("pad")
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, pad_index)
+
             return {
-                "file_browser_html": browser_html,
                 "message": result.get("message"),
                 "message_type": "success",
                 "selected_set": set_path,
-                "clip_options": options,
+                "clip_grid": clip_grid,
+                "pad_grid": pad_grid,
+                "clip_options": "",
                 "selected_clip": None,
                 "notes": [],
                 "envelopes": [],
                 "region": 4.0,
-                "browser_root": base_dir,
+                "set_selector": None,
             }
         elif action == "show_clip":
             set_path = form.getvalue("set_path")
@@ -79,17 +79,50 @@ class SetInspectorHandler(BaseHandler):
                 for e in envelopes
             )
             env_opts = '<option value="" disabled selected>-- Select Envelope --</option>' + env_opts
+            clips_res = list_clips(set_path)
+            clips = clips_res.get("clips", []) if clips_res.get("success") else []
+            clip_grid = build_clip_grid_html(clips, set_path)
+
+            msets, ids = list_msets(return_free_ids=True)
+            color_map = {
+                int(m["mset_id"]): int(m["mset_color"])
+                for m in msets
+                if str(m["mset_color"]).isdigit()
+            }
+            pad_info = get_set_pad_info(set_path)
+            pad_index = pad_info.get("pad")
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, pad_index)
+
             return {
-                "file_browser_html": None,
                 "message": result.get("message"),
                 "message_type": "success",
                 "selected_set": set_path,
                 "clip_options": env_opts,
                 "selected_clip": clip_val,
+                "clip_grid": clip_grid,
+                "pad_grid": pad_grid,
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
-                "browser_root": None,
+                "set_selector": None,
             }
         else:
             return self.format_error_response("Unknown action")
+
+    def generate_pad_grid(self, used_ids, color_map, active=None):
+        """Return HTML pad grid with the active pad highlighted."""
+        cells = []
+        for row in range(4):
+            for col in range(8):
+                idx = (3 - row) * 8 + col
+                num = idx + 1
+                occupied = idx in used_ids
+                status = "occupied" if occupied else "free"
+                color_id = color_map.get(idx)
+                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
+                checked = " checked" if active is not None and idx == active else ""
+                cells.append(
+                    f'<input type="radio" id="insp_pad_{num}" name="pad" value="{num}" disabled{checked}>'
+                    f'<label for="insp_pad_{num}" class="pad-cell {status}"{style}></label>'
+                )
+        return '<div class="pad-grid">' + ''.join(cells) + '</div>'

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -333,14 +333,15 @@ def set_inspector_route():
         message=message,
         success=success,
         message_type=message_type,
-        file_browser_html=result.get("file_browser_html"),
+        set_selector=result.get("set_selector"),
         selected_set=result.get("selected_set"),
         clip_options=result.get("clip_options"),
         selected_clip=result.get("selected_clip"),
+        clip_grid=result.get("clip_grid"),
+        pad_grid=result.get("pad_grid"),
         notes=result.get("notes"),
         envelopes=result.get("envelopes"),
         region=result.get("region"),
-        browser_root=result.get("browser_root"),
         active_tab="set-inspector",
     )
 

--- a/static/style.css
+++ b/static/style.css
@@ -475,7 +475,58 @@ select {
 }
 
 .pad-grid label {
-	margin-bottom: 0;
+        margin-bottom: 0;
+}
+
+/* Pad selector buttons */
+.pad-cell form {
+    height: 100%;
+}
+
+.pad-cell button {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 0;
+    font-weight: inherit;
+}
+
+.pad-cell.empty {
+    background: #f0f0f0;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+/* Clip grid styling for set inspector */
+.clip-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+.clip-grid-row {
+    display: flex;
+    gap: 0.5rem;
+}
+.clip-cell {
+    flex: 1 1 0;
+    text-align: center;
+}
+.clip-cell button {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #f5f5f5;
+    cursor: pointer;
+}
+.clip-cell.empty {
+    background: #f0f0f0;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.5rem;
 }
 
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -5,38 +5,32 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 {% if not selected_set %}
-  <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/set-inspector" data-field="set_path" data-value="select_set">
-    {{ file_browser_html | safe }}
-  </div>
-{% elif not selected_clip %}
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
-    <input type="hidden" name="action" value="show_clip">
-    <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <label for="clip_select">Clip:</label>
-    <select name="clip_select" id="clip_select">{{ clip_options | safe }}</select>
-    <button type="submit">Load Clip</button>
-  </form>
-  <form method="get" action="{{ host_prefix }}/set-inspector">
-    <button type="submit">Choose Another Set</button>
-  </form>
+  {{ set_selector | safe }}
 {% else %}
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
-    <input type="hidden" name="action" value="select_set">
-    <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <button type="submit">Choose Another Clip</button>
-  </form>
-  <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
-    <button type="submit">Choose Another Set</button>
-  </form>
-  <div style="margin-top:1rem;">
-    <label for="envelope_select">Envelope:</label>
-    <select id="envelope_select">{{ clip_options | safe }}</select>
-  </div>
-  <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+  {{ pad_grid | safe }}
+  {{ clip_grid | safe }}
+  {% if not selected_clip %}
+    <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+      <button type="submit">Choose Another Set</button>
+    </form>
+  {% else %}
+    <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+      <input type="hidden" name="action" value="select_set">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <button type="submit">Choose Another Clip</button>
+    </form>
+    <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
+      <button type="submit">Choose Another Set</button>
+    </form>
+    <div style="margin-top:1rem;">
+      <label for="envelope_select">Envelope:</label>
+      <select id="envelope_select">{{ clip_options | safe }}</select>
+    </div>
+    <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
+    <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+  {% endif %}
 {% endif %}
 {% endblock %}
 {% block scripts %}
-<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 <script type="module" src="{{ host_prefix }}/static/set_inspector.js"></script>
 {% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -691,16 +691,17 @@ def test_files_route_not_found(client, tmp_path, monkeypatch):
 def test_set_inspector_get(client, monkeypatch):
     def fake_get():
         return {
-            'file_browser_html': '<ul></ul>',
+            'set_selector': '<div class="pad-grid"></div>',
             'message': '',
             'message_type': 'info',
             'selected_set': None,
-            'browser_root': '/tmp'
+            'clip_grid': None,
+            'pad_grid': None,
         }
     monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_get', fake_get)
     resp = client.get('/set-inspector')
     assert resp.status_code == 200
-    assert b'class="file-browser"' in resp.data
+    assert b'class="pad-grid"' in resp.data
 
 
 def test_set_inspector_post(client, monkeypatch):
@@ -708,14 +709,15 @@ def test_set_inspector_post(client, monkeypatch):
         return {
             'message': 'ok',
             'message_type': 'success',
-            'file_browser_html': None,
+            'set_selector': None,
             'selected_set': '/tmp/a.abl',
             'clip_options': '<option>1</option>',
             'selected_clip': '0:0',
+            'clip_grid': None,
+            'pad_grid': None,
             'notes': [],
             'envelopes': [],
             'region': 4.0,
-            'browser_root': None,
         }
     monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_post', fake_post)
     resp = client.post('/set-inspector', data={'action': 'select_set', 'set_path': 'x'})


### PR DESCRIPTION
## Summary
- replace directory browser with pad-based set selector
- show clips when a set is chosen using the same grid layout
- keep waveform details with envelope selector

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bb4c935d4832581f56e990b825cea