### PR TITLE
Implement pitchbend editor for drum pads

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -53,7 +53,9 @@ def list_clips(set_path: str) -> Dict[str, Any]:
                 if clip:
                     name = clip.get("name", f"Track {ti+1} Clip {ci+1}")
                     color = clip.get("color")
-                    clips.append({"track": ti, "clip": ci, "name": name, "color": color})
+                    clips.append(
+                        {"track": ti, "clip": ci, "name": name, "color": color}
+                    )
         return {"success": True, "message": "Clips loaded", "clips": clips}
     except Exception as e:
         return {"success": False, "message": f"Failed to read set: {e}"}
@@ -84,7 +86,11 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
 
         # Load parameter metadata from available instrument schemas
         schemas: Dict[str, Dict[str, Any]] = {}
-        for loader in (load_drift_schema, load_wavetable_schema, load_melodic_sampler_schema):
+        for loader in (
+            load_drift_schema,
+            load_wavetable_schema,
+            load_melodic_sampler_schema,
+        ):
             try:
                 schemas.update(loader() or {})
             except Exception:
@@ -152,9 +158,7 @@ def save_envelope(
         with open(set_path, "r") as f:
             song = json.load(f)
 
-        clip_obj = (
-            song["tracks"][track]["clipSlots"][clip]["clip"]
-        )
+        clip_obj = song["tracks"][track]["clipSlots"][clip]["clip"]
         envelopes = clip_obj.setdefault("envelopes", [])
         for env in envelopes:
             if env.get("parameterId") == parameter_id:
@@ -262,3 +266,14 @@ def steps_to_pitch_notes(
             }
         )
     return notes
+
+
+def pitch_bend_pads(notes: List[Dict[str, Any]]) -> List[int]:
+    """Return the pad note numbers that contain pitch bend automation."""
+
+    pads = {
+        int(n.get("noteNumber"))
+        for n in notes
+        if abs(float(n.get("pitchBend", 0.0))) > 0.0
+    }
+    return sorted(pads)

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -230,7 +230,14 @@ def notes_to_pitch_steps(
     for n in notes:
         if n.get("noteNumber") != pad_number:
             continue
-        pb = float(n.get("pitchBend", 0.0))
+        pb = float(
+            n.get(
+                "pitchBend",
+                n.get("automations", {}).get("PitchBend", [{"value": 0.0}])[0].get(
+                    "value", 0.0
+                ),
+            )
+        )
         pitch = 36 + pb / unit
         pitch_notes.append(
             {
@@ -263,6 +270,7 @@ def steps_to_pitch_notes(
                 "velocity": s.get("velocity", 100.0),
                 "offVelocity": s.get("offVelocity", 0.0),
                 "pitchBend": pb,
+                "automations": {"PitchBend": [{"time": 0.0, "value": pb}]},
             }
         )
     return notes
@@ -274,6 +282,16 @@ def pitch_bend_pads(notes: List[Dict[str, Any]]) -> List[int]:
     pads = {
         int(n.get("noteNumber"))
         for n in notes
-        if abs(float(n.get("pitchBend", 0.0))) > 0.0
+        if abs(
+            float(
+                n.get(
+                    "pitchBend",
+                    n.get("automations", {})
+                    .get("PitchBend", [{"value": 0.0}])[0]
+                    .get("value", 0.0),
+                )
+            )
+        )
+        > 0.0
     }
     return sorted(pads)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -350,6 +350,7 @@ def set_inspector_route():
         param_ranges_json=result.get("param_ranges_json", "{}"),
         pitch_mode=result.get("pitch_mode", False),
         pad_note=result.get("pad_note"),
+        pitch_pads=result.get("pitch_pads", []),
         active_tab="set-inspector",
     )
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -348,6 +348,8 @@ def set_inspector_route():
         loop_start=result.get("loop_start", 0.0),
         loop_end=result.get("loop_end", result.get("region")),
         param_ranges_json=result.get("param_ranges_json", "{}"),
+        pitch_mode=result.get("pitch_mode", False),
+        pad_note=result.get("pad_note"),
         active_tab="set-inspector",
     )
 

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -76,7 +76,7 @@ export function initSetInspector() {
       t: Math.round(n.startTime * ticksPerBeat),
       n: n.noteNumber,
       g: Math.round(n.duration * ticksPerBeat),
-      pb: n.pitchBend || 0
+      pb: n.pitchBend || ((n.automations?.PitchBend?.[0]?.value) ?? 0)
     }));
     if (!piano.hasAttribute('xrange')) piano.xrange = region * ticksPerBeat;
     if (!piano.hasAttribute('markstart')) piano.markstart = loopStart * ticksPerBeat;
@@ -423,7 +423,8 @@ export function initSetInspector() {
           duration: ev.g / ticksPerBeat,
           velocity: 100.0,
           offVelocity: 0.0,
-          pitchBend: pb
+          pitchBend: pb,
+          automations: { PitchBend: [{ time: 0.0, value: pb }] }
         };
       }));
     }

--- a/static/style.css
+++ b/static/style.css
@@ -476,7 +476,8 @@ nav.breadcrumbs form {
     text-align: center;
     font-weight: 600;
     box-sizing: border-box;
-    aspect-ratio: 4 / 3; 
+    aspect-ratio: 4 / 3;
+    position: relative;
 }
 
 .pad-cell.free {
@@ -519,6 +520,29 @@ nav.breadcrumbs form {
 .mini-grid input,
 .mini-grid label {
     pointer-events: none;
+}
+
+.pitch-mark {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    font-size: 0.8rem;
+}
+
+.pitch-pad-bar form {
+    display: inline;
+}
+
+.pitch-icon {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    padding: 0 2px;
+}
+
+.pitch-icon.active {
+    color: #0074D9;
 }
 
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -22,6 +22,10 @@
   <form id="clipSelectForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="show_clip">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="pitch_mode" value="{{ 'true' if pitch_mode else 'false' }}">
+    {% if pad_note is not none %}
+    <input type="hidden" name="pad_note" value="{{ pad_note }}">
+    {% endif %}
     {{ clip_grid | safe }}
     <span id="selected-clip-name" style="margin-left:1rem;"></span>
   </form>
@@ -76,9 +80,13 @@
     <input type="hidden" name="region_end" id="region_end_input">
     <input type="hidden" name="loop_start" id="loop_start_input">
     <input type="hidden" name="loop_end" id="loop_end_input">
+    <input type="hidden" name="pitch_mode" value="{{ 'true' if pitch_mode else 'false' }}">
+    {% if pad_note is not none %}
+    <input type="hidden" name="pad_note" value="{{ pad_note }}">
+    {% endif %}
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitch-mode='{{ pitch_mode | tojson }}' data-pad-note='{{ pad_note if pad_note is not none else '' }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -51,6 +51,29 @@
     </form>
     - Clip {{ (clip_index + 1) if clip_index is not none else '?' }}
   </nav>
+  {% if pitch_pads %}
+  <div class="pitch-pad-bar" style="margin-bottom:0.5rem;">
+    {% for p in pitch_pads %}
+    <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
+      <input type="hidden" name="action" value="show_clip">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+      <input type="hidden" name="pitch_mode" value="true">
+      <input type="hidden" name="pad_note" value="{{ p }}">
+      <button type="submit" class="pitch-icon{% if pitch_mode and pad_note == p %} active{% endif %}" title="Edit pitch for pad {{ p - 35 }}">🎵</button>
+    </form>
+    {% endfor %}
+    {% if pitch_mode %}
+    <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline; margin-left:0.5rem;">
+      <input type="hidden" name="action" value="show_clip">
+      <input type="hidden" name="set_path" value="{{ selected_set }}">
+      <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+      <input type="hidden" name="pitch_mode" value="false">
+      <button type="submit" class="pitch-icon">Back</button>
+    </form>
+    {% endif %}
+  </div>
+  {% endif %}
   <!-- <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
     <input type="hidden" name="action" value="select_set">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
@@ -86,7 +109,7 @@
     {% endif %}
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitch-mode='{{ pitch_mode | tojson }}' data-pad-note='{{ pad_note if pad_note is not none else '' }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitch-mode='{{ pitch_mode | tojson }}' data-pad-note='{{ pad_note if pad_note is not none else '' }}' data-pitch-pads='{{ pitch_pads | tojson }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -16,247 +16,278 @@ move_webserver = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(move_webserver)
 import pytest
 
-@pytest.fixture
 
+@pytest.fixture
 def client(monkeypatch):
-    move_webserver.app.config['TESTING'] = True
+    move_webserver.app.config["TESTING"] = True
     return move_webserver.app.test_client()
 
+
 def test_reverse_get(client):
-    resp = client.get('/reverse')
+    resp = client.get("/reverse")
     assert resp.status_code == 200
     assert b'class="file-browser"' in resp.data
 
+
 def test_reverse_post(client, monkeypatch):
     def fake_handle_post(form):
-        return {'message': 'ok', 'message_type': 'success'}
-    monkeypatch.setattr(move_webserver.reverse_handler, 'handle_post', fake_handle_post)
-    resp = client.post('/reverse', data={'action': 'reverse_file', 'wav_file': 'sample.wav'})
+        return {"message": "ok", "message_type": "success"}
+
+    monkeypatch.setattr(move_webserver.reverse_handler, "handle_post", fake_handle_post)
+    resp = client.post(
+        "/reverse", data={"action": "reverse_file", "wav_file": "sample.wav"}
+    )
     assert resp.status_code == 200
-    assert b'ok' in resp.data
+    assert b"ok" in resp.data
+
 
 def test_adsr_get(client, monkeypatch):
     def fake_get():
         return {
-            'defaults': {
-                'attack': 0.1,
-                'decay': 0.2,
-                'sustain': 0.5,
-                'release': 0.3,
-                'initial': 0.0,
-                'peak': 1.0,
-                'final': 0.0,
+            "defaults": {
+                "attack": 0.1,
+                "decay": 0.2,
+                "sustain": 0.5,
+                "release": 0.3,
+                "initial": 0.0,
+                "peak": 1.0,
+                "final": 0.0,
             },
-            'message': 'hello',
-            'message_type': 'info'
+            "message": "hello",
+            "message_type": "info",
         }
-    monkeypatch.setattr(move_webserver.adsr_handler, 'handle_get', fake_get)
-    resp = client.get('/adsr')
+
+    monkeypatch.setattr(move_webserver.adsr_handler, "handle_get", fake_get)
+    resp = client.get("/adsr")
     assert resp.status_code == 200
-    assert b'ADSR Envelope Visualizer' in resp.data
+    assert b"ADSR Envelope Visualizer" in resp.data
     assert b'id="initial"' in resp.data
     assert b'id="peak"' in resp.data
     assert b'id="final"' in resp.data
 
+
 def test_cyc_env_get(client, monkeypatch):
     def fake_get():
         return {
-            'defaults': {
-                'time': 1.0,
-                'tilt': 0.5,
-                'hold': 0.0,
+            "defaults": {
+                "time": 1.0,
+                "tilt": 0.5,
+                "hold": 0.0,
             },
-            'message': 'hello',
-            'message_type': 'info'
+            "message": "hello",
+            "message_type": "info",
         }
-    monkeypatch.setattr(move_webserver.cyc_env_handler, 'handle_get', fake_get)
-    resp = client.get('/cyc-env')
+
+    monkeypatch.setattr(move_webserver.cyc_env_handler, "handle_get", fake_get)
+    resp = client.get("/cyc-env")
     assert resp.status_code == 200
-    assert b'Cyclic Envelope Visualizer' in resp.data
+    assert b"Cyclic Envelope Visualizer" in resp.data
     assert b'id="time"' in resp.data
     assert b'id="tilt"' in resp.data
     assert b'id="hold"' in resp.data
 
+
 def test_lfo_get(client, monkeypatch):
     def fake_get():
         return {
-            'defaults': {
-                'shape': 'sine',
-                'rate': 1.0,
-                'offset': 0.0,
-                'amount': 1.0,
-                'attack': 0.0,
+            "defaults": {
+                "shape": "sine",
+                "rate": 1.0,
+                "offset": 0.0,
+                "amount": 1.0,
+                "attack": 0.0,
             },
-            'message': 'hello',
-            'message_type': 'info',
+            "message": "hello",
+            "message_type": "info",
         }
 
-    monkeypatch.setattr(move_webserver.lfo_handler, 'handle_get', fake_get)
-    resp = client.get('/lfo')
+    monkeypatch.setattr(move_webserver.lfo_handler, "handle_get", fake_get)
+    resp = client.get("/lfo")
     assert resp.status_code == 200
-    assert b'LFO Cycle Visualizer' in resp.data
+    assert b"LFO Cycle Visualizer" in resp.data
     assert b'id="shape"' in resp.data
     assert b'id="rate"' in resp.data
     assert b'id="offset"' in resp.data
     assert b'id="amount"' in resp.data
     assert b'id="attack"' in resp.data
 
+
 def test_restore_get(client, monkeypatch):
     def fake_get():
-        return {'options': '<option value="1">1</option>', 'pad_grid': '<div class="pad-grid"></div>', 'message': ''}
-    monkeypatch.setattr(move_webserver.restore_handler, 'handle_get', fake_get)
-    resp = client.get('/restore')
+        return {
+            "options": '<option value="1">1</option>',
+            "pad_grid": '<div class="pad-grid"></div>',
+            "message": "",
+        }
+
+    monkeypatch.setattr(move_webserver.restore_handler, "handle_get", fake_get)
+    resp = client.get("/restore")
     assert resp.status_code == 200
     assert b'class="pad-grid"' in resp.data
 
+
 def test_restore_post(client, monkeypatch):
     def fake_handle_post(form):
-        return {'message': 'restored', 'message_type': 'success', 'pad_grid': '<div class="pad-grid"></div>', 'options': ''}
-    monkeypatch.setattr(move_webserver.restore_handler, 'handle_post', fake_handle_post)
-    data = {
-        'action': 'restore_ablbundle',
-        'mset_index': '1',
-        'mset_color': '1'
-    }
-    resp = client.post('/restore', data=data, content_type='multipart/form-data')
+        return {
+            "message": "restored",
+            "message_type": "success",
+            "pad_grid": '<div class="pad-grid"></div>',
+            "options": "",
+        }
+
+    monkeypatch.setattr(move_webserver.restore_handler, "handle_post", fake_handle_post)
+    data = {"action": "restore_ablbundle", "mset_index": "1", "mset_color": "1"}
+    resp = client.post("/restore", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
-    assert b'restored' in resp.data
+    assert b"restored" in resp.data
+
 
 def test_slice_post(client, monkeypatch):
     def fake_handle_post(form):
-        return {'message': 'sliced', 'message_type': 'success'}
-    monkeypatch.setattr(move_webserver.slice_handler, 'handle_post', fake_handle_post)
-    f = (io.BytesIO(b'data'), 'test.wav')
-    data = {
-        'action': 'slice',
-        'mode': 'auto_place',
-        'file': f
-    }
-    resp = client.post('/slice', data=data, content_type='multipart/form-data')
+        return {"message": "sliced", "message_type": "success"}
+
+    monkeypatch.setattr(move_webserver.slice_handler, "handle_post", fake_handle_post)
+    f = (io.BytesIO(b"data"), "test.wav")
+    data = {"action": "slice", "mode": "auto_place", "file": f}
+    resp = client.post("/slice", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
-    assert b'sliced' in resp.data
+    assert b"sliced" in resp.data
+
 
 def test_synth_macros_get(client, monkeypatch):
     def fake_get():
         return {
-            'message': 'choose',
-            'message_type': 'info',
-            'options': '<option value="p">p</option>',
-            'macros_html': '',
-            'selected_preset': None,
-            'schema_json': '{}',
+            "message": "choose",
+            "message_type": "info",
+            "options": '<option value="p">p</option>',
+            "macros_html": "",
+            "selected_preset": None,
+            "schema_json": "{}",
         }
-    monkeypatch.setattr(move_webserver.synth_handler, 'handle_get', fake_get)
-    resp = client.get('/synth-macros')
+
+    monkeypatch.setattr(move_webserver.synth_handler, "handle_get", fake_get)
+    resp = client.get("/synth-macros")
     assert resp.status_code == 200
-    assert b'choose' in resp.data
-    assert b'Currently loaded preset' not in resp.data
+    assert b"choose" in resp.data
+    assert b"Currently loaded preset" not in resp.data
+
 
 def test_synth_macros_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'saved',
-            'message_type': 'success',
-            'macros_html': '<p>done</p>',
-            'all_params_html': '<ul></ul>',
-            'selected_preset': 'x',
-            'browser_root': '/tmp',
-            'schema_json': '{}',
+            "message": "saved",
+            "message_type": "success",
+            "macros_html": "<p>done</p>",
+            "all_params_html": "<ul></ul>",
+            "selected_preset": "x",
+            "browser_root": "/tmp",
+            "schema_json": "{}",
         }
-    monkeypatch.setattr(move_webserver.synth_handler, 'handle_post', fake_post)
-    resp = client.post('/synth-macros', data={'action': 'select_preset'})
+
+    monkeypatch.setattr(move_webserver.synth_handler, "handle_post", fake_post)
+    resp = client.post("/synth-macros", data={"action": "select_preset"})
     assert resp.status_code == 200
-    assert b'saved' in resp.data
-    assert b'Choose Another Preset' in resp.data
-    assert b'<p>done</p>' in resp.data
-    assert b'Currently loaded preset:' in resp.data
-    assert b'View All Parameters' in resp.data
-    assert b'Return to Parameter Editor' in resp.data
+    assert b"saved" in resp.data
+    assert b"Choose Another Preset" in resp.data
+    assert b"<p>done</p>" in resp.data
+    assert b"Currently loaded preset:" in resp.data
+    assert b"View All Parameters" in resp.data
+    assert b"Return to Parameter Editor" in resp.data
+
 
 def test_synth_params_get(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
 
     def fake_get():
         return {
-            'message': 'pick',
-            'message_type': 'info',
-            'file_browser_html': '<ul></ul>',
-            'params_html': '',
-            'selected_preset': None,
-            'param_count': 0,
-            'browser_root': '/tmp',
-            'default_preset_path': DEFAULT_PRESET,
+            "message": "pick",
+            "message_type": "info",
+            "file_browser_html": "<ul></ul>",
+            "params_html": "",
+            "selected_preset": None,
+            "param_count": 0,
+            "browser_root": "/tmp",
+            "default_preset_path": DEFAULT_PRESET,
         }
-    monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_get', fake_get)
-    resp = client.get('/synth-params')
+
+    monkeypatch.setattr(move_webserver.synth_param_handler, "handle_get", fake_get)
+    resp = client.get("/synth-params")
     assert resp.status_code == 200
-    assert b'pick' in resp.data
-    assert b'Editing:' not in resp.data
-    assert b'Create New Drift Preset' in resp.data
+    assert b"pick" in resp.data
+    assert b"Editing:" not in resp.data
+    assert b"Create New Drift Preset" in resp.data
     assert b'name="new_preset_name"' in resp.data
     assert b'id="newPresetModal"' in resp.data
+
 
 def test_synth_params_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'done',
-            'message_type': 'success',
-            'params_html': '<div>p</div>',
-            'browser_root': '/tmp',
-            'selected_preset': 'x',
-            'param_count': 1,
+            "message": "done",
+            "message_type": "success",
+            "params_html": "<div>p</div>",
+            "browser_root": "/tmp",
+            "selected_preset": "x",
+            "param_count": 1,
         }
-    monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
-    resp = client.post('/synth-params', data={'action': 'select_preset'})
+
+    monkeypatch.setattr(move_webserver.synth_param_handler, "handle_post", fake_post)
+    resp = client.post("/synth-params", data={"action": "select_preset"})
     assert resp.status_code == 200
-    assert b'done' in resp.data
-    assert b'Editing:' in resp.data
-    assert b'<div>p</div>' in resp.data
+    assert b"done" in resp.data
+    assert b"Editing:" in resp.data
+    assert b"<div>p</div>" in resp.data
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
-    assert b'disabled' in resp.data
+    assert b"disabled" in resp.data
     assert b'id="randomize-btn"' in resp.data
+
 
 def test_synth_params_get_with_preset(client, monkeypatch):
     def fake_post(form):
-        assert form.getvalue('action') == 'select_preset'
-        assert form.getvalue('preset_select') == 'x'
+        assert form.getvalue("action") == "select_preset"
+        assert form.getvalue("preset_select") == "x"
         return {
-            'message': 'loaded',
-            'message_type': 'success',
-            'params_html': '<div>p</div>',
-            'browser_root': '/tmp',
-            'selected_preset': 'x',
-            'param_count': 1,
-            'default_preset_path': 'x',
-            'macro_knobs_html': '',
-            'rename_checked': False,
+            "message": "loaded",
+            "message_type": "success",
+            "params_html": "<div>p</div>",
+            "browser_root": "/tmp",
+            "selected_preset": "x",
+            "param_count": 1,
+            "default_preset_path": "x",
+            "macro_knobs_html": "",
+            "rename_checked": False,
         }
-    monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
-    resp = client.get('/synth-params?preset=x')
+
+    monkeypatch.setattr(move_webserver.synth_param_handler, "handle_post", fake_post)
+    resp = client.get("/synth-params?preset=x")
     assert resp.status_code == 200
-    assert b'loaded' in resp.data
-    assert b'Editing:' in resp.data
+    assert b"loaded" in resp.data
+    assert b"Editing:" in resp.data
     assert b'id="randomize-btn"' in resp.data
+
 
 def test_synth_params_new_preset(client, monkeypatch):
     from handlers.synth_param_editor_handler_class import DEFAULT_PRESET
 
     def fake_post(form):
         return {
-            'message': 'loaded',
-            'message_type': 'success',
-            'params_html': '<div>x</div>',
-            'browser_root': '/tmp',
-            'selected_preset': DEFAULT_PRESET,
-            'param_count': 2,
-            'default_preset_path': DEFAULT_PRESET,
+            "message": "loaded",
+            "message_type": "success",
+            "params_html": "<div>x</div>",
+            "browser_root": "/tmp",
+            "selected_preset": DEFAULT_PRESET,
+            "param_count": 2,
+            "default_preset_path": DEFAULT_PRESET,
         }
-    monkeypatch.setattr(move_webserver.synth_param_handler, 'handle_post', fake_post)
-    resp = client.post('/synth-params', data={'action': 'new_preset', 'new_preset_name': 'Test'})
+
+    monkeypatch.setattr(move_webserver.synth_param_handler, "handle_post", fake_post)
+    resp = client.post(
+        "/synth-params", data={"action": "new_preset", "new_preset_name": "Test"}
+    )
     assert resp.status_code == 200
-    assert b'loaded' in resp.data
-    assert b'Editing:' in resp.data
+    assert b"loaded" in resp.data
+    assert b"Editing:" in resp.data
     assert b'name="rename"' in resp.data
     assert b'name="new_preset_name"' in resp.data
     assert b'id="randomize-btn"' in resp.data
@@ -265,22 +296,24 @@ def test_synth_params_new_preset(client, monkeypatch):
 def test_wavetable_params_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'ok',
-            'message_type': 'success',
-            'params_html': '<div>p</div>',
-            'browser_root': '/tmp',
-            'selected_preset': 'x',
-            'param_count': 1,
-            'sprites_json': '[]',
-            'sprite1': 'A',
-            'sprite2': 'B',
+            "message": "ok",
+            "message_type": "success",
+            "params_html": "<div>p</div>",
+            "browser_root": "/tmp",
+            "selected_preset": "x",
+            "param_count": 1,
+            "sprites_json": "[]",
+            "sprite1": "A",
+            "sprite2": "B",
         }
 
-    monkeypatch.setattr(move_webserver.wavetable_param_handler, 'handle_post', fake_post)
-    resp = client.post('/wavetable-params', data={'action': 'select_preset'})
+    monkeypatch.setattr(
+        move_webserver.wavetable_param_handler, "handle_post", fake_post
+    )
+    resp = client.post("/wavetable-params", data={"action": "select_preset"})
     assert resp.status_code == 200
-    assert b'ok' in resp.data
-    assert b'<div>p</div>' in resp.data
+    assert b"ok" in resp.data
+    assert b"<div>p</div>" in resp.data
     assert b'name="sprite1"' not in resp.data
 
 
@@ -289,43 +322,45 @@ def test_wavetable_params_get(client, monkeypatch):
 
     def fake_get():
         return {
-            'message': 'pick',
-            'message_type': 'info',
-            'file_browser_html': '<ul></ul>',
-            'params_html': '',
-            'selected_preset': None,
-            'param_count': 0,
-            'browser_root': '/tmp',
-            'default_preset_path': WP,
-            'sprites_json': '[]',
-            'sprite1': '',
-            'sprite2': '',
+            "message": "pick",
+            "message_type": "info",
+            "file_browser_html": "<ul></ul>",
+            "params_html": "",
+            "selected_preset": None,
+            "param_count": 0,
+            "browser_root": "/tmp",
+            "default_preset_path": WP,
+            "sprites_json": "[]",
+            "sprite1": "",
+            "sprite2": "",
         }
 
-    monkeypatch.setattr(move_webserver.wavetable_param_handler, 'handle_get', fake_get)
-    resp = client.get('/wavetable-params')
+    monkeypatch.setattr(move_webserver.wavetable_param_handler, "handle_get", fake_get)
+    resp = client.get("/wavetable-params")
     assert resp.status_code == 200
-    assert b'pick' in resp.data
-    assert b'Create New Wavetable Preset' in resp.data
+    assert b"pick" in resp.data
+    assert b"Create New Wavetable Preset" in resp.data
     assert b'name="sprite1"' not in resp.data
 
 
 def test_melodic_sampler_params_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'ok',
-            'message_type': 'success',
-            'params_html': '<div>p</div>',
-            'browser_root': '/tmp',
-            'selected_preset': 'x',
-            'param_count': 1,
+            "message": "ok",
+            "message_type": "success",
+            "params_html": "<div>p</div>",
+            "browser_root": "/tmp",
+            "selected_preset": "x",
+            "param_count": 1,
         }
 
-    monkeypatch.setattr(move_webserver.melodic_sampler_param_handler, 'handle_post', fake_post)
-    resp = client.post('/melodic-sampler', data={'action': 'select_preset'})
+    monkeypatch.setattr(
+        move_webserver.melodic_sampler_param_handler, "handle_post", fake_post
+    )
+    resp = client.post("/melodic-sampler", data={"action": "select_preset"})
     assert resp.status_code == 200
-    assert b'ok' in resp.data
-    assert b'<div>p</div>' in resp.data
+    assert b"ok" in resp.data
+    assert b"<div>p</div>" in resp.data
 
 
 def test_melodic_sampler_params_get(client, monkeypatch):
@@ -333,75 +368,96 @@ def test_melodic_sampler_params_get(client, monkeypatch):
 
     def fake_get():
         return {
-            'message': 'pick',
-            'message_type': 'info',
-            'file_browser_html': '<ul></ul>',
-            'params_html': '',
-            'selected_preset': None,
-            'param_count': 0,
-            'browser_root': '/tmp',
-            'default_preset_path': MP,
+            "message": "pick",
+            "message_type": "info",
+            "file_browser_html": "<ul></ul>",
+            "params_html": "",
+            "selected_preset": None,
+            "param_count": 0,
+            "browser_root": "/tmp",
+            "default_preset_path": MP,
         }
 
-    monkeypatch.setattr(move_webserver.melodic_sampler_param_handler, 'handle_get', fake_get)
-    resp = client.get('/melodic-sampler')
+    monkeypatch.setattr(
+        move_webserver.melodic_sampler_param_handler, "handle_get", fake_get
+    )
+    resp = client.get("/melodic-sampler")
     assert resp.status_code == 200
-    assert b'pick' in resp.data
-    assert b'Create New Melodic Sampler Preset' in resp.data
+    assert b"pick" in resp.data
+    assert b"Create New Melodic Sampler Preset" in resp.data
+
 
 def test_drum_rack_inspector_get(client, monkeypatch):
     def fake_get():
         return {
-            'file_browser_html': '<ul></ul>',
-            'message': '',
-            'samples_html': '',
-            'browser_root': '/tmp'
+            "file_browser_html": "<ul></ul>",
+            "message": "",
+            "samples_html": "",
+            "browser_root": "/tmp",
         }
-    monkeypatch.setattr(move_webserver.drum_rack_handler, 'handle_get', fake_get)
-    resp = client.get('/drum-rack-inspector')
+
+    monkeypatch.setattr(move_webserver.drum_rack_handler, "handle_get", fake_get)
+    resp = client.get("/drum-rack-inspector")
     assert resp.status_code == 200
     assert b'class="file-browser"' in resp.data
-    assert b'Currently loaded preset' not in resp.data
+    assert b"Currently loaded preset" not in resp.data
+
 
 def test_drum_rack_inspector_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'ok',
-            'message_type': 'success',
-            'samples_html': '<div>grid</div>',
-            'browser_root': '/tmp',
-            'selected_preset': 'x',
+            "message": "ok",
+            "message_type": "success",
+            "samples_html": "<div>grid</div>",
+            "browser_root": "/tmp",
+            "selected_preset": "x",
         }
-    monkeypatch.setattr(move_webserver.drum_rack_handler, 'handle_post', fake_post)
-    resp = client.post('/drum-rack-inspector', data={'action':'select_preset', 'preset_select':'x'})
+
+    monkeypatch.setattr(move_webserver.drum_rack_handler, "handle_post", fake_post)
+    resp = client.post(
+        "/drum-rack-inspector", data={"action": "select_preset", "preset_select": "x"}
+    )
     assert resp.status_code == 200
-    assert b'<div>grid</div>' in resp.data
-    assert b'Currently loaded preset:' in resp.data
+    assert b"<div>grid</div>" in resp.data
+    assert b"Currently loaded preset:" in resp.data
+
 
 def test_chord_get(client):
-    resp = client.get('/chord')
+    resp = client.get("/chord")
     assert resp.status_code == 200
-    assert b'Chord Kit Generator' in resp.data
+    assert b"Chord Kit Generator" in resp.data
     assert b'id="chordList"' in resp.data
+
+
 def test_detect_transients(client, monkeypatch):
     def fake_detect(form):
-        return {'content': '{"success": true}', 'status': 200, 'headers': [('Content-Type', 'application/json')]}
-    monkeypatch.setattr(move_webserver.slice_handler, 'handle_detect_transients', fake_detect)
-    f = (io.BytesIO(b'data'), 'test.wav')
-    resp = client.post('/detect-transients', data={'file': f}, content_type='multipart/form-data')
+        return {
+            "content": '{"success": true}',
+            "status": 200,
+            "headers": [("Content-Type", "application/json")],
+        }
+
+    monkeypatch.setattr(
+        move_webserver.slice_handler, "handle_detect_transients", fake_detect
+    )
+    f = (io.BytesIO(b"data"), "test.wav")
+    resp = client.post(
+        "/detect-transients", data={"file": f}, content_type="multipart/form-data"
+    )
     assert resp.status_code == 200
-    assert resp.json['success'] is True
+    assert resp.json["success"] is True
 
 
 def test_midi_upload_get(client, monkeypatch):
     def fake_get():
         return {
-            'pad_options': '<option value="1">1</option>',
-            'pad_color_options': '<option value="1">1</option>',
-            'pad_grid': '<div class="pad-grid"></div>'
+            "pad_options": '<option value="1">1</option>',
+            "pad_color_options": '<option value="1">1</option>',
+            "pad_grid": '<div class="pad-grid"></div>',
         }
-    monkeypatch.setattr(move_webserver.set_management_handler, 'handle_get', fake_get)
-    resp = client.get('/midi-upload')
+
+    monkeypatch.setattr(move_webserver.set_management_handler, "handle_get", fake_get)
+    resp = client.get("/midi-upload")
     assert resp.status_code == 200
     assert b'class="pad-grid"' in resp.data
 
@@ -409,85 +465,90 @@ def test_midi_upload_get(client, monkeypatch):
 def test_midi_upload_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'ok',
-            'message_type': 'success',
-            'pad_options': '<option value="2">2</option>',
-            'pad_color_options': '<option value="1">1</option>',
-            'pad_grid': '<div class="pad-grid"></div>'
+            "message": "ok",
+            "message_type": "success",
+            "pad_options": '<option value="2">2</option>',
+            "pad_color_options": '<option value="1">1</option>',
+            "pad_grid": '<div class="pad-grid"></div>',
         }
-    monkeypatch.setattr(move_webserver.set_management_handler, 'handle_post', fake_post)
-    f = (io.BytesIO(b'data'), 'test.mid')
+
+    monkeypatch.setattr(move_webserver.set_management_handler, "handle_post", fake_post)
+    f = (io.BytesIO(b"data"), "test.mid")
     data = {
-        'action': 'upload_midi',
-        'midi_type': 'melodic',
-        'set_name': 'MySet',
-        'pad_index': '1',
-        'pad_color': '1',
-        'midi_file': f
+        "action": "upload_midi",
+        "midi_type": "melodic",
+        "set_name": "MySet",
+        "pad_index": "1",
+        "pad_color": "1",
+        "midi_file": f,
     }
-    resp = client.post('/midi-upload', data=data, content_type='multipart/form-data')
+    resp = client.post("/midi-upload", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
-    assert b'ok' in resp.data
+    assert b"ok" in resp.data
+
 
 def test_place_files_post(client, monkeypatch):
     def fake_place(form):
-        return {'message': 'placed', 'message_type': 'success'}
-    monkeypatch.setattr(move_webserver.file_placer_handler, 'handle_post', fake_place)
-    f = (io.BytesIO(b'data'), 'sample.zip')
-    data = {'mode': 'zip', 'file': f, 'destination': '/tmp'}
-    resp = client.post('/place-files', data=data, content_type='multipart/form-data')
+        return {"message": "placed", "message_type": "success"}
+
+    monkeypatch.setattr(move_webserver.file_placer_handler, "handle_post", fake_place)
+    f = (io.BytesIO(b"data"), "sample.zip")
+    data = {"mode": "zip", "file": f, "destination": "/tmp"}
+    resp = client.post("/place-files", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
-    assert resp.json['message'] == 'placed'
+    assert resp.json["message"] == "placed"
 
 
 def test_refresh_post(client, monkeypatch):
     def fake_refresh(form):
-        return {'message': 'refreshed', 'message_type': 'success'}
-    monkeypatch.setattr(move_webserver.refresh_handler, 'handle_post', fake_refresh)
-    resp = client.post('/refresh', data={'action': 'refresh_library'})
+        return {"message": "refreshed", "message_type": "success"}
+
+    monkeypatch.setattr(move_webserver.refresh_handler, "handle_post", fake_refresh)
+    resp = client.post("/refresh", data={"action": "refresh_library"})
     assert resp.status_code == 200
-    assert resp.json['message'] == 'refreshed'
+    assert resp.json["message"] == "refreshed"
 
 
 def test_refresh_get(client, monkeypatch):
-    monkeypatch.setattr(move_webserver, 'refresh_library', lambda: (True, 'done'))
-    resp = client.get('/refresh')
+    monkeypatch.setattr(move_webserver, "refresh_library", lambda: (True, "done"))
+    resp = client.get("/refresh")
     assert resp.status_code == 200
-    assert b'done' in resp.data
+    assert b"done" in resp.data
+
 
 def test_index_redirect(client):
-    resp = client.get('/')
+    resp = client.get("/")
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/restore')
+    assert resp.headers["Location"].endswith("/restore")
 
 
 def test_browse_dir(client, tmp_path):
-    (tmp_path / 'sub').mkdir()
-    (tmp_path / 'a.wav').write_text('x')
-    (tmp_path / 'b.txt').write_text('x')
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.wav").write_text("x")
+    (tmp_path / "b.txt").write_text("x")
     query = {
-        'root': str(tmp_path),
-        'path': '',
-        'action_url': '/do',
-        'field_name': 'file',
-        'action_value': 'act',
-        'filter': 'wav',
+        "root": str(tmp_path),
+        "path": "",
+        "action_url": "/do",
+        "field_name": "file",
+        "action_value": "act",
+        "filter": "wav",
     }
-    resp = client.get('/browse-dir', query_string=query)
+    resp = client.get("/browse-dir", query_string=query)
     assert resp.status_code == 200
     data = resp.data.decode()
     assert 'data-path="sub"' in data
-    assert 'a.wav' in data
-    assert 'b.txt' not in data
+    assert "a.wav" in data
+    assert "b.txt" not in data
 
 
 def test_samples_route(client, tmp_path, monkeypatch):
-    sample = tmp_path / 's.wav'
-    sample.write_bytes(b'data')
+    sample = tmp_path / "s.wav"
+    sample.write_bytes(b"data")
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
 
-    base = '/data/UserData/UserLibrary/Samples/Preset Samples'
+    base = "/data/UserData/UserLibrary/Samples/Preset Samples"
 
     def fake_join(a, *rest):
         if a == base:
@@ -500,18 +561,18 @@ def test_samples_route(client, tmp_path, monkeypatch):
             return real_real(new)
         return real_real(path)
 
-    monkeypatch.setattr(move_webserver.os.path, 'join', fake_join)
-    monkeypatch.setattr(move_webserver.os.path, 'realpath', fake_real)
-    resp = client.get(f'/samples/{sample.name}')
+    monkeypatch.setattr(move_webserver.os.path, "join", fake_join)
+    monkeypatch.setattr(move_webserver.os.path, "realpath", fake_real)
+    resp = client.get(f"/samples/{sample.name}")
     assert resp.status_code == 200
-    assert resp.headers['Access-Control-Allow-Origin'] == '*'
-    assert b'data' in resp.data
+    assert resp.headers["Access-Control-Allow-Origin"] == "*"
+    assert b"data" in resp.data
 
 
 def test_samples_route_not_found(client, tmp_path, monkeypatch):
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
-    base = '/data/UserData/UserLibrary/Samples/Preset Samples'
+    base = "/data/UserData/UserLibrary/Samples/Preset Samples"
 
     def fake_join(a, *rest):
         if a == base:
@@ -524,38 +585,39 @@ def test_samples_route_not_found(client, tmp_path, monkeypatch):
             return real_real(new)
         return real_real(path)
 
-    monkeypatch.setattr(move_webserver.os.path, 'join', fake_join)
-    monkeypatch.setattr(move_webserver.os.path, 'realpath', fake_real)
-    resp = client.get('/samples/missing.wav')
+    monkeypatch.setattr(move_webserver.os.path, "join", fake_join)
+    monkeypatch.setattr(move_webserver.os.path, "realpath", fake_real)
+    resp = client.get("/samples/missing.wav")
     assert resp.status_code == 404
 
 
 def test_pitch_shift_route(client, monkeypatch):
     import sys
+
     monkeypatch.setattr(
-        sys.modules['core.time_stretch_handler'],
-        'pitch_shift_array',
+        sys.modules["core.time_stretch_handler"],
+        "pitch_shift_array",
         lambda d, sr, st: d,
     )
     sr = 22050
     t = np.linspace(0, 1, sr, endpoint=False)
     data = np.sin(2 * np.pi * 440 * t).astype(np.float32)
     buf = io.BytesIO()
-    sf.write(buf, data, sr, format='WAV')
+    sf.write(buf, data, sr, format="WAV")
     buf.seek(0)
     resp = client.post(
-        '/pitch-shift',
-        data={'semitones': '2', 'audio': (buf, 'test.wav')},
-        content_type='multipart/form-data'
+        "/pitch-shift",
+        data={"semitones": "2", "audio": (buf, "test.wav")},
+        content_type="multipart/form-data",
     )
     assert resp.status_code == 200
-    shifted, sr2 = sf.read(io.BytesIO(resp.data), dtype='float32')
+    shifted, sr2 = sf.read(io.BytesIO(resp.data), dtype="float32")
     assert sr2 == sr
     assert len(shifted) == len(data)
 
 
 def test_filter_viz_get(client):
-    resp = client.get('/filter-viz')
+    resp = client.get("/filter-viz")
     assert resp.status_code == 200
     assert b'id="filterChart"' in resp.data
 
@@ -563,39 +625,39 @@ def test_filter_viz_get(client):
 def test_filter_viz_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'status': 200,
-            'headers': [('Content-Type', 'application/json')],
-            'content': '{"freq": [0, 1], "mag": [0, -3]}'
+            "status": 200,
+            "headers": [("Content-Type", "application/json")],
+            "content": '{"freq": [0, 1], "mag": [0, -3]}',
         }
 
-    monkeypatch.setattr(move_webserver.filter_viz_handler, 'handle_post', fake_post)
-    resp = client.post('/filter-viz', data={'filter1_type': 'Lowpass'})
+    monkeypatch.setattr(move_webserver.filter_viz_handler, "handle_post", fake_post)
+    resp = client.post("/filter-viz", data={"filter1_type": "Lowpass"})
     assert resp.status_code == 200
-    assert resp.json['freq'] == [0, 1]
+    assert resp.json["freq"] == [0, 1]
 
 
 def test_filter_viz_parallel_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'status': 200,
-            'headers': [('Content-Type', 'application/json')],
-            'content': '{"freq": [0, 1], "mag1": [0, -3], "mag2": [0, -6]}'
+            "status": 200,
+            "headers": [("Content-Type", "application/json")],
+            "content": '{"freq": [0, 1], "mag1": [0, -3], "mag2": [0, -6]}',
         }
 
-    monkeypatch.setattr(move_webserver.filter_viz_handler, 'handle_post', fake_post)
-    resp = client.post('/filter-viz', data={'routing': 'Parallel'})
+    monkeypatch.setattr(move_webserver.filter_viz_handler, "handle_post", fake_post)
+    resp = client.post("/filter-viz", data={"routing": "Parallel"})
     assert resp.status_code == 200
-    assert resp.json['mag2'] == [0, -6]
+    assert resp.json["mag2"] == [0, -6]
 
 
 def test_files_route_user_library(client, tmp_path, monkeypatch):
-    user_dir = tmp_path / 'user'
+    user_dir = tmp_path / "user"
     user_dir.mkdir()
-    sample = user_dir / 'sample.wav'
-    sample.write_bytes(b'data')
+    sample = user_dir / "sample.wav"
+    sample.write_bytes(b"data")
 
-    base_user = '/data/UserData/UserLibrary'
-    base_core = '/data/CoreLibrary'
+    base_user = "/data/UserData/UserLibrary"
+    base_core = "/data/CoreLibrary"
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
 
@@ -615,23 +677,23 @@ def test_files_route_user_library(client, tmp_path, monkeypatch):
             return real_real(new)
         return real_real(path)
 
-    monkeypatch.setattr(move_webserver.os.path, 'join', fake_join)
-    monkeypatch.setattr(move_webserver.os.path, 'realpath', fake_real)
+    monkeypatch.setattr(move_webserver.os.path, "join", fake_join)
+    monkeypatch.setattr(move_webserver.os.path, "realpath", fake_real)
 
-    resp = client.get('/files/user-library/sample.wav')
+    resp = client.get("/files/user-library/sample.wav")
     assert resp.status_code == 200
-    assert resp.headers['Access-Control-Allow-Origin'] == '*'
-    assert b'data' in resp.data
+    assert resp.headers["Access-Control-Allow-Origin"] == "*"
+    assert b"data" in resp.data
 
 
 def test_files_route_core_library(client, tmp_path, monkeypatch):
-    core_dir = tmp_path / 'core'
+    core_dir = tmp_path / "core"
     core_dir.mkdir()
-    file = core_dir / 'preset.json'
-    file.write_bytes(b'{}')
+    file = core_dir / "preset.json"
+    file.write_bytes(b"{}")
 
-    base_user = '/data/UserData/UserLibrary'
-    base_core = '/data/CoreLibrary'
+    base_user = "/data/UserData/UserLibrary"
+    base_core = "/data/CoreLibrary"
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
 
@@ -651,21 +713,21 @@ def test_files_route_core_library(client, tmp_path, monkeypatch):
             return real_real(new)
         return real_real(path)
 
-    monkeypatch.setattr(move_webserver.os.path, 'join', fake_join)
-    monkeypatch.setattr(move_webserver.os.path, 'realpath', fake_real)
+    monkeypatch.setattr(move_webserver.os.path, "join", fake_join)
+    monkeypatch.setattr(move_webserver.os.path, "realpath", fake_real)
 
-    resp = client.get('/files/core-library/preset.json')
+    resp = client.get("/files/core-library/preset.json")
     assert resp.status_code == 200
-    assert resp.headers['Access-Control-Allow-Origin'] == '*'
-    assert b'{}' in resp.data
+    assert resp.headers["Access-Control-Allow-Origin"] == "*"
+    assert b"{}" in resp.data
 
 
 def test_files_route_not_found(client, tmp_path, monkeypatch):
-    user_dir = tmp_path / 'user'
+    user_dir = tmp_path / "user"
     user_dir.mkdir()
 
-    base_user = '/data/UserData/UserLibrary'
-    base_core = '/data/CoreLibrary'
+    base_user = "/data/UserData/UserLibrary"
+    base_core = "/data/CoreLibrary"
     real_join = move_webserver.os.path.join
     real_real = move_webserver.os.path.realpath
 
@@ -681,24 +743,25 @@ def test_files_route_not_found(client, tmp_path, monkeypatch):
             return real_real(new)
         return real_real(path)
 
-    monkeypatch.setattr(move_webserver.os.path, 'join', fake_join)
-    monkeypatch.setattr(move_webserver.os.path, 'realpath', fake_real)
+    monkeypatch.setattr(move_webserver.os.path, "join", fake_join)
+    monkeypatch.setattr(move_webserver.os.path, "realpath", fake_real)
 
-    resp = client.get('/files/user-library/missing.wav')
+    resp = client.get("/files/user-library/missing.wav")
     assert resp.status_code == 404
 
 
 def test_set_inspector_get(client, monkeypatch):
     def fake_get():
         return {
-            'pad_grid': '<div class="pad-grid"></div>',
-            'clip_grid': '',
-            'message': '',
-            'message_type': 'info',
-            'selected_set': None,
+            "pad_grid": '<div class="pad-grid"></div>',
+            "clip_grid": "",
+            "message": "",
+            "message_type": "info",
+            "selected_set": None,
         }
-    monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_get', fake_get)
-    resp = client.get('/set-inspector')
+
+    monkeypatch.setattr(move_webserver.set_inspector_handler, "handle_get", fake_get)
+    resp = client.get("/set-inspector")
     assert resp.status_code == 200
     assert b'class="pad-grid"' in resp.data
 
@@ -706,42 +769,49 @@ def test_set_inspector_get(client, monkeypatch):
 def test_set_inspector_post(client, monkeypatch):
     def fake_post(form):
         return {
-            'message': 'ok',
-            'message_type': 'success',
-            'pad_grid': '<div class="pad-grid"></div>',
-            'selected_set': '/tmp/a.abl',
-            'clip_grid': '<div class="pad-grid"></div>',
-            'clip_options': '<option>1</option>',
-            'selected_clip': '0:0',
-            'notes': [],
-            'envelopes': [],
-            'region': 4.0,
+            "message": "ok",
+            "message_type": "success",
+            "pad_grid": '<div class="pad-grid"></div>',
+            "selected_set": "/tmp/a.abl",
+            "clip_grid": '<div class="pad-grid"></div>',
+            "clip_options": "<option>1</option>",
+            "selected_clip": "0:0",
+            "notes": [],
+            "envelopes": [],
+            "region": 4.0,
+            "pitch_pads": [],
         }
-    monkeypatch.setattr(move_webserver.set_inspector_handler, 'handle_post', fake_post)
-    resp = client.post('/set-inspector', data={'action': 'select_set', 'pad_index': '1'})
-    assert resp.status_code == 200
-    assert b'ok' in resp.data
 
-    resp = client.post('/set-inspector', data={
-        'action': 'save_envelope',
-        'set_path': '/tmp/a.abl',
-        'clip_select': '0:0',
-        'parameter_id': '1',
-        'envelope_data': '[]'
-    })
+    monkeypatch.setattr(move_webserver.set_inspector_handler, "handle_post", fake_post)
+    resp = client.post(
+        "/set-inspector", data={"action": "select_set", "pad_index": "1"}
+    )
     assert resp.status_code == 200
+    assert b"ok" in resp.data
 
-    resp = client.post('/set-inspector', data={
-        'action': 'save_clip',
-        'set_path': '/tmp/a.abl',
-        'clip_select': '0:0',
-        'clip_notes': '[]',
-        'clip_envelopes': '[]',
-        'region_end': '4.0',
-        'loop_start': '0.0',
-        'loop_end': '4.0'
-    })
+    resp = client.post(
+        "/set-inspector",
+        data={
+            "action": "save_envelope",
+            "set_path": "/tmp/a.abl",
+            "clip_select": "0:0",
+            "parameter_id": "1",
+            "envelope_data": "[]",
+        },
+    )
     assert resp.status_code == 200
 
-
-
+    resp = client.post(
+        "/set-inspector",
+        data={
+            "action": "save_clip",
+            "set_path": "/tmp/a.abl",
+            "clip_select": "0:0",
+            "clip_notes": "[]",
+            "clip_envelopes": "[]",
+            "region_end": "4.0",
+            "loop_start": "0.0",
+            "loop_end": "4.0",
+        },
+    )
+    assert resp.status_code == 200

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -104,28 +104,30 @@ def test_pitch_conversion_roundtrip():
             "noteNumber": 36,
             "startTime": 0.0,
             "duration": 1.0,
-            "pitchBend": 170.6458282470703,
+            "automations": {"PitchBend": [{"time": 0.0, "value": 170.6458282470703}]},
         },
         {
             "noteNumber": 36,
             "startTime": 1.0,
             "duration": 1.0,
-            "pitchBend": -170.6458282470703,
+            "automations": {"PitchBend": [{"time": 0.0, "value": -170.6458282470703}]},
         },
     ]
     steps = sih.notes_to_pitch_steps(notes, 36)
     assert steps[0]["noteNumber"] == 37
     assert steps[1]["noteNumber"] == 35
     recon = sih.steps_to_pitch_notes(steps, 36)
-    assert abs(recon[0]["pitchBend"] - notes[0]["pitchBend"]) < 1e-6
-    assert abs(recon[1]["pitchBend"] - notes[1]["pitchBend"]) < 1e-6
+    orig0 = notes[0]["automations"]["PitchBend"][0]["value"]
+    orig1 = notes[1]["automations"]["PitchBend"][0]["value"]
+    assert abs(recon[0]["pitchBend"] - orig0) < 1e-6
+    assert abs(recon[1]["pitchBend"] - orig1) < 1e-6
 
 
 def test_pitch_bend_pad_detection():
     notes = [
-        {"noteNumber": 36, "pitchBend": 10.0},
-        {"noteNumber": 37, "pitchBend": 0.0},
-        {"noteNumber": 38, "pitchBend": -5.0},
+        {"noteNumber": 36, "automations": {"PitchBend": [{"time": 0.0, "value": 10.0}]}},
+        {"noteNumber": 37},
+        {"noteNumber": 38, "automations": {"PitchBend": [{"time": 0.0, "value": -5.0}]}},
     ]
     pads = sih.pitch_bend_pads(notes)
     assert pads == [36, 38]

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -81,3 +81,16 @@ def test_get_clip_data_param_ranges(monkeypatch, tmp_path):
     assert data["param_ranges"][1]["max"] == 1.0
     env = data["envelopes"][0]
     assert env["rangeMin"] == 0.0 and env["rangeMax"] == 1.0
+
+
+def test_pitch_conversion_roundtrip():
+    notes = [
+        {"noteNumber": 36, "startTime": 0.0, "duration": 1.0, "pitchBend": 170.6458282470703},
+        {"noteNumber": 36, "startTime": 1.0, "duration": 1.0, "pitchBend": -170.6458282470703},
+    ]
+    steps = sih.notes_to_pitch_steps(notes, 36)
+    assert steps[0]["noteNumber"] == 37
+    assert steps[1]["noteNumber"] == 35
+    recon = sih.steps_to_pitch_notes(steps, 36)
+    assert abs(recon[0]["pitchBend"] - notes[0]["pitchBend"]) < 1e-6
+    assert abs(recon[1]["pitchBend"] - notes[1]["pitchBend"]) < 1e-6


### PR DESCRIPTION
## Summary
- add helper functions for converting pitchbend notes in `set_inspector_handler`
- pass pitch edit mode information through the Set Inspector handler
- expose pitch mode fields to the template and JS
- update JS to convert notes to and from pitchbend values
- test pitchbend conversion logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dca3e4958832590aba1101834dba7