### PR TITLE
Fix note labels scaling on Y zoom

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1081,7 +1081,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.redrawYRuler=function(){
             if(this.yruler){
                 this.ctx.textAlign="right";
-                this.ctx.font=(this.steph/2)+"px 'sans-serif'";
+                this.ctx.font="10px 'sans-serif'";
                 this.ctx.fillStyle=this.colrulerbg;
                 this.ctx.fillRect(0,this.xruler,this.yruler,this.sheight);
                 this.ctx.fillStyle=this.colrulerborder;
@@ -1104,7 +1104,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.redrawKeyboard=function(){
             if(this.yruler){
                 this.ctx.textAlign="right";
-                this.ctx.font=(this.steph/2)+"px 'sans-serif'";
+                this.ctx.font="10px 'sans-serif'";
                 this.ctx.fillStyle=this.colortab.kbwh;
                 this.ctx.fillRect(1,this.xruler,this.yruler,this.sheight);
                 this.ctx.fillStyle=this.colortab.kbbk;


### PR DESCRIPTION
## Summary
- keep note labels at a fixed font size when zooming in the clip editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d748183ec8325b7bb20052dc039c0