### PR TITLE
Show parameter names in Set Inspector

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -3,6 +3,18 @@ import os
 from typing import Any, Dict, List
 
 
+def _collect_param_ids(obj: Any, mapping: Dict[int, str]) -> None:
+    """Recursively collect parameterId mappings from the given object."""
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if isinstance(val, dict) and "id" in val and isinstance(val["id"], int):
+                mapping[val["id"]] = val.get("customName") or key
+            _collect_param_ids(val, mapping)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_param_ids(item, mapping)
+
+
 def list_clips(set_path: str) -> Dict[str, Any]:
     """Return list of clips in the set."""
     try:
@@ -26,16 +38,20 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
     try:
         with open(set_path, "r") as f:
             song = json.load(f)
-        clip_obj = song["tracks"][track]["clipSlots"][clip]["clip"]
+        track_obj = song["tracks"][track]
+        clip_obj = track_obj["clipSlots"][clip]["clip"]
         notes = clip_obj.get("notes", [])
         envelopes = clip_obj.get("envelopes", [])
         region = clip_obj.get("region", {}).get("end", 4.0)
+        param_map: Dict[int, str] = {}
+        _collect_param_ids(track_obj.get("devices", []), param_map)
         return {
             "success": True,
             "message": "Clip loaded",
             "notes": notes,
             "envelopes": envelopes,
             "region": region,
+            "param_map": param_map,
         }
     except Exception as e:
         return {"success": False, "message": f"Failed to read clip: {e}"}

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -105,8 +105,13 @@ class SetInspectorHandler(BaseHandler):
             if not result.get("success"):
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             envelopes = result.get("envelopes", [])
+            param_map = result.get("param_map", {})
             env_opts = "".join(
-                f'<option value="{e.get("parameterId")}">{e.get("parameterId")}</option>'
+                (
+                    f'<option value="{e.get("parameterId")}">'
+                    f'{param_map.get(e.get("parameterId"), e.get("parameterId"))}'
+                    f'</option>'
+                )
                 for e in envelopes
             )
             env_opts = '<option value="" disabled selected>-- Select Envelope --</option>' + env_opts


### PR DESCRIPTION
## Summary
- collect `parameterId` mappings when reading clips
- use mapping to show envelope names instead of raw IDs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc517fb908325be1ced4f77230f12