### PR TITLE
Fix loop marker initialization

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -65,8 +65,8 @@ export function initSetInspector() {
       g: Math.round(n.duration * ticksPerBeat)
     }));
     if (!piano.hasAttribute('xrange')) piano.xrange = region * ticksPerBeat;
-    if (!piano.hasAttribute('markstart')) piano.markstart = loopStart * ticksPerBeat;
-    if (!piano.hasAttribute('markend')) piano.markend = loopEnd * ticksPerBeat;
+    piano.markstart = loopStart * ticksPerBeat;
+    piano.markend = loopEnd * ticksPerBeat;
     const { min, max } = notes.length
       ? { min: Math.min(...notes.map(n => n.noteNumber)),
           max: Math.max(...notes.map(n => n.noteNumber)) }


### PR DESCRIPTION
## Summary
- ensure loop markers are set when loading clip data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d218116688325a39932f7e026b09e