### PR TITLE
Indicate looped section in Set Inspector

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -68,7 +68,11 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
         clip_obj = track_obj["clipSlots"][clip]["clip"]
         notes = clip_obj.get("notes", [])
         envelopes = clip_obj.get("envelopes", [])
-        region = clip_obj.get("region", {}).get("end", 4.0)
+        region_info = clip_obj.get("region", {})
+        region = region_info.get("end", 4.0)
+        loop_info = region_info.get("loop", {})
+        loop_start = loop_info.get("start", 0.0)
+        loop_end = loop_info.get("end", region)
         track_name = _track_display_name(track_obj, track)
         clip_name = clip_obj.get("name") or f"Clip {clip + 1}"
         param_map: Dict[int, str] = {}
@@ -122,6 +126,8 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
             "notes": notes,
             "envelopes": envelopes,
             "region": region,
+            "loop_start": loop_start,
+            "loop_end": loop_end,
             "param_map": param_map,
             "param_context": param_context,
             "param_ranges": param_ranges,

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -144,6 +144,8 @@ class SetInspectorHandler(BaseHandler):
                 "notes": [],
                 "envelopes": [],
                 "region": 4.0,
+                "loop_start": 0.0,
+                "loop_end": 4.0,
                 "param_ranges_json": "{}",
             }
         elif action == "show_clip":
@@ -192,6 +194,8 @@ class SetInspectorHandler(BaseHandler):
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
                 "region": result.get("region", 4.0),
+                "loop_start": result.get("loop_start", 0.0),
+                "loop_end": result.get("loop_end", result.get("region", 4.0)),
                 "param_ranges_json": json.dumps(result.get("param_ranges", {})),
                 "track_index": track_idx,
                 "clip_index": clip_idx,
@@ -257,6 +261,8 @@ class SetInspectorHandler(BaseHandler):
                 "notes": clip_data.get("notes", []),
                 "envelopes": envelopes,
                 "region": clip_data.get("region", 4.0),
+                "loop_start": clip_data.get("loop_start", 0.0),
+                "loop_end": clip_data.get("loop_end", clip_data.get("region", 4.0)),
                 "param_ranges_json": json.dumps(clip_data.get("param_ranges", {})),
                 "track_index": track_idx,
                 "clip_index": clip_idx,

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -32,6 +32,8 @@ export function initSetInspector() {
   const notes = JSON.parse(dataDiv.dataset.notes || '[]');
   const envelopes = JSON.parse(dataDiv.dataset.envelopes || '[]');
   const region = parseFloat(dataDiv.dataset.region || '4');
+  const loopStart = parseFloat(dataDiv.dataset.loopStart || '0');
+  const loopEnd = parseFloat(dataDiv.dataset.loopEnd || dataDiv.dataset.region || '4');
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
@@ -119,6 +121,14 @@ export function initSetInspector() {
       ctx.lineTo(canvas.width, y);
       ctx.stroke();
     }
+  }
+
+  function shadeUnlooped() {
+    ctx.fillStyle = 'rgba(0,0,0,0.1)';
+    const ls = (loopStart / region) * canvas.width;
+    const le = (loopEnd / region) * canvas.width;
+    if (ls > 0) ctx.fillRect(0, 0, ls, canvas.height);
+    if (le < canvas.width) ctx.fillRect(le, 0, canvas.width - le, canvas.height);
   }
 
   function drawLabels() {
@@ -216,6 +226,7 @@ export function initSetInspector() {
 
   function draw() {
     drawGrid();
+    shadeUnlooped();
     drawNotes();
     drawLabels();
     drawEnvelope();

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -73,7 +73,7 @@
     <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-loop-start='{{ loop_start }}' data-loop-end='{{ loop_end }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -292,4 +292,6 @@ def test_save_envelope(tmp_path):
     envs = data.get("envelopes", [])
     assert envs and envs[0]["parameterId"] == 1
     assert envs[0]["breakpoints"] == bps
+    assert data.get("loop_start") == 0.0
+    assert data.get("loop_end") == 4.0
 

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -716,6 +716,8 @@ def test_set_inspector_post(client, monkeypatch):
             'notes': [],
             'envelopes': [],
             'region': 4.0,
+            'loop_start': 0.0,
+            'loop_end': 4.0,
         }
     monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_post', fake_post)
     resp = client.post('/set-inspector', data={'action': 'select_set', 'pad_index': '1'})


### PR DESCRIPTION
## Summary
- return loop start/end information from `get_clip_data`
- include loop parameters in Set Inspector responses
- expose loop start/end in template data attributes
- shade unlooped areas of the clip in the Set Inspector canvas
- update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c0e0d327c83258a21a568ae067cbd