### PR TITLE
Fix clip loop marker display

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -64,9 +64,15 @@ export function initSetInspector() {
       n: n.noteNumber,
       g: Math.round(n.duration * ticksPerBeat)
     }));
-    if (!piano.hasAttribute('xrange')) piano.xrange = region * ticksPerBeat;
-    if (!piano.hasAttribute('markstart')) piano.markstart = loopStart * ticksPerBeat;
-    if (!piano.hasAttribute('markend')) piano.markend = loopEnd * ticksPerBeat;
+    // Always update the visible region and loop markers with the
+    // values read from the clip. Previously these properties were
+    // only set when the element lacked the corresponding attribute,
+    // which meant switching clips could leave stale loop points
+    // displayed.  Setting them unconditionally ensures the piano
+    // roll always reflects the loaded clip data.
+    piano.xrange = region * ticksPerBeat;
+    piano.markstart = loopStart * ticksPerBeat;
+    piano.markend = loopEnd * ticksPerBeat;
     const { min, max } = notes.length
       ? { min: Math.min(...notes.map(n => n.noteNumber)),
           max: Math.max(...notes.map(n => n.noteNumber)) }


### PR DESCRIPTION
## Summary
- fix piano roll loop markers in Set Inspector

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'mido', 'requests', 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684d218116688325a39932f7e026b09e