### PR TITLE
Add loop display toggle for Set Inspector

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -85,6 +85,7 @@ class SetInspectorHandler(BaseHandler):
             "notes": [],
             "envelopes": [],
             "region": 4.0,
+            "clip_length": 4.0,
             "param_ranges_json": "{}",
         }
 
@@ -144,6 +145,7 @@ class SetInspectorHandler(BaseHandler):
                 "notes": [],
                 "envelopes": [],
                 "region": 4.0,
+                "clip_length": 4.0,
                 "param_ranges_json": "{}",
             }
         elif action == "show_clip":
@@ -192,6 +194,7 @@ class SetInspectorHandler(BaseHandler):
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
+                "clip_length": result.get("clip_length", result.get("region", 4.0)),
                 "param_ranges_json": json.dumps(result.get("param_ranges", {})),
                 "track_index": track_idx,
                 "clip_index": clip_idx,
@@ -257,6 +260,7 @@ class SetInspectorHandler(BaseHandler):
                 "notes": clip_data.get("notes", []),
                 "envelopes": envelopes,
                 "region": clip_data.get("region", 4.0),
+                "clip_length": clip_data.get("clip_length", clip_data.get("region", 4.0)),
                 "param_ranges_json": json.dumps(clip_data.get("param_ranges", {})),
                 "track_index": track_idx,
                 "clip_index": clip_idx,

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -31,7 +31,9 @@ export function initSetInspector() {
   if (!dataDiv) return;
   const notes = JSON.parse(dataDiv.dataset.notes || '[]');
   const envelopes = JSON.parse(dataDiv.dataset.envelopes || '[]');
-  const region = parseFloat(dataDiv.dataset.region || '4');
+  let region = parseFloat(dataDiv.dataset.region || '4');
+  const loopLength = parseFloat(dataDiv.dataset.loopLength || dataDiv.dataset.region || '4');
+  const clipLength = parseFloat(dataDiv.dataset.clipLength || loopLength);
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
@@ -43,6 +45,7 @@ export function initSetInspector() {
   const paramInput = document.getElementById('parameter_id_input');
   const envInput = document.getElementById('envelope_data_input');
   const valueDiv = document.getElementById('envValue');
+  const showEntireCb = document.getElementById('showEntireClip');
 
   let editing = false;
   let drawing = false;
@@ -50,6 +53,10 @@ export function initSetInspector() {
   let currentEnv = [];
   let tailEnv = [];
   let envInfo = null;
+
+  function setRegion() {
+    region = showEntireCb && showEntireCb.checked ? clipLength : loopLength;
+  }
 
   function isNormalized(env) {
     if (!env || !env.breakpoints || !env.breakpoints.length) return false;
@@ -81,6 +88,13 @@ export function initSetInspector() {
     legendDiv.style.justifyContent = 'space-between';
     legendDiv.style.alignItems = 'flex-end';
     legendDiv.style.height = canvas.height + 'px';
+  }
+
+  if (showEntireCb) {
+    showEntireCb.addEventListener('change', () => {
+      setRegion();
+      draw();
+    });
   }
 
   function getVisibleRange() {
@@ -363,10 +377,12 @@ export function initSetInspector() {
     envInput.value = JSON.stringify(currentEnv);
   });
   if (envSelect && envSelect.value) {
+    setRegion();
     envSelect.dispatchEvent(new Event('change'));
   } else {
     updateLegend();
     updateControls();
+    setRegion();
     draw();
   }
 }

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -73,7 +73,8 @@
     <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <label style="margin-top:0.5rem; display:block;"><input type="checkbox" id="showEntireClip"> Show entire clip</label>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-loop-length='{{ region }}' data-clip-length='{{ clip_length }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -716,6 +716,7 @@ def test_set_inspector_post(client, monkeypatch):
             'notes': [],
             'envelopes': [],
             'region': 4.0,
+            'clip_length': 4.0,
         }
     monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_post', fake_post)
     resp = client.post('/set-inspector', data={'action': 'select_set', 'pad_index': '1'})


### PR DESCRIPTION
## Summary
- compute clip length and loop length when reading clip data
- return clip_length from Set Inspector handler
- provide checkbox to toggle showing the entire clip
- update Set Inspector JS to switch between loop and full clip
- adjust unit tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c04bedb248325990a204fee29da7f