### PR TITLE
Adjust drag zoom sensitivity

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -890,7 +890,8 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             case "X":
                 var dy=this.dragging.y0-pos.y;
                 var dx=this.dragging.x0-pos.x;
-                var f=Math.pow(1.01,dy);
+                var dz=Math.abs(dy)>5?(dy>0?dy-5:dy+5):0;
+                var f=Math.pow(1.01,dz/2);
                 this.xrange=this.dragging.range/f;
                 this.xoffset=this.dragging.t-(this.dragging.t-this.dragging.off)/f;
                 this.xoffset+=dx*(this.xrange/this.width);
@@ -899,7 +900,8 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             case "Y":
                 var dx=this.dragging.x0-pos.x;
                 var dy=pos.y-this.dragging.y0;
-                var f=Math.pow(1.01,dx);
+                var dz=Math.abs(dx)>5?(dx>0?dx-5:dx+5):0;
+                var f=Math.pow(1.01,dz/2);
                 this.yrange=this.dragging.range/f;
                 this.yoffset=this.dragging.n-(this.dragging.n-this.dragging.off)/f;
                 this.yoffset+=dy*(this.yrange/this.height);


### PR DESCRIPTION
## Summary
- reduce zoom sensitivity when dragging in clip editor
- add 5px dead zone before zoom engages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d70b9a7408325ada6dc6b7388b18f