### PR TITLE
Fix envelope drawing loops

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -227,7 +227,13 @@ export function initSetInspector() {
       return;
     }
     const { x, y } = canvasPos(ev);
-    currentEnv.push({ time: (x / canvas.width) * region, value: 1 - y / canvas.height });
+    const t = (x / canvas.width) * region;
+    const v = 1 - y / canvas.height;
+    if (currentEnv.length && t <= currentEnv[currentEnv.length - 1].time) {
+      currentEnv[currentEnv.length - 1] = { time: t, value: v };
+    } else {
+      currentEnv.push({ time: t, value: v });
+    }
     draw();
     ev.preventDefault();
   }

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -229,11 +229,10 @@ export function initSetInspector() {
     const { x, y } = canvasPos(ev);
     const t = (x / canvas.width) * region;
     const v = 1 - y / canvas.height;
-    if (currentEnv.length && t <= currentEnv[currentEnv.length - 1].time) {
-      currentEnv[currentEnv.length - 1] = { time: t, value: v };
-    } else {
-      currentEnv.push({ time: t, value: v });
+    while (currentEnv.length && t <= currentEnv[currentEnv.length - 1].time) {
+      currentEnv.pop();
     }
+    currentEnv.push({ time: t, value: v });
     draw();
     ev.preventDefault();
   }


### PR DESCRIPTION
## Summary
- prevent editing envelope from going backward in time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd4ecc0888325860fe7a3e9c66826