### PR TITLE
Add parameter range legend to Set Inspector

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -3,6 +3,7 @@ from core.set_inspector_handler import list_clips, get_clip_data
 from core.list_msets_handler import list_msets
 from core.pad_colors import rgb_string
 from core.config import MSETS_DIRECTORY
+import json
 import os
 
 class SetInspectorHandler(BaseHandler):
@@ -78,6 +79,7 @@ class SetInspectorHandler(BaseHandler):
             "notes": [],
             "envelopes": [],
             "region": 4.0,
+            "param_ranges_json": "{}",
         }
 
     def handle_post(self, form):
@@ -122,6 +124,7 @@ class SetInspectorHandler(BaseHandler):
                 "notes": [],
                 "envelopes": [],
                 "region": 4.0,
+                "param_ranges_json": "{}",
             }
         elif action == "show_clip":
             set_path = form.getvalue("set_path")
@@ -156,6 +159,7 @@ class SetInspectorHandler(BaseHandler):
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
+                "param_ranges_json": json.dumps(result.get("param_ranges", {})),
             }
         else:
             return self.format_error_response("Unknown action", pad_grid=pad_grid)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -341,6 +341,7 @@ def set_inspector_route():
         notes=result.get("notes"),
         envelopes=result.get("envelopes"),
         region=result.get("region"),
+        param_ranges_json=result.get("param_ranges_json", "{}"),
         active_tab="set-inspector",
     )
 

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -32,9 +32,11 @@ export function initSetInspector() {
   const notes = JSON.parse(dataDiv.dataset.notes || '[]');
   const envelopes = JSON.parse(dataDiv.dataset.envelopes || '[]');
   const region = parseFloat(dataDiv.dataset.region || '4');
+  const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
   const envSelect = document.getElementById('envelope_select');
+  const legendDiv = document.getElementById('paramLegend');
 
   function getVisibleRange() {
     if (!notes.length) return { min: 60, max: 71 }; // default middle C octave
@@ -117,6 +119,27 @@ export function initSetInspector() {
     ctx.stroke();
   }
 
+  function updateLegend() {
+    if (!legendDiv) return;
+    if (!envSelect || !envSelect.value) {
+      legendDiv.textContent = '';
+      return;
+    }
+    const param = parseInt(envSelect.value);
+    const range = paramRanges[param];
+    if (!range || typeof range.min !== 'number' || typeof range.max !== 'number') {
+      legendDiv.textContent = '';
+      return;
+    }
+    const mid = (range.min + range.max) / 2;
+    const unit = range.unit ? ' ' + range.unit : '';
+    const fmt = v => Number(v).toFixed(2) + unit;
+    legendDiv.innerHTML =
+      `<div style="text-align:right;">${fmt(range.max)}</div>` +
+      `<div style="text-align:right;">${fmt(mid)}</div>` +
+      `<div style="text-align:right;">${fmt(range.min)}</div>`;
+  }
+
   function draw() {
     drawGrid();
     drawNotes();
@@ -124,7 +147,8 @@ export function initSetInspector() {
     drawEnvelope();
   }
 
-  if (envSelect) envSelect.addEventListener('change', draw);
+  if (envSelect) envSelect.addEventListener('change', () => { updateLegend(); draw(); });
+  updateLegend();
   draw();
 }
 

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -37,6 +37,13 @@ export function initSetInspector() {
   const ctx = canvas.getContext('2d');
   const envSelect = document.getElementById('envelope_select');
   const legendDiv = document.getElementById('paramLegend');
+  if (legendDiv) {
+    legendDiv.style.display = 'flex';
+    legendDiv.style.flexDirection = 'column';
+    legendDiv.style.justifyContent = 'space-between';
+    legendDiv.style.alignItems = 'flex-end';
+    legendDiv.style.height = canvas.height + 'px';
+  }
 
   function getVisibleRange() {
     if (!notes.length) return { min: 60, max: 71 }; // default middle C octave

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -36,7 +36,7 @@
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
-    <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2;"></div>
+    <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -34,8 +34,11 @@
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
   </div>
-  <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;margin-top:1rem;"></canvas>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}'></div>
+  <div style="margin-top:1rem; display:flex; align-items:flex-start;">
+    <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
+    <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2;"></div>
+  </div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- show parameter ranges in set inspector clip view
- expose instrument schema ranges from backend
- render legend next to envelope grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc9a0742c8325bfd7037601b24a9d