### PR TITLE
Add clip editor warning for non-copy sets

### DIFF
--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -183,6 +183,12 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
+            warn_message = None
+            if "copy" not in set_name.lower():
+                warn_message = (
+                    "It looks like this isn't a copy of a Set! "
+                    "Are you sure you want to edit this?"
+                )
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             return {
                 "pad_grid": pad_grid,
@@ -203,6 +209,7 @@ class SetInspectorHandler(BaseHandler):
                 "clip_index": clip_idx,
                 "track_name": result.get("track_name"),
                 "clip_name": result.get("clip_name"),
+                "warning_message": warn_message,
             }
         elif action == "save_envelope":
             set_path = form.getvalue("set_path")
@@ -250,6 +257,12 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
+            warn_message = None
+            if "copy" not in set_name.lower():
+                warn_message = (
+                    "It looks like this isn't a copy of a Set! "
+                    "Are you sure you want to edit this?"
+                )
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             return {
                 "pad_grid": pad_grid,
@@ -270,6 +283,7 @@ class SetInspectorHandler(BaseHandler):
                 "clip_index": clip_idx,
                 "track_name": clip_data.get("track_name"),
                 "clip_name": clip_data.get("clip_name"),
+                "warning_message": warn_message,
             }
         elif action == "save_clip":
             set_path = form.getvalue("set_path")
@@ -338,6 +352,12 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
+            warn_message = None
+            if "copy" not in set_name.lower():
+                warn_message = (
+                    "It looks like this isn't a copy of a Set! "
+                    "Are you sure you want to edit this?"
+                )
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             return {
                 "pad_grid": pad_grid,
@@ -358,6 +378,7 @@ class SetInspectorHandler(BaseHandler):
                 "clip_index": clip_idx,
                 "track_name": clip_data.get("track_name"),
                 "clip_name": clip_data.get("clip_name"),
+                "warning_message": warn_message,
             }
         else:
             return self.format_error_response("Unknown action", pad_grid=pad_grid)

--- a/static/style.css
+++ b/static/style.css
@@ -336,6 +336,15 @@ body.page-melodic-sampler .waveform-container {
     margin-bottom: 1rem;
 }
 
+/* Warning messages */
+.warning {
+    color: #856404;
+    padding: 0.75rem;
+    background-color: #fff3cd;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
 .current-preset {
     font-weight: 500;
     margin-bottom: 1rem;

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -47,6 +47,9 @@
     </form>
     - Clip {{ (clip_index + 1) if clip_index is not none else '?' }}
   </nav>
+  {% if warning_message %}
+  <p class="warning">{{ warning_message }}</p>
+  {% endif %}
   <!-- <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
     <input type="hidden" name="action" value="select_set">
     <input type="hidden" name="set_path" value="{{ selected_set }}">


### PR DESCRIPTION
## Summary
- warn users in clip editor when set name lacks "Copy"
- display warning message in template
- style new warning class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dac4ff2dc8325945c29f89007f093