### PR TITLE
Improve envelope mapping for drum pads

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -147,7 +147,7 @@ class SetInspectorHandler(BaseHandler):
             env_opts = "".join(
                 (
                     f'<option value="{e.get("parameterId")}">'
-                    f'{param_map.get(e.get("parameterId"), e.get("parameterId"))}'
+                    f'{e.get("owner") or param_map.get(e.get("parameterId"), e.get("parameterId"))}'
                     f'</option>'
                 )
                 for e in envelopes
@@ -195,7 +195,7 @@ class SetInspectorHandler(BaseHandler):
             env_opts = "".join(
                 (
                     f'<option value="{e.get("parameterId")}">' +
-                    f'{param_map.get(e.get("parameterId"), e.get("parameterId"))}' +
+                    f'{e.get("owner") or param_map.get(e.get("parameterId"), e.get("parameterId"))}' +
                     f'</option>'
                 )
                 for e in envelopes


### PR DESCRIPTION
## Summary
- gather pad-specific parameter metadata when loading clips
- label envelopes with owning drum pad or device
- preserve ranges when saving envelopes
- display envelope owners in the Set Inspector UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bea73245c8325aefbb645c0b65f57