### PR TITLE
Add pitch bend viewer

### DIFF
--- a/core/pitch_bend_handler.py
+++ b/core/pitch_bend_handler.py
@@ -1,0 +1,59 @@
+import json
+from typing import List, Dict, Any
+
+from core.set_inspector_handler import get_clip_data
+
+PITCH_UNIT = 170.6458282470703
+BASE_NOTE = 36  # C2
+
+
+def extract_pitch_segments(notes: List[Dict[str, Any]], pad_note: int,
+                           unit: float = PITCH_UNIT,
+                           base: int = BASE_NOTE) -> List[Dict[str, Any]]:
+    """Convert pitch bend automation into note segments for display."""
+    segments: List[Dict[str, Any]] = []
+    for note in notes:
+        if int(note.get("noteNumber", -1)) != pad_note:
+            continue
+        start = float(note.get("startTime", 0.0))
+        duration = float(note.get("duration", 0.0))
+        pb_list = note.get("automations", {}).get("PitchBend", [])
+        pb_list = sorted(pb_list, key=lambda x: x.get("time", 0.0))
+        # Ensure we cover entire note duration
+        if not pb_list:
+            pb_list = [{"time": 0.0, "value": 0.0}]
+        if pb_list[-1].get("time", 0.0) < duration:
+            pb_list.append({"time": duration, "value": pb_list[-1].get("value", 0.0)})
+        prev_time = 0.0
+        prev_val = pb_list[0].get("value", 0.0)
+        for bp in pb_list[1:]:
+            seg_start = start + prev_time
+            seg_dur = bp.get("time", 0.0) - prev_time
+            semi = int(round(prev_val / unit))
+            note_num = base + semi
+            segments.append({
+                "noteNumber": note_num,
+                "startTime": seg_start,
+                "duration": seg_dur,
+                "velocity": note.get("velocity", 1.0),
+                "offVelocity": note.get("offVelocity", 0.0),
+            })
+            prev_time = bp.get("time", 0.0)
+            prev_val = bp.get("value", 0.0)
+    return segments
+
+
+def get_pad_pitch_data(set_path: str, track: int, clip: int, pad_note: int) -> Dict[str, Any]:
+    """Load a clip and return pitch bend note segments for a pad."""
+    clip_data = get_clip_data(set_path, track, clip)
+    if not clip_data.get("success"):
+        return clip_data
+    notes = clip_data.get("notes", [])
+    segments = extract_pitch_segments(notes, pad_note)
+    return {
+        "success": True,
+        "message": clip_data.get("message", ""),
+        "segments": segments,
+        "clip_name": clip_data.get("clip_name"),
+        "track_name": clip_data.get("track_name"),
+    }

--- a/handlers/pitch_bend_viewer_handler_class.py
+++ b/handlers/pitch_bend_viewer_handler_class.py
@@ -1,0 +1,36 @@
+from handlers.base_handler import BaseHandler
+from core.pitch_bend_handler import get_pad_pitch_data
+
+class PitchBendViewerHandler(BaseHandler):
+    def handle_get(self):
+        return {
+            "message": "Select a set and clip to view pitch bends",
+            "segments": [],
+            "set_path": "",
+            "track_idx": 0,
+            "clip_idx": 0,
+            "pad_note": 36,
+        }
+
+    def handle_post(self, form):
+        action = form.getvalue("action")
+        set_path = form.getvalue("set_path")
+        track_idx = int(form.getvalue("track_idx") or 0)
+        clip_idx = int(form.getvalue("clip_idx") or 0)
+        pad_note = int(form.getvalue("pad_note") or 36)
+
+        if action == "load":
+            if not set_path:
+                return self.format_error_response("Set path required")
+            result = get_pad_pitch_data(set_path, track_idx, clip_idx, pad_note)
+            if not result.get("success"):
+                return self.format_error_response(result.get("message"))
+            return {
+                "message": result.get("message"),
+                "segments": result.get("segments"),
+                "set_path": set_path,
+                "track_idx": track_idx,
+                "clip_idx": clip_idx,
+                "pad_note": pad_note,
+            }
+        return self.format_error_response("Unknown action")

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -47,6 +47,7 @@ from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
+from handlers.pitch_bend_viewer_handler_class import PitchBendViewerHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -137,6 +138,7 @@ adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
 set_inspector_handler = SetInspectorHandler()
+pitch_bend_viewer_handler = PitchBendViewerHandler()
 
 
 @app.before_request
@@ -349,6 +351,28 @@ def set_inspector_route():
         loop_end=result.get("loop_end", result.get("region")),
         param_ranges_json=result.get("param_ranges_json", "{}"),
         active_tab="set-inspector",
+    )
+
+
+@app.route("/pitchbend-viewer", methods=["GET", "POST"])
+def pitchbend_viewer_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = pitch_bend_viewer_handler.handle_post(form)
+    else:
+        result = pitch_bend_viewer_handler.handle_get()
+    message = result.get("message")
+    success = result.get("success", True)
+    return render_template(
+        "pitchbend_viewer.html",
+        message=message,
+        segments=result.get("segments"),
+        set_path=result.get("set_path"),
+        track_idx=result.get("track_idx"),
+        clip_idx=result.get("clip_idx"),
+        pad_note=result.get("pad_note"),
+        success=success,
+        active_tab="pitchbend-viewer",
     )
 
 

--- a/static/pitchbend_viewer.js
+++ b/static/pitchbend_viewer.js
@@ -1,0 +1,19 @@
+export function initPitchViewer() {
+  const dataDiv = document.getElementById('pitchData');
+  const piano = document.getElementById('pitchRoll');
+  if (!dataDiv || !piano) return;
+  const segs = JSON.parse(dataDiv.dataset.segments || '[]');
+  const tpq = parseInt(piano.getAttribute('timebase') || '16', 10) / 4;
+  piano.sequence = segs.map(s => ({
+    t: Math.round(s.startTime * tpq),
+    n: s.noteNumber,
+    g: Math.round(s.duration * tpq)
+  }));
+  const end = segs.reduce((m, s) => Math.max(m, s.startTime + s.duration), 4);
+  piano.xrange = end * tpq;
+  piano.yoffset = 24;
+  piano.yrange = 48;
+  if (piano.redraw) piano.redraw();
+}
+
+document.addEventListener('DOMContentLoaded', initPitchViewer);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -19,6 +19,7 @@
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
+        <a href="{{ host_prefix }}/pitchbend-viewer" class="{% if active_tab == 'pitchbend-viewer' %}active{% endif %}">Pitchbend</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
         <!-- <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a> -->

--- a/templates_jinja/pitchbend_viewer.html
+++ b/templates_jinja/pitchbend_viewer.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Pitch Bend Viewer</h2>
+{% if message %}<p>{{ message }}</p>{% endif %}
+<form method="post" action="{{ host_prefix }}/pitchbend-viewer">
+  <input type="hidden" name="action" value="load">
+  <label>Set Path: <input type="text" name="set_path" value="{{ set_path }}" size="60"></label><br>
+  <label>Track Index: <input type="number" name="track_idx" value="{{ track_idx }}"></label><br>
+  <label>Clip Index: <input type="number" name="clip_idx" value="{{ clip_idx }}"></label><br>
+  <label>Pad Note: <input type="number" name="pad_note" value="{{ pad_note }}"></label><br>
+  <button type="submit">Load</button>
+</form>
+{% if segments %}
+<div id="pitchData" data-segments='{{ segments | tojson }}'></div>
+<webaudio-pianoroll id="pitchRoll" width="800" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16"></webaudio-pianoroll>
+{% endif %}
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/webaudio-pianoroll.js"></script>
+<script type="module" src="{{ host_prefix }}/static/pitchbend_viewer.js"></script>
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -744,4 +744,32 @@ def test_set_inspector_post(client, monkeypatch):
     assert resp.status_code == 200
 
 
+def test_pitchbend_viewer_get(client):
+    resp = client.get('/pitchbend-viewer')
+    assert resp.status_code == 200
+    assert b'Pitch Bend Viewer' in resp.data
+
+
+def test_pitchbend_viewer_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'message': 'ok',
+            'segments': [],
+            'set_path': '/tmp/a.abl',
+            'track_idx': 0,
+            'clip_idx': 0,
+            'pad_note': 36,
+        }
+    monkeypatch.setattr(move_webserver.pitch_bend_viewer_handler, 'handle_post', fake_post)
+    resp = client.post('/pitchbend-viewer', data={
+        'action': 'load',
+        'set_path': '/tmp/a.abl',
+        'track_idx': '0',
+        'clip_idx': '0',
+        'pad_note': '36'
+    })
+    assert resp.status_code == 200
+    assert b'ok' in resp.data
+
+
 


### PR DESCRIPTION
## Summary
- add new core helper to read pitchbend automation
- add `PitchBendViewerHandler` for a simple UI
- add `pitchbend-viewer` route and link
- add basic JS + template to render pitch bend segments
- test new Flask route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da3cc23d48325a556d41672fe3d09