### PR TITLE
Add miniature grids for set inspector navigation

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -30,6 +30,16 @@ def _collect_param_ids(
             _collect_param_ids(item, mapping, context, prefix)
 
 
+def _track_display_name(track_obj: Dict[str, Any], idx: int) -> str:
+    """Return display name for a track using first device name."""
+    devices = track_obj.get("devices", [])
+    if devices and isinstance(devices, list):
+        first = devices[0]
+        if isinstance(first, dict) and first.get("name"):
+            return first.get("name")
+    return track_obj.get("name") or f"Track {idx + 1}"
+
+
 def list_clips(set_path: str) -> Dict[str, Any]:
     """Return list of clips in the set."""
     try:
@@ -59,7 +69,7 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
         notes = clip_obj.get("notes", [])
         envelopes = clip_obj.get("envelopes", [])
         region = clip_obj.get("region", {}).get("end", 4.0)
-        track_name = track_obj.get("name") or f"Track {track + 1}"
+        track_name = _track_display_name(track_obj, track)
         clip_name = clip_obj.get("name") or f"Clip {clip + 1}"
         param_map: Dict[int, str] = {}
         param_context: Dict[int, str] = {}

--- a/static/style.css
+++ b/static/style.css
@@ -499,7 +499,26 @@ nav.breadcrumbs form {
 }
 
 .pad-grid label {
-	margin-bottom: 0;
+        margin-bottom: 0;
+}
+
+/* Miniature grid wrapper */
+.mini-grid {
+    width: 120px;
+    height: 40px;
+    overflow: hidden;
+    display: inline-block;
+    cursor: pointer;
+}
+
+.mini-grid .pad-grid {
+    transform: scale(0.2);
+    transform-origin: top left;
+}
+
+.mini-grid input,
+.mini-grid label {
+    pointer-events: none;
 }
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -504,7 +504,7 @@ nav.breadcrumbs form {
 
 /* Miniature grid wrapper */
 .mini-grid {
-    width: 120px;
+    width: 90px;
     height: 40px;
     overflow: hidden;
     display: inline-block;
@@ -512,7 +512,7 @@ nav.breadcrumbs form {
 }
 
 .mini-grid .pad-grid {
-    transform: scale(0.2);
+    transform: scale(0.4);
     transform-origin: top left;
 }
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -13,6 +13,9 @@
     <span id="selected-set-name" style="margin-left:1rem;"></span>
   </form>
 {% elif not selected_clip %}
+  <div style="margin-bottom:0.5rem;">
+    <a href="{{ host_prefix }}/set-inspector" class="mini-grid">{{ pad_grid | safe }}</a>
+  </div>
   <nav class="breadcrumbs" style="margin-bottom:1rem;">
     <form method="get" action="{{ host_prefix }}/set-inspector" style="display:inline;">
       <button type="submit" class="link-button">{{ set_name }}</button>
@@ -28,6 +31,14 @@
     <button type="submit">Choose Another Set</button>
   </form> -->
 {% else %}
+  <div style="margin-bottom:0.5rem; display:flex; gap:0.5rem; align-items:center;">
+    <a href="{{ host_prefix }}/set-inspector" class="mini-grid">{{ pad_grid | safe }}</a>
+    <form id="miniClipForm" method="post" action="{{ host_prefix }}/set-inspector" style="display:inline; margin:0;">
+      <input type="hidden" name="action" value="select_set">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <button type="submit" class="mini-grid" style="border:none; background:none; padding:0;">{{ clip_grid | safe }}</button>
+    </form>
+  </div>
   <nav class="breadcrumbs" style="margin-bottom:1rem;">
     <form method="get" action="{{ host_prefix }}/set-inspector" style="display:inline;">
       <button type="submit" class="link-button">{{ set_name }}</button>

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -13,13 +13,11 @@
     <span id="selected-set-name" style="margin-left:1rem;"></span>
   </form>
 {% elif not selected_clip %}
-  <div style="margin-bottom:0.5rem;">
-    <a href="{{ host_prefix }}/set-inspector" class="mini-grid">{{ pad_grid | safe }}</a>
-  </div>
-  <nav class="breadcrumbs" style="margin-bottom:1rem;">
+  <nav class="breadcrumbs" style="margin-bottom:1rem; display:flex; align-items:center; gap:0.5rem;">
     <form method="get" action="{{ host_prefix }}/set-inspector" style="display:inline;">
       <button type="submit" class="link-button">{{ set_name }}</button>
     </form>
+    <a href="{{ host_prefix }}/set-inspector" class="mini-grid">{{ pad_grid | safe }}</a>
   </nav>
   <form id="clipSelectForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="show_clip">
@@ -31,23 +29,21 @@
     <button type="submit">Choose Another Set</button>
   </form> -->
 {% else %}
-  <div style="margin-bottom:0.5rem; display:flex; gap:0.5rem; align-items:center;">
-    <a href="{{ host_prefix }}/set-inspector" class="mini-grid">{{ pad_grid | safe }}</a>
-    <form id="miniClipForm" method="post" action="{{ host_prefix }}/set-inspector" style="display:inline; margin:0;">
-      <input type="hidden" name="action" value="select_set">
-      <input type="hidden" name="set_path" value="{{ selected_set }}">
-      <button type="submit" class="mini-grid" style="border:none; background:none; padding:0;">{{ clip_grid | safe }}</button>
-    </form>
-  </div>
-  <nav class="breadcrumbs" style="margin-bottom:1rem;">
+  <nav class="breadcrumbs" style="margin-bottom:1rem; display:flex; align-items:center; gap:0.5rem;">
     <form method="get" action="{{ host_prefix }}/set-inspector" style="display:inline;">
       <button type="submit" class="link-button">{{ set_name }}</button>
     </form>
+    <a href="{{ host_prefix }}/set-inspector" class="mini-grid">{{ pad_grid | safe }}</a>
     -
     <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
       <input type="hidden" name="action" value="select_set">
       <input type="hidden" name="set_path" value="{{ selected_set }}">
       <button type="submit" class="link-button">Track {{ (track_index + 1) if track_index is not none else '?' }}: {{ track_name }}</button>
+    </form>
+    <form id="miniClipForm" method="post" action="{{ host_prefix }}/set-inspector" style="display:inline; margin:0;">
+      <input type="hidden" name="action" value="select_set">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <button type="submit" class="mini-grid" style="border:none; background:none; padding:0;">{{ clip_grid | safe }}</button>
     </form>
     - Clip {{ (clip_index + 1) if clip_index is not none else '?' }}
   </nav>


### PR DESCRIPTION
## Summary
- highlight selected set with new `selected_idx` option
- show miniature set and clip grids for orientation
- add `mini-grid` CSS and hook into template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfd0cfb948325a14049bf2afde8c3