### PR TITLE
Show set clips on grid

### DIFF
--- a/move-webserver.py
+++ b/move-webserver.py
@@ -335,6 +335,7 @@ def set_inspector_route():
         message_type=message_type,
         pad_grid=result.get("pad_grid"),
         selected_set=result.get("selected_set"),
+        clip_grid=result.get("clip_grid"),
         clip_options=result.get("clip_options"),
         selected_clip=result.get("selected_clip"),
         notes=result.get("notes"),

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -15,8 +15,7 @@
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="show_clip">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <label for="clip_select">Clip:</label>
-    <select name="clip_select" id="clip_select">{{ clip_options | safe }}</select>
+    {{ clip_grid | safe }}
     <button type="submit">Load Clip</button>
   </form>
   <form method="get" action="{{ host_prefix }}/set-inspector">

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -709,6 +709,7 @@ def test_set_inspector_post(client, monkeypatch):
             'message_type': 'success',
             'pad_grid': '<div class="pad-grid"></div>',
             'selected_set': '/tmp/a.abl',
+            'clip_grid': '<div class="pad-grid"></div>',
             'clip_options': '<option>1</option>',
             'selected_clip': '0:0',
             'notes': [],


### PR DESCRIPTION
## Summary
- expand set inspector to generate a clip grid
- render the grid in the UI so clips appear in rows by track
- plumb clip grid through the server
- update route tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc4d120a48325a9e67277532bafb6