### PR TITLE
Add drum pad pitch editor

### DIFF
--- a/core/pad_pitch_handler.py
+++ b/core/pad_pitch_handler.py
@@ -1,0 +1,101 @@
+import json
+from typing import Any, Dict, List
+from .utils import midi_to_note_name
+
+SEMITONE_VALUE = 170.6458282470703
+BASE_NOTE = 36  # C2
+
+
+def _load_song(set_path: str) -> Dict[str, Any]:
+    with open(set_path, "r") as f:
+        return json.load(f)
+
+
+def _save_song(set_path: str, data: Dict[str, Any]) -> None:
+    with open(set_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def pads_with_pitch(notes: List[Dict[str, Any]]) -> Dict[int, bool]:
+    """Return mapping of pad note numbers to whether they contain pitch bend."""
+    result: Dict[int, bool] = {}
+    for n in notes:
+        pad = int(n.get("noteNumber", 0))
+        has = bool(n.get("automations", {}).get("PitchBend"))
+        result[pad] = result.get(pad, False) or has
+    return result
+
+
+def extract_pad_clip(set_path: str, track: int, clip: int, pad: int) -> Dict[str, Any]:
+    """Return pitch-converted notes for a specific pad."""
+    song = _load_song(set_path)
+    clip_obj = song["tracks"][track]["clipSlots"][clip]["clip"]
+    region_info = clip_obj.get("region", {})
+    region_end = region_info.get("end", 4.0)
+    loop_info = region_info.get("loop", {})
+    loop_start = loop_info.get("start", 0.0)
+    loop_end = loop_info.get("end", region_end)
+
+    out_notes = []
+    for n in clip_obj.get("notes", []):
+        if int(n.get("noteNumber", 0)) != pad:
+            continue
+        pb = 0.0
+        pb_list = n.get("automations", {}).get("PitchBend")
+        if pb_list and isinstance(pb_list, list):
+            pb = float(pb_list[0].get("value", 0.0))
+        new_note = {
+            "noteNumber": int(round(BASE_NOTE + pb / SEMITONE_VALUE)),
+            "startTime": n.get("startTime", 0.0),
+            "duration": n.get("duration", 0.0),
+            "velocity": n.get("velocity", 1.0),
+            "offVelocity": n.get("offVelocity", 0.0),
+        }
+        out_notes.append(new_note)
+
+    track_name = song["tracks"][track].get("name")
+    clip_name = clip_obj.get("name")
+
+    return {
+        "success": True,
+        "notes": out_notes,
+        "region": region_end,
+        "loop_start": loop_start,
+        "loop_end": loop_end,
+        "track_name": track_name,
+        "clip_name": clip_name,
+    }
+
+
+def save_pad_clip(
+    set_path: str,
+    track: int,
+    clip: int,
+    pad: int,
+    notes: List[Dict[str, Any]],
+    region_end: float,
+    loop_start: float,
+    loop_end: float,
+) -> Dict[str, Any]:
+    """Write edited pad notes back to the set."""
+    song = _load_song(set_path)
+    clip_obj = song["tracks"][track]["clipSlots"][clip]["clip"]
+    other = [n for n in clip_obj.get("notes", []) if int(n.get("noteNumber", 0)) != pad]
+    new_notes = []
+    for n in notes:
+        pb = (int(n.get("noteNumber", BASE_NOTE)) - BASE_NOTE) * SEMITONE_VALUE
+        new_notes.append({
+            "noteNumber": pad,
+            "startTime": n.get("startTime", 0.0),
+            "duration": n.get("duration", 0.0),
+            "velocity": n.get("velocity", 1.0),
+            "offVelocity": n.get("offVelocity", 0.0),
+            "automations": {"PitchBend": [{"time": 0.0, "value": pb}]},
+        })
+    clip_obj["notes"] = sorted(other + new_notes, key=lambda x: x["startTime"])
+    region = clip_obj.setdefault("region", {})
+    region["start"] = 0.0
+    region["end"] = region_end
+    region["loop"] = {"start": loop_start, "end": loop_end}
+    _save_song(set_path, song)
+    return {"success": True, "message": "Pad clip saved"}

--- a/core/utils.py
+++ b/core/utils.py
@@ -10,3 +10,15 @@ def load_set_template(template_path: str) -> Dict[str, Any]:
     except Exception as e:
         raise Exception(f"Failed to load template: {str(e)}")
 
+
+NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+
+def midi_to_note_name(midi_number: int) -> str:
+    """Convert a MIDI note number to a note name like ``C4``."""
+    if not 0 <= midi_number <= 127:
+        raise ValueError(f"Invalid MIDI note number: {midi_number}")
+    octave = midi_number // 12 - 1
+    name = NOTE_NAMES[midi_number % 12]
+    return f"{name}{octave}"
+

--- a/handlers/pad_pitch_handler_class.py
+++ b/handlers/pad_pitch_handler_class.py
@@ -1,0 +1,57 @@
+from handlers.base_handler import BaseHandler
+import json
+from core.pad_pitch_handler import extract_pad_clip, save_pad_clip
+
+
+class PadPitchHandler(BaseHandler):
+    def handle_get(self, form):
+        set_path = form.getvalue("set_path")
+        track = form.getvalue("track_index")
+        clip = form.getvalue("clip_index")
+        pad = form.getvalue("pad_number")
+        if not (set_path and track and clip and pad):
+            return self.format_error_response("Missing parameters")
+        try:
+            data = extract_pad_clip(set_path, int(track), int(clip), int(pad))
+            data.update({
+                "selected_set": set_path,
+                "track_index": int(track),
+                "clip_index": int(clip),
+                "pad_number": int(pad),
+                "message": "Pad clip loaded",
+                "message_type": "success",
+            })
+            return data
+        except Exception as e:
+            return self.format_error_response(f"Failed to load pad clip: {e}")
+
+    def handle_post(self, form):
+        set_path = form.getvalue("set_path")
+        track = form.getvalue("track_index")
+        clip = form.getvalue("clip_index")
+        pad = form.getvalue("pad_number")
+        notes_data = form.getvalue("clip_notes")
+        region_end = form.getvalue("region_end")
+        loop_start = form.getvalue("loop_start")
+        loop_end = form.getvalue("loop_end")
+        if not all([set_path, track, clip, pad, notes_data, region_end, loop_start, loop_end]):
+            return self.format_error_response("Missing parameters")
+        try:
+            notes = json.loads(notes_data)
+            region_end = float(region_end)
+            loop_start = float(loop_start)
+            loop_end = float(loop_end)
+        except Exception:
+            return self.format_error_response("Invalid data")
+        result = save_pad_clip(set_path, int(track), int(clip), int(pad), notes, region_end, loop_start, loop_end)
+        if not result.get("success"):
+            return self.format_error_response(result.get("message"))
+        return {
+            "message": result.get("message"),
+            "message_type": "success",
+            **extract_pad_clip(set_path, int(track), int(clip), int(pad)),
+            "selected_set": set_path,
+            "track_index": int(track),
+            "clip_index": int(clip),
+            "pad_number": int(pad),
+        }

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -47,6 +47,7 @@ from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
+from handlers.pad_pitch_handler_class import PadPitchHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -137,6 +138,7 @@ adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
 set_inspector_handler = SetInspectorHandler()
+pad_pitch_handler = PadPitchHandler()
 
 
 @app.before_request
@@ -343,11 +345,40 @@ def set_inspector_route():
         track_index=result.get("track_index"),
         clip_index=result.get("clip_index"),
         notes=result.get("notes"),
+        pad_list=result.get("pad_list"),
         envelopes=result.get("envelopes"),
         region=result.get("region"),
         loop_start=result.get("loop_start", 0.0),
         loop_end=result.get("loop_end", result.get("region")),
         param_ranges_json=result.get("param_ranges_json", "{}"),
+        active_tab="set-inspector",
+    )
+
+
+@app.route("/pad-pitch", methods=["GET", "POST"])
+def pad_pitch_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = pad_pitch_handler.handle_post(form)
+    else:
+        form = SimpleForm(request.args.to_dict())
+        result = pad_pitch_handler.handle_get(form)
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    return render_template(
+        "pad_pitch.html",
+        message=message,
+        success=success,
+        message_type=message_type,
+        selected_set=result.get("selected_set"),
+        track_index=result.get("track_index"),
+        clip_index=result.get("clip_index"),
+        pad_number=result.get("pad_number"),
+        notes=result.get("notes"),
+        region=result.get("region"),
+        loop_start=result.get("loop_start"),
+        loop_end=result.get("loop_end"),
         active_tab="set-inspector",
     )
 

--- a/templates_jinja/pad_pitch.html
+++ b/templates_jinja/pad_pitch.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Pad {{ pad_number }} Pitch Editor</h2>
+<nav class="breadcrumbs" style="margin-bottom:1rem;">
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+    <input type="hidden" name="action" value="show_clip">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="clip_select" value="{{ track_index }}:{{ clip_index }}">
+    <button type="submit" class="link-button">&larr; Back to Clip</button>
+  </form>
+</nav>
+<div style="margin-top:1rem; display:flex; align-items:flex-start;">
+  <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">
+    <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
+    <canvas id="clipCanvas" width="836" height="300" style="position:absolute; left:64px; top:0; pointer-events:none;"></canvas>
+  </div>
+</div>
+<form id="saveClipForm" method="post" action="{{ host_prefix }}/pad-pitch" style="margin-top:0.5rem;">
+  <input type="hidden" name="set_path" value="{{ selected_set }}">
+  <input type="hidden" name="track_index" value="{{ track_index }}">
+  <input type="hidden" name="clip_index" value="{{ clip_index }}">
+  <input type="hidden" name="pad_number" value="{{ pad_number }}">
+  <input type="hidden" name="clip_notes" id="clip_notes_input">
+  <input type="hidden" name="region_end" id="region_end_input">
+  <input type="hidden" name="loop_start" id="loop_start_input">
+  <input type="hidden" name="loop_end" id="loop_end_input">
+  <button id="saveClipBtn" type="submit">Save Pad</button>
+</form>
+<div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='[]' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{}'></div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ host_prefix }}/static/webaudio-pianoroll.js"></script>
+<script type="module" src="{{ host_prefix }}/static/set_inspector.js"></script>
+{% endblock %}

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -78,6 +78,12 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
+  {% if pad_list %}
+  <div style="margin-top:1rem;">
+    <h3>Pads</h3>
+    {{ pad_list | safe }}
+  </div>
+  {% endif %}
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}

--- a/tests/test_midi_helpers.py
+++ b/tests/test_midi_helpers.py
@@ -8,6 +8,7 @@ from core.midi_pattern_generator import (
     create_scale_pattern,
     create_rhythm_pattern,
 )
+from core.utils import midi_to_note_name
 
 
 def test_note_name_to_midi_basic():
@@ -37,3 +38,9 @@ def test_create_rhythm_pattern_velocity_cycle():
     velocities = [n["velocity"] for n in pattern]
     assert velocities == [80, 100, 80, 100]
     assert [n["start"] for n in pattern] == [0, 0.5, 1.0, 1.5]
+
+
+def test_midi_to_note_name_roundtrip():
+    for n in [0, 12, 60, 73, 127]:
+        name = midi_to_note_name(n)
+        assert note_name_to_midi(name) == n

--- a/tests/test_pad_pitch_handler.py
+++ b/tests/test_pad_pitch_handler.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.pad_pitch_handler import extract_pad_clip, save_pad_clip, pads_with_pitch, SEMITONE_VALUE, BASE_NOTE
+
+
+def create_pad_set(path):
+    note1 = {
+        "noteNumber": 40,
+        "startTime": 0.0,
+        "duration": 0.5,
+        "velocity": 1.0,
+        "offVelocity": 0.0,
+        "automations": {"PitchBend": [{"time": 0.0, "value": SEMITONE_VALUE}]},
+    }
+    note2 = {
+        "noteNumber": 40,
+        "startTime": 1.0,
+        "duration": 0.5,
+        "velocity": 1.0,
+        "offVelocity": 0.0,
+        "automations": {"PitchBend": [{"time": 0.0, "value": 0.0}]},
+    }
+    clip = {"name": "Clip1", "notes": [note1, note2], "envelopes": [], "region": {"end": 4.0}}
+    track = {"name": "Track1", "devices": [], "clipSlots": [{"clip": clip}]}
+    song = {"tracks": [track]}
+    Path(path).write_text(json.dumps(song))
+
+
+def test_extract_and_save_pad_clip(tmp_path):
+    set_path = tmp_path / "set.abl"
+    create_pad_set(set_path)
+    data = extract_pad_clip(str(set_path), 0, 0, 40)
+    assert len(data["notes"]) == 2
+    assert data["notes"][0]["noteNumber"] == BASE_NOTE + 1
+    # modify and save
+    data["notes"][0]["noteNumber"] = BASE_NOTE + 2
+    save_pad_clip(str(set_path), 0, 0, 40, data["notes"], 4.0, 0.0, 4.0)
+    new = extract_pad_clip(str(set_path), 0, 0, 40)
+    assert new["notes"][0]["noteNumber"] == BASE_NOTE + 2
+    with open(set_path) as f:
+        song = json.load(f)
+    first = song["tracks"][0]["clipSlots"][0]["clip"]["notes"][0]
+    assert abs(first["automations"]["PitchBend"][0]["value"] - 2 * SEMITONE_VALUE) < 1e-4
+
+
+def test_pads_with_pitch(tmp_path):
+    set_path = tmp_path / "s.abl"
+    create_pad_set(set_path)
+    with open(set_path) as f:
+        song = json.load(f)
+    notes = song["tracks"][0]["clipSlots"][0]["clip"]["notes"]
+    pads = pads_with_pitch(notes)
+    assert pads[40]
+


### PR DESCRIPTION
## Summary
- support MIDI to note name helper
- add pad-level pitch editor backend
- show available pads in the Set Inspector
- new route `/pad-pitch` with editor page
- tests for new utilities and handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, mido, flask, requests)*

------
https://chatgpt.com/codex/tasks/task_e_684da66af2dc832586d61c2750be8cd8