### PR TITLE
Add dblclick zoom reset for clip editor

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -74,6 +74,27 @@ export function initSetInspector() {
     piano.yoffset = Math.max(0, min - 2);
     piano.yrange = Math.max(12, max - min + 5);
     if (piano.redraw) piano.redraw();
+
+    piano.addEventListener('dblclick', ev => {
+      const rect = piano.getBoundingClientRect();
+      const x = ev.clientX - rect.left;
+      const y = ev.clientY - rect.top;
+      if (y < piano.xruler) {
+        piano.xoffset = 0;
+        piano.xrange = region * ticksPerBeat;
+        if (piano.redraw) piano.redraw();
+        return;
+      }
+      if (x < piano.yruler + piano.kbwidth) {
+        const { min, max } = notes.length
+          ? { min: Math.min(...notes.map(n => n.noteNumber)),
+              max: Math.max(...notes.map(n => n.noteNumber)) }
+          : { min: 60, max: 71 };
+        piano.yoffset = Math.max(0, min - 2);
+        piano.yrange = Math.max(12, max - min + 5);
+        if (piano.redraw) piano.redraw();
+      }
+    });
   }
 
   function isNormalized(env) {

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -62,7 +62,7 @@
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">
-      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="1" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}"></webaudio-pianoroll>
+      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}"></webaudio-pianoroll>
       <canvas id="clipCanvas" width="836" height="300" style="position:absolute; left:64px; top:0; pointer-events:none;"></canvas>
     </div>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:300px;"></div>


### PR DESCRIPTION
## Summary
- disable scroll wheel zoom on the pianoroll
- allow double-clicking the header to reset horizontal view
- allow double-clicking the sidebar to fit all notes vertically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684d741a705483258288e46ee998265d