### PR TITLE
Ensure selected envelope persists after save

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -195,16 +195,21 @@ class SetInspectorHandler(BaseHandler):
             envelopes = clip_data.get("envelopes", [])
             param_map = clip_data.get("param_map", {})
             param_context = clip_data.get("param_context", {})
+            selected_pid = int(param_val)
             env_opts = "".join(
                 (
-                    f'<option value="{e.get("parameterId")}">' +
+                    f'<option value="{e.get("parameterId")}"' +
+                    (
+                        ' selected' if e.get("parameterId") == selected_pid else ''
+                    ) +
+                    '>' +
                     f'{param_context.get(e.get("parameterId"), "Track")}: ' +
                     f'{param_map.get(e.get("parameterId"), e.get("parameterId"))}' +
-                    f'</option>'
+                    '</option>'
                 )
                 for e in envelopes
             )
-            env_opts = '<option value="" disabled selected>-- Select Envelope --</option>' + env_opts
+            env_opts = '<option value="" disabled>-- Select Envelope --</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
             return {
                 "pad_grid": pad_grid,

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -362,9 +362,13 @@ export function initSetInspector() {
   if (saveForm) saveForm.addEventListener('submit', () => {
     envInput.value = JSON.stringify(currentEnv);
   });
-  updateLegend();
-  updateControls();
-  draw();
+  if (envSelect && envSelect.value) {
+    envSelect.dispatchEvent(new Event('change'));
+  } else {
+    updateLegend();
+    updateControls();
+    draw();
+  }
 }
 
 document.addEventListener('DOMContentLoaded', initSetInspector);


### PR DESCRIPTION
## Summary
- keep envelope selected after saving edits
- initialize envelope display if one is already selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfaf808fc8325b4ddcf79a98d243d