### PR TITLE
Add clip editor prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Here’s what you can do with Extending Move:
 - **Set Inspector**
   - View notes and envelopes for sets and clips
   - Edit envelopes and draw your own curves
+- **Clip Editor**
+  - Prototype piano-roll interface for editing notes and velocities
 
 - **Sample Reversal**
   - Create reversed versions of any WAV file

--- a/core/clip_editor_handler.py
+++ b/core/clip_editor_handler.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Utilities for the Clip Editor prototype."""
+
+from typing import Dict, List
+
+
+def get_default_clip() -> Dict[str, List[Dict[str, float]] | float | str]:
+    """Return a simple default clip with a few notes."""
+    notes = [
+        {"id": 1, "pitch": 60, "start": 0.0, "duration": 1.0, "velocity": 100},
+        {"id": 2, "pitch": 64, "start": 1.0, "duration": 1.0, "velocity": 100},
+        {"id": 3, "pitch": 67, "start": 2.0, "duration": 1.0, "velocity": 100},
+    ]
+    return {
+        "notes": notes,
+        "region": 4.0,
+        "message": "Use the canvas to edit notes",
+        "message_type": "info",
+    }
+

--- a/handlers/clip_editor_handler_class.py
+++ b/handlers/clip_editor_handler_class.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Handler for the Clip Editor prototype."""
+
+from handlers.base_handler import BaseHandler
+from core.clip_editor_handler import get_default_clip
+
+
+class ClipEditorHandler(BaseHandler):
+    """Provide clip data for the editor."""
+
+    def handle_get(self):
+        return get_default_clip()
+
+    def handle_post(self, form):
+        # Prototype does not yet support saving
+        return self.format_error_response("Saving not implemented")
+

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -47,6 +47,7 @@ from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
+from handlers.clip_editor_handler_class import ClipEditorHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -137,6 +138,7 @@ adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
 set_inspector_handler = SetInspectorHandler()
+clip_editor_handler = ClipEditorHandler()
 
 
 @app.before_request
@@ -415,6 +417,21 @@ def lfo_route():
         message_type=message_type,
         defaults=defaults,
         active_tab="lfo",
+    )
+
+
+@app.route("/clip-editor", methods=["GET"])
+def clip_editor_route():
+    result = clip_editor_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    return render_template(
+        "clip_editor.html",
+        message=message,
+        message_type=message_type,
+        notes=result.get("notes", []),
+        region=result.get("region", 4.0),
+        active_tab="clip-editor",
     )
 
 

--- a/static/clip_editor.js
+++ b/static/clip_editor.js
@@ -1,0 +1,170 @@
+function snap(val, res) {
+  return Math.round(val / res) * res;
+}
+
+function isInNote(x, y, note) {
+  return (
+    x >= note.start &&
+    x <= note.start + note.duration &&
+    y >= note.pitch - 0.5 &&
+    y <= note.pitch + 0.5
+  );
+}
+
+export function initClipEditor() {
+  const dataDiv = document.getElementById('clipData');
+  const notes = JSON.parse(dataDiv.dataset.notes || '[]');
+  const region = parseFloat(dataDiv.dataset.region || '4');
+
+  const gridCanvas = document.getElementById('grid');
+  const rulerCanvas = document.getElementById('ruler');
+  const pianoCanvas = document.getElementById('piano');
+  const velCanvas = document.getElementById('velocity');
+
+  const gCtx = gridCanvas.getContext('2d');
+  const rCtx = rulerCanvas.getContext('2d');
+  const pCtx = pianoCanvas.getContext('2d');
+  const vCtx = velCanvas.getContext('2d');
+
+  const state = {
+    notes,
+    selection: new Set(),
+    playhead: 0,
+    grid: { resolution: 0.25, snap: true },
+    zoom: { x: 1, y: 1 },
+    scroll: { x: 0, y: 0 },
+  };
+
+  const noteHeight = gridCanvas.height / 12;
+
+  function drawBackground() {
+    gCtx.clearRect(0, 0, gridCanvas.width, gridCanvas.height);
+    for (let b = 0; b <= region; b += state.grid.resolution) {
+      const x = (b / region) * gridCanvas.width;
+      gCtx.strokeStyle = b % 1 === 0 ? '#999' : '#ddd';
+      gCtx.beginPath();
+      gCtx.moveTo(x, 0);
+      gCtx.lineTo(x, gridCanvas.height);
+      gCtx.stroke();
+    }
+    for (let p = 0; p < 128; p++) {
+      const y = gridCanvas.height - (p + 1) * noteHeight;
+      gCtx.strokeStyle = p % 12 === 0 ? '#ccc' : '#eee';
+      gCtx.beginPath();
+      gCtx.moveTo(0, y);
+      gCtx.lineTo(gridCanvas.width, y);
+      gCtx.stroke();
+    }
+  }
+
+  function drawNotes() {
+    gCtx.fillStyle = '#0074D9';
+    state.notes.forEach(n => {
+      const x = (n.start / region) * gridCanvas.width;
+      const w = (n.duration / region) * gridCanvas.width;
+      const y = gridCanvas.height - (n.pitch + 1) * noteHeight;
+      gCtx.fillRect(x, y, w, noteHeight);
+      if (state.selection.has(n.id)) {
+        gCtx.strokeStyle = '#FF4136';
+        gCtx.strokeRect(x, y, w, noteHeight);
+      }
+    });
+  }
+
+  function drawVelocity() {
+    vCtx.clearRect(0, 0, velCanvas.width, velCanvas.height);
+    state.notes.forEach(n => {
+      const x = (n.start / region) * velCanvas.width;
+      const w = (n.duration / region) * velCanvas.width;
+      const h = (n.velocity / 127) * velCanvas.height;
+      vCtx.fillStyle = state.selection.has(n.id) ? '#FF4136' : '#888';
+      vCtx.fillRect(x, velCanvas.height - h, w, h);
+    });
+  }
+
+  function drawRuler() {
+    rCtx.clearRect(0, 0, rulerCanvas.width, rulerCanvas.height);
+    rCtx.fillStyle = '#000';
+    for (let b = 0; b <= region; b++) {
+      const x = (b / region) * rulerCanvas.width;
+      rCtx.fillText(b.toString(), x + 2, 10);
+    }
+    rCtx.strokeStyle = '#FF4136';
+    const x = (state.playhead / region) * rulerCanvas.width;
+    rCtx.beginPath();
+    rCtx.moveTo(x, 0);
+    rCtx.lineTo(x, rulerCanvas.height);
+    rCtx.stroke();
+  }
+
+  function drawPiano() {
+    pCtx.clearRect(0, 0, pianoCanvas.width, pianoCanvas.height);
+    for (let p = 0; p < 128; p++) {
+      const y = pianoCanvas.height - (p + 1) * noteHeight;
+      pCtx.fillStyle = p % 12 === 0 ? '#bbb' : '#eee';
+      pCtx.fillRect(0, y, pianoCanvas.width, noteHeight);
+      if (p % 12 === 0) {
+        const octave = Math.floor(p / 12) - 1;
+        pCtx.fillStyle = '#000';
+        pCtx.fillText('C' + octave, 2, y + noteHeight - 2);
+      }
+    }
+  }
+
+  function draw() {
+    drawBackground();
+    drawNotes();
+    drawVelocity();
+    drawRuler();
+    drawPiano();
+  }
+
+  let currentNote = null;
+  function canvasPos(ev) {
+    const rect = gridCanvas.getBoundingClientRect();
+    return {
+      x: ev.clientX - rect.left,
+      y: ev.clientY - rect.top,
+    };
+  }
+
+  gridCanvas.addEventListener('mousedown', ev => {
+    const pos = canvasPos(ev);
+    const time = (pos.x / gridCanvas.width) * region;
+    const pitch = 127 - Math.floor(pos.y / noteHeight);
+    currentNote = {
+      id: Date.now(),
+      pitch,
+      start: snap(time, state.grid.resolution),
+      duration: state.grid.resolution,
+      velocity: 100,
+    };
+    state.notes.push(currentNote);
+    state.selection = new Set([currentNote.id]);
+    draw();
+  });
+
+  gridCanvas.addEventListener('mousemove', ev => {
+    if (!currentNote) return;
+    const pos = canvasPos(ev);
+    const time = (pos.x / gridCanvas.width) * region;
+    const dur = snap(time, state.grid.resolution) - currentNote.start;
+    currentNote.duration = Math.max(state.grid.resolution, dur);
+    draw();
+  });
+
+  document.addEventListener('mouseup', () => {
+    currentNote = null;
+  });
+
+  rulerCanvas.addEventListener('mousedown', ev => {
+    const rect = rulerCanvas.getBoundingClientRect();
+    const x = ev.clientX - rect.left;
+    state.playhead = (x / rulerCanvas.width) * region;
+    drawRuler();
+  });
+
+  draw();
+}
+
+document.addEventListener('DOMContentLoaded', initClipEditor);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -19,6 +19,7 @@
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
+        <a href="{{ host_prefix }}/clip-editor" class="{% if active_tab == 'clip-editor' %}active{% endif %}">Clip Editor</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
         <!-- <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a> -->

--- a/templates_jinja/clip_editor.html
+++ b/templates_jinja/clip_editor.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Clip Editor</h2>
+{% if message %}
+  <p class="{{ message_type }}">{{ message }}</p>
+{% endif %}
+<div style="display:flex; gap:0.5rem;">
+  <canvas id="piano" width="60" height="240" style="border:1px solid #ccc;"></canvas>
+  <div>
+    <canvas id="ruler" width="600" height="20" style="border:1px solid #ccc;"></canvas>
+    <canvas id="grid" width="600" height="240" style="border:1px solid #ccc;"></canvas>
+    <canvas id="velocity" width="600" height="80" style="border:1px solid #ccc;"></canvas>
+  </div>
+</div>
+<div id="clipData" data-notes='{{ notes | tojson }}' data-region='{{ region }}'></div>
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ host_prefix }}/static/clip_editor.js"></script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- prototype Clip Editor feature with simple piano-roll
- integrate handler, route, template, JS, and sample data
- link Clip Editor in navigation
- document new page in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cedd8663c8325a968d52e88b22e37