### PR TITLE
Add grid subdivisions and dropdown

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -56,6 +56,7 @@ export function initSetInspector() {
   const valueDiv = document.getElementById('envValue');
   const saveClipForm = document.getElementById('saveClipForm');
   const saveClipBtn = document.getElementById('saveClipBtn');
+  const gridSelect = document.getElementById('grid_sub_select');
   const notesInput = document.getElementById('clip_notes_input');
   const envsInput = document.getElementById('clip_envelopes_input');
   const regionInput = document.getElementById('region_end_input');
@@ -95,6 +96,28 @@ export function initSetInspector() {
     piano.yoffset = Math.max(0, min - 2);
     piano.yrange = Math.max(12, max - min + 5);
     if (piano.redraw) piano.redraw();
+
+    if (gridSelect) {
+      const noteTicks = val => {
+        switch (val) {
+          case '1/4': return timebase / 4;
+          case '1/8': return timebase / 8;
+          case '1/16': return timebase / 16;
+          case '1/32': return timebase / 32;
+          case '1/4t': return timebase / 6;
+          case '1/8t': return timebase / 12;
+          case '1/16t': return timebase / 24;
+          case '1/32t': return timebase / 48;
+          default: return 0;
+        }
+      };
+      const applyGrid = () => {
+        piano.subgrid = noteTicks(gridSelect.value);
+        if (piano.redraw) piano.redraw();
+      };
+      gridSelect.addEventListener('change', applyGrid);
+      applyGrid();
+    }
 
     piano.addEventListener('dblclick', ev => {
       const rect = piano.getBoundingClientRect();

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -52,6 +52,8 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 collt:              {type:String, value:"#ccc"},
                 coldk:              {type:String, value:"#aaa"},
                 colgrid:            {type:String, value:"#666"},
+                colsubgrid:        {type:String, value:"#999"},
+                subgrid:           {type:Number, value:0},
                 colnote:            {type:String, value:"#f22"},
                 colnotesel:         {type:String, value:"#0f0"},
                 colnoteborder:      {type:String, value:"#000"},
@@ -1058,6 +1060,17 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 this.ctx.fillStyle=this.colgrid;
                 this.ctx.fillRect(this.yruler+this.kbwidth, ys|0, this.swidth,1);
             }
+            if(this.subgrid>0){
+                this.ctx.fillStyle=this.colsubgrid;
+                for(let t=0;;t+=this.grid/this.subgrid){
+                    if(Math.abs(t % this.grid) < 1e-6) continue;
+                    let x=this.stepw*(t-this.xoffset)+this.yruler+this.kbwidth;
+                    this.ctx.fillRect(x|0,this.xruler,1,this.sheight);
+                    if(x>=this.width)
+                        break;
+                }
+            }
+            this.ctx.fillStyle=this.colgrid;
             for(let t=0;;t+=this.grid){
                 let x=this.stepw*(t-this.xoffset)+this.yruler+this.kbwidth;
                 this.ctx.fillRect(x|0,this.xruler,1,this.sheight);

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -59,6 +59,17 @@
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
+    <label for="grid_sub_select" style="margin-left:1rem;">Grid:</label>
+    <select id="grid_sub_select">
+      <option value="1/4">1/4</option>
+      <option value="1/8">1/8</option>
+      <option value="1/16" selected>1/16</option>
+      <option value="1/32">1/32</option>
+      <option value="1/4t">1/4t</option>
+      <option value="1/8t">1/8t</option>
+      <option value="1/16t">1/16t</option>
+      <option value="1/32t">1/32t</option>
+    </select>
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">


### PR DESCRIPTION
## Summary
- expose `subgrid` and `colsubgrid` in `webaudio-pianoroll`
- render minor grid lines when `subgrid` is set
- allow choosing sub grid size in Set Inspector
- set grid from dropdown in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da90c1ee48325b1810a82ed16bb61