### PR TITLE
Add drum pad pitch bend subclip view

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -35,6 +35,7 @@ export function initSetInspector() {
   const loopStart = parseFloat(dataDiv.dataset.loopStart || '0');
   const loopEnd = parseFloat(dataDiv.dataset.loopEnd || String(region));
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
+  const pitchMode = dataDiv.dataset.pitchMode === '1';
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
   const piano = document.getElementById('clipEditor');
@@ -62,6 +63,11 @@ export function initSetInspector() {
   const loopStartInput = document.getElementById('loop_start_input');
   const loopEndInput = document.getElementById('loop_end_input');
 
+  if (pitchMode) {
+    if (envSelect) envSelect.disabled = true;
+    if (legendDiv) legendDiv.style.display = 'none';
+  }
+
   let editing = false;
   let drawing = false;
   let dirty = false;
@@ -72,7 +78,7 @@ export function initSetInspector() {
   let clipModified = false;
 
   function updateSaveButton() {
-    if (saveClipBtn) saveClipBtn.disabled = !clipModified;
+    if (saveClipBtn) saveClipBtn.disabled = pitchMode || !clipModified;
   }
 
   if (saveClipBtn) saveClipBtn.disabled = true;
@@ -127,6 +133,9 @@ export function initSetInspector() {
   }
 
   const defaultEditMode = piano ? (piano.editmode || piano.getAttribute('editmode') || 'dragpoly') : 'dragpoly';
+  if (pitchMode && piano) {
+    piano.editmode = '';
+  }
 
   function updateControls() {
     if (canvas) {

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -60,6 +60,19 @@
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
   </div>
+  {% if pad_note_options %}
+  <form id="pitchSelectForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
+    <input type="hidden" name="action" value="show_pitchbend">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+    <label for="pad_note_select">Pad:</label>
+    <select name="pad_note" id="pad_note_select">{{ pad_note_options | safe }}</select>
+    <button type="submit">View Pitch Bends</button>
+  </form>
+  {% endif %}
+  {% if pitch_mode %}
+  <p style="margin-top:0.5rem;"><em>Pitch bend view for Pad {{ pad_note }}. Saving disabled.</em></p>
+  {% endif %}
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">
       <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
@@ -76,9 +89,9 @@
     <input type="hidden" name="region_end" id="region_end_input">
     <input type="hidden" name="loop_start" id="loop_start_input">
     <input type="hidden" name="loop_end" id="loop_end_input">
-    <button id="saveClipBtn" type="submit">Save Clip</button>
+    <button id="saveClipBtn" type="submit"{% if pitch_mode %} disabled{% endif %}>Save Clip</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitch-mode='{{ 1 if pitch_mode else 0 }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -81,3 +81,31 @@ def test_get_clip_data_param_ranges(monkeypatch, tmp_path):
     assert data["param_ranges"][1]["max"] == 1.0
     env = data["envelopes"][0]
     assert env["rangeMin"] == 0.0 and env["rangeMax"] == 1.0
+
+
+def test_extract_pitchbend_notes():
+    notes = [{
+        "noteNumber": 40,
+        "startTime": 0.0,
+        "duration": 1.0,
+        "velocity": 1.0,
+        "offVelocity": 0.0,
+        "automations": {
+            "PitchBend": [
+                {"time": 0.0, "value": sih.PITCHBEND_STEP},
+                {"time": 0.5, "value": 0.0}
+            ]
+        }
+    }]
+    pb = sih.extract_pitchbend_notes(notes, 40)
+    assert len(pb) == 2
+    assert pb[0]["noteNumber"] == sih.PITCHBEND_BASE_NOTE + 1
+    assert abs(pb[1]["startTime"] - 0.5) < 1e-6
+
+
+def test_get_pitchbend_pad_notes():
+    notes = [
+        {"noteNumber": 38, "automations": {"PitchBend": [{"time": 0.0, "value": 0}]}}
+    ]
+    pads = sih.get_pitchbend_pad_notes(notes)
+    assert pads == [38]


### PR DESCRIPTION
## Summary
- support extracting pitch-bend info from clip notes
- expose pitch-bend pads in set inspector handler
- add a `show_pitchbend` action and pad selector UI in the set inspector
- disable editing and saving when viewing pitch bends
- tests for new pitch-bend utilities

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da3cc23d48325a556d41672fe3d09