### PR TITLE
Fix loop marker display

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -64,9 +64,9 @@ export function initSetInspector() {
       n: n.noteNumber,
       g: Math.round(n.duration * ticksPerBeat)
     }));
-    if (!piano.hasAttribute('xrange')) piano.xrange = region * ticksPerBeat;
-    if (!piano.hasAttribute('markstart')) piano.markstart = loopStart * ticksPerBeat;
-    if (!piano.hasAttribute('markend')) piano.markend = loopEnd * ticksPerBeat;
+    piano.xrange = region * ticksPerBeat;
+    piano.markstart = loopStart * ticksPerBeat;
+    piano.markend = loopEnd * ticksPerBeat;
     const { min, max } = notes.length
       ? { min: Math.min(...notes.map(n => n.noteNumber)),
           max: Math.max(...notes.map(n => n.noteNumber)) }


### PR DESCRIPTION
## Summary
- always set pianoroll range and markers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d15bdb790832599dec0191c9bedf6