### PR TITLE
Add pitch bend pad view

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -88,6 +88,7 @@ class SetInspectorHandler(BaseHandler):
             "loop_start": 0.0,
             "loop_end": 4.0,
             "param_ranges_json": "{}",
+            "pitch_pads": [],
         }
 
     def handle_post(self, form):
@@ -149,6 +150,7 @@ class SetInspectorHandler(BaseHandler):
                 "loop_start": 0.0,
                 "loop_end": 4.0,
                 "param_ranges_json": "{}",
+                "pitch_pads": [],
             }
         elif action == "show_clip":
             set_path = form.getvalue("set_path")
@@ -199,6 +201,7 @@ class SetInspectorHandler(BaseHandler):
                 "loop_start": result.get("loop_start", 0.0),
                 "loop_end": result.get("loop_end", 4.0),
                 "param_ranges_json": json.dumps(result.get("param_ranges", {})),
+                "pitch_pads": result.get("pitch_pads", []),
                 "track_index": track_idx,
                 "clip_index": clip_idx,
                 "track_name": result.get("track_name"),
@@ -266,6 +269,7 @@ class SetInspectorHandler(BaseHandler):
                 "loop_start": clip_data.get("loop_start", 0.0),
                 "loop_end": clip_data.get("loop_end", 4.0),
                 "param_ranges_json": json.dumps(clip_data.get("param_ranges", {})),
+                "pitch_pads": clip_data.get("pitch_pads", []),
                 "track_index": track_idx,
                 "clip_index": clip_idx,
                 "track_name": clip_data.get("track_name"),
@@ -354,6 +358,7 @@ class SetInspectorHandler(BaseHandler):
                 "loop_start": clip_data.get("loop_start", 0.0),
                 "loop_end": clip_data.get("loop_end", 4.0),
                 "param_ranges_json": json.dumps(clip_data.get("param_ranges", {})),
+                "pitch_pads": clip_data.get("pitch_pads", []),
                 "track_index": track_idx,
                 "clip_index": clip_idx,
                 "track_name": clip_data.get("track_name"),

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -60,6 +60,15 @@
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
   </div>
+  <div style="margin-top:0.5rem; display:flex; align-items:center;">
+    <label for="pad_pitch_select">Pitch Pad:</label>
+    <select id="pad_pitch_select">
+      <option value="">Main Clip</option>
+      {% for p in pitch_pads %}
+        <option value="{{ p }}">{{ p }}</option>
+      {% endfor %}
+    </select>
+  </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">
       <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
@@ -78,7 +87,7 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitch-pads='{{ pitch_pads | default([]) | tojson }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- handle drum note pitch bend data in set inspector core logic
- surface pads with pitch bend automation
- add Pitch Pad selector to inspector template
- allow viewing & editing pad pitch bends in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da66af2dc832586d61c2750be8cd8