### PR TITLE
Add toggle to hide clip editor playback cursor

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -67,6 +67,7 @@ export function initSetInspector() {
     if (!piano.hasAttribute('xrange')) piano.xrange = region * ticksPerBeat;
     if (!piano.hasAttribute('markstart')) piano.markstart = loopStart * ticksPerBeat;
     if (!piano.hasAttribute('markend')) piano.markend = loopEnd * ticksPerBeat;
+    piano.showcursor = false;
     const { min, max } = notes.length
       ? { min: Math.min(...notes.map(n => n.noteNumber)),
           max: Math.max(...notes.map(n => n.noteNumber)) }

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -63,6 +63,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 bgsrc:              {type:String, value:null, observer:'layout'},
                 cursorsrc:          {type:String, value:"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJub25lIj4NCjxwYXRoIGZpbGw9InJnYmEoMjU1LDEwMCwxMDAsMC44KSIgZD0iTTAsMSAyNCwxMiAwLDIzIHoiLz4NCjwvc3ZnPg0K"},
                 cursoroffset:       {type:Number, value:0},
+                showcursor:         {type:Boolean, value:true, observer:'toggleCursor'},
                 markstartsrc:       {type:String, value:"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4NCjxwYXRoIGZpbGw9IiMwYzAiIGQ9Ik0wLDEgMjQsMSAwLDIzIHoiLz4NCjwvc3ZnPg0K"},
                 markstartoffset:    {type:Number, value:0},
                 markendsrc:         {type:String, value:"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4NCjxwYXRoIGZpbGw9IiMwYzAiIGQ9Ik0wLDEgMjQsMSAyNCwyMyB6Ii8+DQo8L3N2Zz4NCg=="},
@@ -691,7 +692,13 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             this.kbimg.style.backgroundSize=(this.steph*12)+"px";
             this.layout();
             this.initialized=1;
+            this.toggleCursor();
             this.redraw();
+        };
+        this.toggleCursor=function(){
+            if(!this.cursorimg)
+                return;
+            this.cursorimg.style.display=this.showcursor?"block":"none";
         };
         this.setupImage=function(){
         };
@@ -1032,7 +1039,9 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             if(!this.initialized)
                 return;
             const cur=(this.cursor-this.xoffset)*this.stepw+this.yruler+this.kbwidth;
-            this.cursorimg.style.left=(cur+this.cursoroffset)+"px";
+            if(this.showcursor){
+                this.cursorimg.style.left=(cur+this.cursoroffset)+"px";
+            }
             const start=(this.markstart-this.xoffset)*this.stepw+this.yruler+this.kbwidth;
             this.markstartimg.style.left=(start+this.markstartoffset)+"px";
             const end=(this.markend-this.xoffset)*this.stepw+this.yruler+this.kbwidth;

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -62,7 +62,7 @@
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">
-      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}"></webaudio-pianoroll>
+      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
       <canvas id="clipCanvas" width="836" height="300" style="position:absolute; left:64px; top:0; pointer-events:none;"></canvas>
     </div>
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:300px;"></div>


### PR DESCRIPTION
## Summary
- allow hiding the playback cursor in `webaudio-pianoroll`
- hide the playback cursor in the set inspector clip editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d75a12e008325a2c50222e2944e7e