### PR TITLE
Use loop info for clip inspector region

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -70,9 +70,9 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
         envelopes = clip_obj.get("envelopes", [])
         region_info = clip_obj.get("region", {})
         loop_info = region_info.get("loop", {})
-        loop_start = loop_info.get("start", region_info.get("start", 0.0))
-        loop_end = loop_info.get("end", region_info.get("end", 4.0))
-        region = float(loop_end) - float(loop_start)
+        loop_start = float(loop_info.get("start", region_info.get("start", 0.0)))
+        loop_end = float(loop_info.get("end", region_info.get("end", 4.0)))
+        region = loop_end - loop_start
         track_name = _track_display_name(track_obj, track)
         clip_name = clip_obj.get("name") or f"Clip {clip + 1}"
         param_map: Dict[int, str] = {}
@@ -127,6 +127,7 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
             "envelopes": envelopes,
             "region": region,
             "loop_start": loop_start,
+            "loop_end": loop_end,
             "param_map": param_map,
             "param_context": param_context,
             "param_ranges": param_ranges,

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -86,6 +86,7 @@ class SetInspectorHandler(BaseHandler):
             "envelopes": [],
             "region": 4.0,
             "loop_start": 0.0,
+            "loop_end": 4.0,
             "param_ranges_json": "{}",
         }
 
@@ -194,6 +195,7 @@ class SetInspectorHandler(BaseHandler):
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
                 "loop_start": result.get("loop_start", 0.0),
+                "loop_end": result.get("loop_end", 4.0),
                 "param_ranges_json": json.dumps(result.get("param_ranges", {})),
                 "track_index": track_idx,
                 "clip_index": clip_idx,
@@ -260,6 +262,7 @@ class SetInspectorHandler(BaseHandler):
                 "envelopes": envelopes,
                 "region": clip_data.get("region", 4.0),
                 "loop_start": clip_data.get("loop_start", 0.0),
+                "loop_end": clip_data.get("loop_end", 4.0),
                 "param_ranges_json": json.dumps(clip_data.get("param_ranges", {})),
                 "track_index": track_idx,
                 "clip_index": clip_idx,

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -33,6 +33,7 @@ export function initSetInspector() {
   const envelopes = JSON.parse(dataDiv.dataset.envelopes || '[]');
   const region = parseFloat(dataDiv.dataset.region || '4');
   const loopStart = parseFloat(dataDiv.dataset.loopStart || '0');
+  const loopEnd = parseFloat(dataDiv.dataset.loopEnd || (loopStart + region));
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
@@ -102,13 +103,18 @@ export function initSetInspector() {
     const noteRange = max - min + 1;
 
     ctx.strokeStyle = '#ddd';
-    for (let b = 0; b <= region; b++) {
-      const x = (b / region) * canvas.width;
+    const startBar = Math.floor(loopStart);
+    const endBar = Math.ceil(loopEnd);
+    for (let b = startBar; b <= endBar; b++) {
+      const x = ((b - loopStart) / region) * canvas.width;
       ctx.beginPath();
       ctx.lineWidth = b % 4 === 0 ? 2 : 1;
       ctx.moveTo(x, 0);
       ctx.lineTo(x, canvas.height);
       ctx.stroke();
+      ctx.fillStyle = '#000';
+      ctx.font = '10px sans-serif';
+      ctx.fillText(b.toString(), x + 2, 10);
     }
     ctx.lineWidth = 1;
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -73,7 +73,7 @@
     <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-loop-start='{{ loop_start }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-loop-start='{{ loop_start }}' data-loop-end='{{ loop_end }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- respect loop start/end when loading clip data
- expose `loop_start` in handler and HTML
- draw clip contents relative to the loop in JS

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c07811e1c8325ae8e40a53fdedf34