### PR TITLE
Use pad grid for set inspector

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -1,22 +1,36 @@
 from handlers.base_handler import BaseHandler
-from core.file_browser import generate_dir_html
 from core.set_inspector_handler import list_clips, get_clip_data
+from core.list_msets_handler import list_msets
+from core.pad_colors import rgb_string
+from core.config import MSETS_DIRECTORY
 import os
 
 class SetInspectorHandler(BaseHandler):
+    def generate_pad_grid(self, used_ids, color_map):
+        """Return HTML for a 32-pad grid showing sets with colors."""
+        cells = []
+        for row in range(4):
+            for col in range(8):
+                idx = (3 - row) * 8 + col
+                num = idx + 1
+                has_set = idx in used_ids
+                status = 'occupied' if has_set else 'free'
+                disabled = '' if has_set else 'disabled'
+                color_id = color_map.get(idx)
+                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
+                cells.append(
+                    f'<input type="radio" id="inspect_pad_{num}" name="pad_index" value="{num}" {disabled}>'
+                    f'<label for="inspect_pad_{num}" class="pad-cell {status}"{style}></label>'
+                )
+        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
+
     def handle_get(self):
-        base_dir = "/data/UserData/UserLibrary/Sets"
-        if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
-            base_dir = "examples/Sets"
-        browser_html = generate_dir_html(
-            base_dir,
-            "",
-            "/set-inspector",
-            "set_path",
-            "select_set",
-        )
+        msets, ids = list_msets(return_free_ids=True)
+        used = ids.get("used", set())
+        color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
+        pad_grid = self.generate_pad_grid(used, color_map)
         return {
-            "file_browser_html": browser_html,
+            "pad_grid": pad_grid,
             "message": "Select a set to inspect",
             "message_type": "info",
             "selected_set": None,
@@ -25,35 +39,34 @@ class SetInspectorHandler(BaseHandler):
             "notes": [],
             "envelopes": [],
             "region": 4.0,
-            "browser_root": base_dir,
         }
 
     def handle_post(self, form):
         action = form.getvalue("action")
+        msets, ids = list_msets(return_free_ids=True)
+        used = ids.get("used", set())
+        color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
+        pad_grid = self.generate_pad_grid(used, color_map)
+
         if action == "select_set":
-            set_path = form.getvalue("set_path")
-            if not set_path:
-                return self.format_error_response("No set selected")
+            pad_val = form.getvalue("pad_index")
+            if not pad_val or not pad_val.isdigit():
+                return self.format_error_response("No set selected", pad_grid=pad_grid)
+            idx = int(pad_val) - 1
+            entry = next((m for m in msets if m.get("mset_id") == idx), None)
+            if not entry:
+                return self.format_error_response("No set on selected pad", pad_grid=pad_grid)
+            set_path = os.path.join(MSETS_DIRECTORY, entry["uuid"], entry["mset_name"], "Song.abl")
             result = list_clips(set_path)
             if not result.get("success"):
-                return self.format_error_response(result.get("message"))
+                return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             options = "".join(
                 f'<option value="{c["track"]}:{c["clip"]}">{c["name"]}</option>'
                 for c in result.get("clips", [])
             )
             options = '<option value="" disabled selected>-- Select Clip --</option>' + options
-            base_dir = "/data/UserData/UserLibrary/Sets"
-            if not os.path.exists(base_dir) and os.path.exists("examples/Sets"):
-                base_dir = "examples/Sets"
-            browser_html = generate_dir_html(
-                base_dir,
-                "",
-                "/set-inspector",
-                "set_path",
-                "select_set",
-            )
             return {
-                "file_browser_html": browser_html,
+                "pad_grid": pad_grid,
                 "message": result.get("message"),
                 "message_type": "success",
                 "selected_set": set_path,
@@ -62,17 +75,16 @@ class SetInspectorHandler(BaseHandler):
                 "notes": [],
                 "envelopes": [],
                 "region": 4.0,
-                "browser_root": base_dir,
             }
         elif action == "show_clip":
             set_path = form.getvalue("set_path")
             clip_val = form.getvalue("clip_select")
             if not set_path or not clip_val:
-                return self.format_error_response("Missing parameters")
+                return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             track_idx, clip_idx = map(int, clip_val.split(":"))
             result = get_clip_data(set_path, track_idx, clip_idx)
             if not result.get("success"):
-                return self.format_error_response(result.get("message"))
+                return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             envelopes = result.get("envelopes", [])
             env_opts = "".join(
                 f'<option value="{e.get("parameterId")}">{e.get("parameterId")}</option>'
@@ -80,7 +92,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="" disabled selected>-- Select Envelope --</option>' + env_opts
             return {
-                "file_browser_html": None,
+                "pad_grid": pad_grid,
                 "message": result.get("message"),
                 "message_type": "success",
                 "selected_set": set_path,
@@ -89,7 +101,6 @@ class SetInspectorHandler(BaseHandler):
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
-                "browser_root": None,
             }
         else:
-            return self.format_error_response("Unknown action")
+            return self.format_error_response("Unknown action", pad_grid=pad_grid)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -333,14 +333,13 @@ def set_inspector_route():
         message=message,
         success=success,
         message_type=message_type,
-        file_browser_html=result.get("file_browser_html"),
+        pad_grid=result.get("pad_grid"),
         selected_set=result.get("selected_set"),
         clip_options=result.get("clip_options"),
         selected_clip=result.get("selected_clip"),
         notes=result.get("notes"),
         envelopes=result.get("envelopes"),
         region=result.get("region"),
-        browser_root=result.get("browser_root"),
         active_tab="set-inspector",
     )
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -5,9 +5,11 @@
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 {% if not selected_set %}
-  <div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/set-inspector" data-field="set_path" data-value="select_set">
-    {{ file_browser_html | safe }}
-  </div>
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+    <input type="hidden" name="action" value="select_set">
+    {{ pad_grid | safe }}
+    <button type="submit">Load Set</button>
+  </form>
 {% elif not selected_clip %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="show_clip">
@@ -37,6 +39,5 @@
 {% endif %}
 {% endblock %}
 {% block scripts %}
-<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
 <script type="module" src="{{ host_prefix }}/static/set_inspector.js"></script>
 {% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -691,16 +691,15 @@ def test_files_route_not_found(client, tmp_path, monkeypatch):
 def test_set_inspector_get(client, monkeypatch):
     def fake_get():
         return {
-            'file_browser_html': '<ul></ul>',
+            'pad_grid': '<div class="pad-grid"></div>',
             'message': '',
             'message_type': 'info',
             'selected_set': None,
-            'browser_root': '/tmp'
         }
     monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_get', fake_get)
     resp = client.get('/set-inspector')
     assert resp.status_code == 200
-    assert b'class="file-browser"' in resp.data
+    assert b'class="pad-grid"' in resp.data
 
 
 def test_set_inspector_post(client, monkeypatch):
@@ -708,17 +707,16 @@ def test_set_inspector_post(client, monkeypatch):
         return {
             'message': 'ok',
             'message_type': 'success',
-            'file_browser_html': None,
+            'pad_grid': '<div class="pad-grid"></div>',
             'selected_set': '/tmp/a.abl',
             'clip_options': '<option>1</option>',
             'selected_clip': '0:0',
             'notes': [],
             'envelopes': [],
             'region': 4.0,
-            'browser_root': None,
         }
     monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_post', fake_post)
-    resp = client.post('/set-inspector', data={'action': 'select_set', 'set_path': 'x'})
+    resp = client.post('/set-inspector', data={'action': 'select_set', 'pad_index': '1'})
     assert resp.status_code == 200
     assert b'ok' in resp.data
 


### PR DESCRIPTION
## Summary
- show set slots in inspector using same pad grid as set restoration
- update server route to supply pad grid data
- simplify template to render pad grid and remove file browser
- adjust tests for new grid-based inspector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc0bea22c8325974c4be79119676b