### PR TITLE
Update envelope editor UI

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -47,6 +47,19 @@ export function initSetInspector() {
   let editing = false;
   let drawing = false;
   let currentEnv = [];
+
+  function updateControls() {
+    const hasEnv = envSelect && envSelect.value;
+    if (editBtn) {
+      editBtn.style.display = hasEnv && !editing ? '' : 'none';
+    }
+    if (saveForm) {
+      saveForm.style.display = hasEnv ? 'block' : 'none';
+    }
+    if (!hasEnv) {
+      saveBtn.disabled = true;
+    }
+  }
   if (legendDiv) {
     legendDiv.style.display = 'flex';
     legendDiv.style.flexDirection = 'column';
@@ -179,14 +192,13 @@ export function initSetInspector() {
   }
 
   if (envSelect) envSelect.addEventListener('change', () => {
-    updateLegend();
-    if (editing) {
-      const param = parseInt(envSelect.value);
-      const src = envelopes.find(e => e.parameterId === param);
-      currentEnv = src ? src.breakpoints.map(bp => ({ ...bp })) : [];
+    editing = false;
+    currentEnv = [];
+    if (envSelect.value) {
       paramInput.value = envSelect.value;
-      saveBtn.style.display = 'none';
     }
+    updateLegend();
+    updateControls();
     draw();
   });
 
@@ -218,6 +230,7 @@ export function initSetInspector() {
     currentEnv = [];
     const { x, y } = canvasPos(ev);
     currentEnv.push({ time: (x / canvas.width) * region, value: 1 - y / canvas.height });
+    if (saveBtn) saveBtn.disabled = false;
     ev.preventDefault();
   }
 
@@ -240,7 +253,6 @@ export function initSetInspector() {
   function endDraw() {
     if (drawing) {
       drawing = false;
-      if (saveBtn) saveBtn.style.display = '';
     }
   }
 
@@ -259,9 +271,8 @@ export function initSetInspector() {
     const src = envelopes.find(e => e.parameterId === param);
     currentEnv = src ? src.breakpoints.map(bp => ({ ...bp })) : [];
     paramInput.value = envSelect.value;
-    editBtn.style.display = 'none';
-    if (saveForm) saveForm.style.display = 'block';
-    saveBtn.style.display = 'none';
+    if (saveBtn) saveBtn.disabled = true;
+    updateControls();
     draw();
   });
 
@@ -269,6 +280,7 @@ export function initSetInspector() {
     envInput.value = JSON.stringify(currentEnv);
   });
   updateLegend();
+  updateControls();
   draw();
 }
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -50,20 +50,20 @@
   <div style="margin-top:1rem;">
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
+    <button id="editEnvBtn" type="button" style="margin-left:0.5rem; display:none;">Edit Envelope</button>
     <span id="envValue" style="margin-top:0.5rem; font-size:0.8em;"></span>
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
-  <button id="editEnvBtn" type="button" style="margin-top:0.5rem;">Edit Envelope</button>
   <form id="saveEnvForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem; display:none;">
     <input type="hidden" name="action" value="save_envelope">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
     <input type="hidden" name="clip_select" value="{{ selected_clip }}">
     <input type="hidden" name="parameter_id" id="parameter_id_input">
     <input type="hidden" name="envelope_data" id="envelope_data_input">
-    <button id="saveEnvBtn" type="submit" style="display:none;">Save Envelope</button>
+    <button id="saveEnvBtn" type="submit" disabled>Save Envelope</button>
   </form>
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}


### PR DESCRIPTION
## Summary
- place the envelope editing button next to the selector
- show save button when an envelope is selected and enable it only after edits
- adjust JS logic for envelope selector and editing controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd8d3162c8325a683c67ff7fa4a21