### PR TITLE
Improve pitch bend icon positioning

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -532,6 +532,19 @@ nav.breadcrumbs form {
     cursor: pointer;
 }
 
+.pitch-icon {
+    position: absolute;
+    left: 2px;
+    width: 12px;
+    height: 12px;
+    padding: 0;
+    border: none;
+    background: none;
+    font-size: 12px;
+    line-height: 12px;
+    cursor: pointer;
+}
+
 
 /* Knob interface layout */
 #knob-container {

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -46,6 +46,15 @@
       <button type="submit" class="mini-grid" style="border:none; background:none; padding:0;">{{ clip_grid | safe }}</button>
     </form>
     - Clip {{ (clip_index + 1) if clip_index is not none else '?' }}
+    {% if pitch_pad is not none %}
+    - Pitch {{ pitch_pad }}
+    <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+      <input type="hidden" name="action" value="show_clip">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+      <button type="submit" class="link-button">Back</button>
+    </form>
+    {% endif %}
   </nav>
   <!-- <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
     <input type="hidden" name="action" value="select_set">
@@ -68,17 +77,27 @@
     <div id="paramLegend" style="margin-left:0.5rem; font-size:10px; line-height:1.2; display:flex; flex-direction:column; justify-content:space-between; align-items:flex-end; height:300px;"></div>
   </div>
   <form id="saveClipForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
-    <input type="hidden" name="action" value="save_clip">
+    <input type="hidden" name="action" value="{{ 'save_pitchbend' if pitch_pad is not none else 'save_clip' }}">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
     <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+    {% if pitch_pad is not none %}
+    <input type="hidden" name="note_number" value="{{ pitch_pad }}">
+    {% endif %}
     <input type="hidden" name="clip_notes" id="clip_notes_input">
     <input type="hidden" name="clip_envelopes" id="clip_envelopes_input">
     <input type="hidden" name="region_end" id="region_end_input">
     <input type="hidden" name="loop_start" id="loop_start_input">
     <input type="hidden" name="loop_end" id="loop_end_input">
-    <button id="saveClipBtn" type="submit">Save Clip</button>
+    <button id="saveClipBtn" type="submit">Save {{ 'Pitchbend' if pitch_pad is not none else 'Clip' }}</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitchbend-notes='{{ pitchbend_notes | default([]) | tojson }}' data-pitch-pad='{{ pitch_pad if pitch_pad is not none else '' }}'></div>
+
+  <form id="openPitchForm" method="post" action="{{ host_prefix }}/set-inspector" style="display:none;">
+    <input type="hidden" name="action" value="open_pitchbend">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+    <input type="hidden" name="note_number" id="pitch_note_input">
+  </form>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -374,3 +374,90 @@ def test_save_clip(tmp_path):
     assert data["loop_start"] == 0.0
     assert data["loop_end"] == 4.0
 
+ 
+
+
+def test_get_pad_pitchbend_data(tmp_path):
+    set_path = tmp_path / "set.abl"
+    song = {
+        "tracks": [
+            {
+                "kind": "midi",
+                "clipSlots": [
+                    {
+                        "clip": {
+                            "notes": [
+                                {
+                                    "noteNumber": 40,
+                                    "startTime": 0.0,
+                                    "duration": 0.5,
+                                    "velocity": 1.0,
+                                    "offVelocity": 0.0,
+                                    "automations": {
+                                        "PitchBend": [
+                                            {"time": 0.0, "value": 0.0},
+                                            {"time": 0.25, "value": 170.6458282470703},
+                                        ]
+                                    },
+                                }
+                            ],
+                            "envelopes": [],
+                            "region": {"end": 1.0},
+                        }
+                    }
+                ],
+            }
+        ]
+    }
+    set_path.write_text(json.dumps(song))
+
+    from core.set_inspector_handler import get_pad_pitchbend_data
+
+    result = get_pad_pitchbend_data(str(set_path), 0, 0, 40)
+    assert result["success"], result.get("message")
+    pitches = [n["noteNumber"] for n in result.get("notes", [])]
+    assert pitches == [36, 37]
+
+
+def test_save_pad_pitchbend_data(tmp_path):
+    set_path = tmp_path / "set.abl"
+    song = {
+        "tracks": [
+            {
+                "kind": "midi",
+                "clipSlots": [
+                    {
+                        "clip": {
+                            "notes": [
+                                {
+                                    "noteNumber": 40,
+                                    "startTime": 0.0,
+                                    "duration": 0.5,
+                                    "velocity": 1.0,
+                                    "offVelocity": 0.0,
+                                    "automations": {"PitchBend": []},
+                                }
+                            ],
+                            "envelopes": [],
+                            "region": {"end": 1.0},
+                        }
+                    }
+                ],
+            }
+        ]
+    }
+    set_path.write_text(json.dumps(song))
+
+    from core.set_inspector_handler import save_pad_pitchbend_data, get_pad_pitchbend_data
+
+    notes = [
+        {"noteNumber": 36, "startTime": 0.0, "duration": 0.001, "velocity": 1.0, "offVelocity": 0.0},
+        {"noteNumber": 37, "startTime": 0.25, "duration": 0.001, "velocity": 1.0, "offVelocity": 0.0},
+    ]
+    result = save_pad_pitchbend_data(str(set_path), 0, 0, 40, notes)
+    assert result["success"], result.get("message")
+
+    result = get_pad_pitchbend_data(str(set_path), 0, 0, 40)
+    assert result["success"]
+    pitches = [n["noteNumber"] for n in result.get("notes", [])]
+    assert pitches == [36, 37]


### PR DESCRIPTION
## Summary
- ensure pitchbend notes show in the pianoroll
- reposition pitchbend icons with scrolling
- keep notes visible with minimal duration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da3cc23d48325a556d41672fe3d09