### PR TITLE
Add clip envelope editing

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -84,3 +84,34 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
         }
     except Exception as e:
         return {"success": False, "message": f"Failed to read clip: {e}"}
+
+
+def save_envelope(
+    set_path: str,
+    track: int,
+    clip: int,
+    parameter_id: int,
+    breakpoints: List[Dict[str, float]],
+) -> Dict[str, Any]:
+    """Update or create an envelope and write the set back to disk."""
+    try:
+        with open(set_path, "r") as f:
+            song = json.load(f)
+
+        clip_obj = (
+            song["tracks"][track]["clipSlots"][clip]["clip"]
+        )
+        envelopes = clip_obj.setdefault("envelopes", [])
+        for env in envelopes:
+            if env.get("parameterId") == parameter_id:
+                env["breakpoints"] = breakpoints
+                break
+        else:
+            envelopes.append({"parameterId": parameter_id, "breakpoints": breakpoints})
+
+        with open(set_path, "w") as f:
+            json.dump(song, f, indent=2)
+
+        return {"success": True, "message": "Envelope saved"}
+    except Exception as e:
+        return {"success": False, "message": f"Failed to save envelope: {e}"}

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -38,6 +38,16 @@
     <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
+  <div id="envValue" style="margin-top:0.5rem; font-size:0.8em;"></div>
+  <button id="editEnvBtn" type="button" style="margin-top:0.5rem;">Edit Envelope</button>
+  <form id="saveEnvForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem; display:none;">
+    <input type="hidden" name="action" value="save_envelope">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+    <input type="hidden" name="parameter_id" id="parameter_id_input">
+    <input type="hidden" name="envelope_data" id="envelope_data_input">
+    <button id="saveEnvBtn" type="submit" style="display:none;">Save Envelope</button>
+  </form>
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -261,3 +261,35 @@ def test_get_melodic_sampler_sample(tmp_path):
     assert info["sample_name"] == "test sample.wav"
     assert info["sample_path"].endswith("test sample.wav")
 
+
+def test_save_envelope(tmp_path):
+    set_path = tmp_path / "set.abl"
+    song = {
+        "tracks": [
+            {
+                "kind": "midi",
+                "clipSlots": [
+                    {
+                        "clip": {
+                            "notes": [],
+                            "envelopes": [],
+                            "region": {"end": 4.0},
+                        }
+                    }
+                ],
+            }
+        ]
+    }
+    set_path.write_text(json.dumps(song))
+
+    from core.set_inspector_handler import save_envelope, get_clip_data
+
+    bps = [{"time": 0, "value": 0}, {"time": 1, "value": 1}]
+    result = save_envelope(str(set_path), 0, 0, 1, bps)
+    assert result["success"], result.get("message")
+
+    data = get_clip_data(str(set_path), 0, 0)
+    envs = data.get("envelopes", [])
+    assert envs and envs[0]["parameterId"] == 1
+    assert envs[0]["breakpoints"] == bps
+

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -722,5 +722,14 @@ def test_set_inspector_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'ok' in resp.data
 
+    resp = client.post('/set-inspector', data={
+        'action': 'save_envelope',
+        'set_path': '/tmp/a.abl',
+        'clip_select': '0:0',
+        'parameter_id': '1',
+        'envelope_data': '[]'
+    })
+    assert resp.status_code == 200
+
 
 


### PR DESCRIPTION
## Summary
- implement `save_envelope` for writing envelopes to sets
- handle new `save_envelope` action in `SetInspectorHandler`
- enable envelope editing UI with buttons and value display
- extend JavaScript for editing and hovering envelopes
- test new core save logic and route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcda19fa48325b3c6bf3206b6f592