### PR TITLE
Add gridline options to clip editor

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -54,6 +54,7 @@ export function initSetInspector() {
   const envSelect = document.getElementById('envelope_select');
   const legendDiv = document.getElementById('paramLegend');
   const valueDiv = document.getElementById('envValue');
+  const gridSelect = document.getElementById('grid_select');
   const saveClipForm = document.getElementById('saveClipForm');
   const saveClipBtn = document.getElementById('saveClipBtn');
   const notesInput = document.getElementById('clip_notes_input');
@@ -116,6 +117,32 @@ export function initSetInspector() {
         if (piano.redraw) piano.redraw();
       }
     });
+    if (gridSelect) {
+      const gridMap = {
+        '8 bars': timebase * 8,
+        '4 bars': timebase * 4,
+        '2 bars': timebase * 2,
+        '1 bar': timebase,
+        '1/2': timebase / 2,
+        '1/4': timebase / 4,
+        '1/4t': timebase / 6,
+        '1/8': timebase / 8,
+        '1/8t': timebase / 12,
+        '1/16': timebase / 16,
+        '1/16t': timebase / 24,
+        '1/32': timebase / 32,
+        '1/32t': timebase / 48,
+      };
+      const applyGrid = () => {
+        const v = gridSelect.value;
+        const snap = gridMap[v] || timebase / 16;
+        piano.subgrid = snap;
+        piano.snap = snap;
+        if (piano.redraw) piano.redraw();
+      };
+      gridSelect.addEventListener('change', applyGrid);
+      applyGrid();
+    }
   }
 
   function isNormalized(env) {

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -42,6 +42,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 xscroll:            {type:Number, value:0},
                 yscroll:            {type:Number, value:0},
                 gridnoteratio:      {type:Number, value:0.5, observer:'updateTimer'},
+                subgrid:            {type:Number, value:0},
                 xruler:             {type:Number, value:24, observer:'layout'},
                 yruler:             {type:Number, value:24, observer:'layout'},
                 octadj:             {type:Number, value:-1},
@@ -1057,6 +1058,23 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 this.ctx.fillRect(this.yruler+this.kbwidth, ys|0, this.swidth,-this.steph);
                 this.ctx.fillStyle=this.colgrid;
                 this.ctx.fillRect(this.yruler+this.kbwidth, ys|0, this.swidth,1);
+            }
+            if(this.subgrid>0){
+                this.ctx.strokeStyle=this.colgrid;
+                this.ctx.globalAlpha=0.4;
+                this.ctx.setLineDash([2,4]);
+                for(let t=0;;t+=this.subgrid){
+                    if(Math.abs(t%this.grid)<1e-6) continue;
+                    let x=this.stepw*(t-this.xoffset)+this.yruler+this.kbwidth;
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(x|0,this.xruler);
+                    this.ctx.lineTo(x|0,this.height);
+                    this.ctx.stroke();
+                    if(x>=this.width)
+                        break;
+                }
+                this.ctx.setLineDash([]);
+                this.ctx.globalAlpha=1.0;
             }
             for(let t=0;;t+=this.grid){
                 let x=this.stepw*(t-this.xoffset)+this.yruler+this.kbwidth;

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -59,6 +59,22 @@
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
+    <label for="grid_select" style="margin-left:1rem;">Grid:</label>
+    <select id="grid_select">
+      <option value="8 bars">8 bars</option>
+      <option value="4 bars">4 bars</option>
+      <option value="2 bars">2 bars</option>
+      <option value="1 bar">1 bar</option>
+      <option value="1/2">1/2</option>
+      <option value="1/4">1/4</option>
+      <option value="1/4t">1/4t</option>
+      <option value="1/8">1/8</option>
+      <option value="1/8t">1/8t</option>
+      <option value="1/16" selected>1/16</option>
+      <option value="1/16t">1/16t</option>
+      <option value="1/32">1/32</option>
+      <option value="1/32t">1/32t</option>
+    </select>
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:300px; border:1px solid #ccc;">


### PR DESCRIPTION
## Summary
- add `subgrid` option to the pianoroll element for lighter gridlines
- add grid subdivision selector to the Set Inspector page
- draw hashed sublines in the pianoroll
- hook dropdown to new `subgrid` property
- default grid to 1/16 and sync snap resolution
- expand grid options up to 8 bars

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da90c1ee48325b1810a82ed16bb61