### PR TITLE
Fix macro ranges defaulting to 0-1

### DIFF
--- a/core/synth_preset_inspector_handler.py
+++ b/core/synth_preset_inspector_handler.py
@@ -519,6 +519,29 @@ def update_preset_parameter_mappings(preset_path, parameter_updates):
         # Load the preset file
         with open(preset_path, 'r') as f:
             preset_data = json.load(f)
+
+        # Load parameter metadata so we can fill in default ranges
+        schema = {}
+        for loader in (
+            load_drift_schema,
+            load_wavetable_schema,
+            load_melodic_sampler_schema,
+        ):
+            try:
+                schema.update(loader() or {})
+            except Exception:
+                continue
+
+        # Fill in default ranges from the schema
+        for info in parameter_updates.values():
+            pname = info.get("parameter")
+            if not pname:
+                continue
+            meta = schema.get(pname, {})
+            if (info.get("rangeMin") is None or info.get("rangeMin") == "") and "min" in meta:
+                info["rangeMin"] = meta["min"]
+            if (info.get("rangeMax") is None or info.get("rangeMax") == "") and "max" in meta:
+                info["rangeMax"] = meta["max"]
         
         # Track parameters that were updated
         updated_params = []


### PR DESCRIPTION
## Summary
- fallback to parameter min/max when saving macro mappings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdfb17d7483258153532a27619478