### PR TITLE
Add selectable gridlines to clip editor

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -52,6 +52,7 @@ export function initSetInspector() {
     canvas.style.top = `${xruler}px`;
   }
   const envSelect = document.getElementById('envelope_select');
+  const gridSelect = document.getElementById('grid_select');
   const legendDiv = document.getElementById('paramLegend');
   const valueDiv = document.getElementById('envValue');
   const saveClipForm = document.getElementById('saveClipForm');
@@ -331,6 +332,28 @@ export function initSetInspector() {
     updateControls();
     draw();
   });
+
+  if (gridSelect && piano) {
+    const divToTicks = val => {
+      switch (val) {
+        case '1/4': return 4;
+        case '1/8': return 2;
+        case '1/16': return 1;
+        case '1/32': return 0.5;
+        case '1/4t': return (4 * 2) / 3;
+        case '1/8t': return (4 * 1) / 3;
+        case '1/6t': return 4 / 6;
+        case '1/32t': return 4 / 12;
+        default: return 1;
+      }
+    };
+    const updateGrid = () => {
+      piano.subgrid = divToTicks(gridSelect.value);
+      if (piano.redraw) piano.redraw();
+    };
+    gridSelect.addEventListener('change', updateGrid);
+    updateGrid();
+  }
 
   if (piano) {
     piano.addEventListener('mouseup', () => { clipModified = true; updateSaveButton(); });

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -35,6 +35,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 xoffset:            {type:Number, value:0, observer:'layout'},
                 yoffset:            {type:Number, value:60, observer:'layout'},
                 grid:               {type:Number, value:4},
+                subgrid:            {type:Number, value:1},
                 snap:               {type:Number, value:1},
                 wheelzoom:          {type:Number, value:0},
                 wheelzoomx:         {type:Number, value:0},
@@ -52,6 +53,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 collt:              {type:String, value:"#ccc"},
                 coldk:              {type:String, value:"#aaa"},
                 colgrid:            {type:String, value:"#666"},
+                colsubgrid:         {type:String, value:"#bbb"},
                 colnote:            {type:String, value:"#f22"},
                 colnotesel:         {type:String, value:"#0f0"},
                 colnoteborder:      {type:String, value:"#000"},
@@ -1060,9 +1062,20 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             }
             for(let t=0;;t+=this.grid){
                 let x=this.stepw*(t-this.xoffset)+this.yruler+this.kbwidth;
+                this.ctx.fillStyle=this.colgrid;
                 this.ctx.fillRect(x|0,this.xruler,1,this.sheight);
                 if(x>=this.width)
                     break;
+            }
+            if(this.subgrid>0){
+                for(let t=0;;t+=this.subgrid){
+                    if(Math.abs(t % this.grid) < 1e-6) continue;
+                    let x=this.stepw*(t-this.xoffset)+this.yruler+this.kbwidth;
+                    this.ctx.fillStyle=this.colsubgrid;
+                    this.ctx.fillRect(x|0,this.xruler,1,this.sheight);
+                    if(x>=this.width)
+                        break;
+                }
             }
         };
         this.semiflag=[6,1,0,1,0,2,1,0,1,0,1,0];

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -60,6 +60,19 @@
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
   </div>
+  <div style="margin-top:0.5rem;">
+    <label for="grid_select">Grid:</label>
+    <select id="grid_select">
+      <option value="1/4">1/4</option>
+      <option value="1/8">1/8</option>
+      <option value="1/16" selected>1/16</option>
+      <option value="1/32">1/32</option>
+      <option value="1/4t">1/4t</option>
+      <option value="1/8t">1/8t</option>
+      <option value="1/6t">1/6t</option>
+      <option value="1/32t">1/32t</option>
+    </select>
+  </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">
       <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>


### PR DESCRIPTION
## Summary
- let user choose grid subdivision in set inspector clip editor
- support sub-beat lines in `webaudio-pianoroll`
- update JS to sync dropdown value with pianoroll

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da90c1ee48325b1810a82ed16bb61