### PR TITLE
Display clips in track-based grid

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -15,7 +15,8 @@ def list_clips(set_path: str) -> Dict[str, Any]:
                 clip = slot.get("clip")
                 if clip:
                     name = clip.get("name", f"Track {ti+1} Clip {ci+1}")
-                    clips.append({"track": ti, "clip": ci, "name": name})
+                    color = clip.get("color")
+                    clips.append({"track": ti, "clip": ci, "name": name, "color": color})
         return {"success": True, "message": "Clips loaded", "clips": clips}
     except Exception as e:
         return {"success": False, "message": f"Failed to read set: {e}"}

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -94,13 +94,20 @@ class SetInspectorHandler(BaseHandler):
 
         if action == "select_set":
             pad_val = form.getvalue("pad_index")
-            if not pad_val or not pad_val.isdigit():
+            set_path = form.getvalue("set_path")
+            if pad_val and pad_val.isdigit():
+                idx = int(pad_val) - 1
+                entry = next((m for m in msets if m.get("mset_id") == idx), None)
+                if not entry:
+                    return self.format_error_response("No set on selected pad", pad_grid=pad_grid)
+                set_path = os.path.join(
+                    MSETS_DIRECTORY,
+                    entry["uuid"],
+                    entry["mset_name"],
+                    "Song.abl",
+                )
+            if not set_path:
                 return self.format_error_response("No set selected", pad_grid=pad_grid)
-            idx = int(pad_val) - 1
-            entry = next((m for m in msets if m.get("mset_id") == idx), None)
-            if not entry:
-                return self.format_error_response("No set on selected pad", pad_grid=pad_grid)
-            set_path = os.path.join(MSETS_DIRECTORY, entry["uuid"], entry["mset_name"], "Song.abl")
             result = list_clips(set_path)
             if not result.get("success"):
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -335,6 +335,7 @@ def set_inspector_route():
         message_type=message_type,
         pad_grid=result.get("pad_grid"),
         selected_set=result.get("selected_set"),
+        clip_grid=result.get("clip_grid"),
         clip_options=result.get("clip_options"),
         selected_clip=result.get("selected_clip"),
         notes=result.get("notes"),

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -11,6 +11,18 @@ export function initSetInspector() {
     });
   }
 
+  // Show selected clip name when choosing a clip
+  const clipGrid = document.querySelector('#clipSelectForm .pad-grid');
+  const clipNameSpan = document.getElementById('selected-clip-name');
+  if (clipGrid && clipNameSpan) {
+    clipGrid.querySelectorAll('input[name="clip_select"]').forEach(radio => {
+      radio.addEventListener('change', () => {
+        const label = clipGrid.querySelector(`label[for="${radio.id}"]`);
+        clipNameSpan.textContent = label?.dataset.name || '';
+      });
+    });
+  }
+
   const dataDiv = document.getElementById('clipData');
   if (!dataDiv) return;
   const notes = JSON.parse(dataDiv.dataset.notes || '[]');

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -11,14 +11,18 @@ export function initSetInspector() {
     });
   }
 
-  // Show selected clip name when choosing a clip
+  // Auto-load clip when a clip cell is clicked
   const clipGrid = document.querySelector('#clipSelectForm .pad-grid');
   const clipNameSpan = document.getElementById('selected-clip-name');
-  if (clipGrid && clipNameSpan) {
+  if (clipGrid) {
+    const form = document.getElementById('clipSelectForm');
     clipGrid.querySelectorAll('input[name="clip_select"]').forEach(radio => {
       radio.addEventListener('change', () => {
         const label = clipGrid.querySelector(`label[for="${radio.id}"]`);
-        clipNameSpan.textContent = label?.dataset.name || '';
+        if (clipNameSpan) {
+          clipNameSpan.textContent = label?.dataset.name || '';
+        }
+        form.submit();
       });
     });
   }

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -11,18 +11,25 @@
     <button type="submit">Load Set</button>
     <span id="selected-set-name" style="margin-left:1rem;"></span>
   </form>
-{% else %}
+{% elif not selected_clip %}
   <form id="clipSelectForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="show_clip">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
     {{ clip_grid | safe }}
-    <button type="submit">Load Clip</button>
     <span id="selected-clip-name" style="margin-left:1rem;"></span>
   </form>
   <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <button type="submit">Choose Another Set</button>
   </form>
-  {% if selected_clip %}
+{% else %}
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+    <input type="hidden" name="action" value="select_set">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <button type="submit">Back to Clips</button>
+  </form>
+  <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
+    <button type="submit">Choose Another Set</button>
+  </form>
   <div style="margin-top:1rem;">
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
@@ -30,7 +37,6 @@
   <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
   {% endif %}
-{% endif %}
 {% endblock %}
 {% block scripts %}
 <script type="module" src="{{ host_prefix }}/static/set_inspector.js"></script>

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -11,32 +11,25 @@
     <button type="submit">Load Set</button>
     <span id="selected-set-name" style="margin-left:1rem;"></span>
   </form>
-{% elif not selected_clip %}
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+{% else %}
+  <form id="clipSelectForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="show_clip">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <label for="clip_select">Clip:</label>
-    <select name="clip_select" id="clip_select">{{ clip_options | safe }}</select>
+    {{ clip_grid | safe }}
     <button type="submit">Load Clip</button>
+    <span id="selected-clip-name" style="margin-left:1rem;"></span>
   </form>
-  <form method="get" action="{{ host_prefix }}/set-inspector">
+  <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <button type="submit">Choose Another Set</button>
   </form>
-{% else %}
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
-    <input type="hidden" name="action" value="select_set">
-    <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <button type="submit">Choose Another Clip</button>
-  </form>
-  <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
-    <button type="submit">Choose Another Set</button>
-  </form>
+  {% if selected_clip %}
   <div style="margin-top:1rem;">
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
   </div>
   <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+  {% endif %}
 {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -692,6 +692,7 @@ def test_set_inspector_get(client, monkeypatch):
     def fake_get():
         return {
             'pad_grid': '<div class="pad-grid"></div>',
+            'clip_grid': '',
             'message': '',
             'message_type': 'info',
             'selected_set': None,
@@ -709,6 +710,7 @@ def test_set_inspector_post(client, monkeypatch):
             'message_type': 'success',
             'pad_grid': '<div class="pad-grid"></div>',
             'selected_set': '/tmp/a.abl',
+            'clip_grid': '<div class="pad-grid"></div>',
             'clip_options': '<option>1</option>',
             'selected_clip': '0:0',
             'notes': [],


### PR DESCRIPTION
## Summary
- add clip color info in `list_clips`
- generate a clip grid for each track in `SetInspectorHandler`
- tweak set inspector template and JS to use the new grid
- send new grid data through Flask route
- adjust test stubs for updated API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc4f1d0a48325820fd40353880a89