### PR TITLE
Integrate piano-roll for clip display

### DIFF
--- a/static/piano_roll.css
+++ b/static/piano_roll.css
@@ -1,0 +1,11 @@
+#pianoRoll {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+#pianoRoll .note {
+  position: absolute;
+  background: #0074D9;
+  opacity: 0.6;
+}

--- a/static/piano_roll.js
+++ b/static/piano_roll.js
@@ -1,0 +1,41 @@
+export class PianoRoll {
+  constructor(container, options = {}) {
+    this.container = container;
+    this.notes = options.notes || [];
+    this.region = options.region || 4.0;
+    this.draw();
+  }
+
+  getRange() {
+    if (!this.notes.length) return { min: 60, max: 71 };
+    let min = Math.min(...this.notes.map(n => n.noteNumber));
+    let max = Math.max(...this.notes.map(n => n.noteNumber));
+    if (max - min < 11) {
+      const extra = 11 - (max - min);
+      min = Math.max(0, min - Math.floor(extra / 2));
+      max = Math.min(127, max + Math.ceil(extra / 2));
+    }
+    return { min, max };
+  }
+
+  draw() {
+    const { min, max } = this.getRange();
+    const noteRange = max - min + 1;
+    const containerWidth = this.container.clientWidth;
+    const containerHeight = this.container.clientHeight;
+    const h = containerHeight / noteRange;
+    this.container.innerHTML = '';
+    this.notes.forEach(n => {
+      const el = document.createElement('div');
+      el.className = 'note';
+      const x = (n.startTime / this.region) * containerWidth;
+      const w = (n.duration / this.region) * containerWidth;
+      const y = containerHeight - (n.noteNumber - min + 1) * h;
+      el.style.left = x + 'px';
+      el.style.top = y + 'px';
+      el.style.width = w + 'px';
+      el.style.height = h + 'px';
+      this.container.appendChild(el);
+    });
+  }
+}

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -1,3 +1,5 @@
+import { PianoRoll } from './piano_roll.js';
+
 export function initSetInspector() {
   // Show selected set name when choosing a pad
   const grid = document.querySelector('#setSelectForm .pad-grid');
@@ -33,6 +35,7 @@ export function initSetInspector() {
   const envelopes = JSON.parse(dataDiv.dataset.envelopes || '[]');
   const region = parseFloat(dataDiv.dataset.region || '4');
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
+  const rollDiv = document.getElementById('pianoRoll');
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
   const envSelect = document.getElementById('envelope_select');
@@ -50,6 +53,7 @@ export function initSetInspector() {
   let currentEnv = [];
   let tailEnv = [];
   let envInfo = null;
+  let pianoRoll = rollDiv ? new PianoRoll(rollDiv, { notes, region }) : null;
 
   function isNormalized(env) {
     if (!env || !env.breakpoints || !env.breakpoints.length) return false;
@@ -216,7 +220,7 @@ export function initSetInspector() {
 
   function draw() {
     drawGrid();
-    drawNotes();
+    if (pianoRoll) pianoRoll.draw();
     drawLabels();
     drawEnvelope();
   }

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Move - Extended</title>
     <link rel="stylesheet" href="{{ host_prefix }}/static/style.css">
+    {% block extra_head %}{% endblock %}
 </head>
 <body class="page-{{ active_tab }}">
     <h1 id="header">Move - Extended</h1>

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block extra_head %}
+<link rel="stylesheet" href="{{ host_prefix }}/static/piano_roll.css">
+{% endblock %}
 {% block content %}
 <h2>Set Inspector</h2>
 <p><em>Note: This will edit your sets, and a broken set can't be loaded. Back up your sets before making modifications!</em></p>
@@ -70,7 +73,10 @@
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
-    <canvas id="clipCanvas" width="400" height="200" style="border:1px solid #ccc;"></canvas>
+    <div id="pianoRollContainer" style="position:relative; width:400px; height:200px; border:1px solid #ccc;">
+      <div id="pianoRoll" style="width:100%; height:100%;"></div>
+      <canvas id="clipCanvas" width="400" height="200" style="position:absolute; left:0; top:0; pointer-events:none;"></canvas>
+    </div>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:200px;"></div>
   </div>
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>


### PR DESCRIPTION
## Summary
- add a simple PianoRoll class and styles
- allow pages to add extra assets in `<head>`
- update Set Inspector template to use the piano roll
- render notes with PianoRoll instead of canvas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ced126f488325a83c10d8a1dc46a5