### PR TITLE
Add pitchbend pad editor route

### DIFF
--- a/core/pitchbend_editor_handler.py
+++ b/core/pitchbend_editor_handler.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Utilities for editing drum pad pitchbend notes."""
+
+import logging
+from typing import List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+PITCHBEND_STEP = 170.6458282470703
+C2_NOTE = 48
+
+
+def pitchbend_to_note_pitch(pb_value: float) -> float:
+    """Convert a pitchbend value to a note pitch number."""
+    return C2_NOTE + pb_value / PITCHBEND_STEP
+
+
+def note_pitch_to_pitchbend(pitch: float) -> float:
+    """Convert a note pitch back to a pitchbend value."""
+    return (pitch - C2_NOTE) * PITCHBEND_STEP
+
+
+def get_pad_notes(notes: List[Dict[str, Any]], pad_number: int) -> List[Dict[str, Any]]:
+    """Return notes for the given pad with derived pitch information."""
+    pad_notes = []
+    for note in notes:
+        if note.get("noteNumber") != pad_number:
+            continue
+        pb_value = 0.0
+        autom = note.get("automations", {})
+        if autom and autom.get("PitchBend"):
+            pb_value = autom["PitchBend"][0].get("value", 0.0)
+        pad_notes.append(
+            {
+                "startTime": note.get("startTime"),
+                "duration": note.get("duration"),
+                "pitchbend": pb_value,
+                "display_pitch": pitchbend_to_note_pitch(pb_value),
+            }
+        )
+    return pad_notes
+
+
+def apply_pad_edits(
+    notes: List[Dict[str, Any]], pad_number: int, edited: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Apply edited notes back onto the original notes list."""
+    updated: List[Dict[str, Any]] = [n for n in notes if n.get("noteNumber") != pad_number]
+    for ed in edited:
+        pb = note_pitch_to_pitchbend(ed.get("display_pitch", C2_NOTE))
+        updated.append(
+            {
+                "noteNumber": pad_number,
+                "startTime": ed.get("startTime"),
+                "duration": ed.get("duration"),
+                "velocity": ed.get("velocity", 127.0),
+                "offVelocity": ed.get("offVelocity", 0.0),
+                "automations": {"PitchBend": [{"time": 0.0, "value": pb}]},
+            }
+        )
+    return updated

--- a/handlers/pitchbend_editor_handler_class.py
+++ b/handlers/pitchbend_editor_handler_class.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Handler for viewing drum pad pitchbend notes."""
+
+import json
+from handlers.base_handler import BaseHandler
+from core.pitchbend_editor_handler import get_pad_notes
+
+
+class PitchbendEditorHandler(BaseHandler):
+    """Simple handler exposing pitchbend note information."""
+
+    def handle_get(self):
+        return {
+            "notes": None,
+            "message": "Paste note JSON and select pad",
+            "message_type": "info",
+        }
+
+    def handle_post(self, form):
+        action = form.getvalue("action")
+        if action != "display":
+            return self.format_error_response("Invalid action")
+        notes_json = form.getvalue("notes_data")
+        pad_number = form.getvalue("pad_number")
+        if notes_json is None or pad_number is None:
+            return self.format_error_response("Missing notes or pad number")
+        try:
+            notes = json.loads(notes_json)
+            pad = int(pad_number)
+        except Exception as exc:  # noqa: BLE001
+            return self.format_error_response(f"Error parsing input: {exc}")
+        pad_notes = get_pad_notes(notes, pad)
+        return self.format_success_response("Parsed notes", notes=pad_notes)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -38,6 +38,7 @@ from handlers.wavetable_param_editor_handler_class import (
 from handlers.melodic_sampler_param_editor_handler_class import (
     MelodicSamplerParamEditorHandler,
 )
+from handlers.pitchbend_editor_handler_class import PitchbendEditorHandler
 from handlers.drum_rack_inspector_handler_class import DrumRackInspectorHandler
 from handlers.file_placer_handler_class import FilePlacerHandler
 from handlers.refresh_handler_class import RefreshHandler
@@ -128,6 +129,7 @@ synth_handler = SynthPresetInspectorHandler()
 synth_param_handler = SynthParamEditorHandler()
 wavetable_param_handler = WavetableParamEditorHandler()
 melodic_sampler_param_handler = MelodicSamplerParamEditorHandler()
+pitchbend_editor_handler = PitchbendEditorHandler()
 file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
 drum_rack_handler = DrumRackInspectorHandler()
@@ -916,6 +918,26 @@ def pitch_shift_route():
     resp.headers["Content-Type"] = "audio/wav"
     resp.headers["Access-Control-Allow-Origin"] = "*"
     return resp
+
+@app.route("/pitchbend-edit", methods=["GET", "POST"])
+def pitchbend_edit_route():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = pitchbend_editor_handler.handle_post(form)
+    else:
+        result = pitchbend_editor_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    notes = result.get("notes")
+    return render_template(
+        "pitchbend_edit.html",
+        message=message,
+        message_type=message_type,
+        success=success,
+        notes=notes,
+        active_tab="pitchbend-edit",
+    )
 
 
 @app.route("/detect-transients", methods=["POST"])

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -17,6 +17,7 @@
         <!-- <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a> -->
         <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a>
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
+        <a href="{{ host_prefix }}/pitchbend-edit" class="{% if active_tab == 'pitchbend-edit' %}active{% endif %}">Pitchbend Editor</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>

--- a/templates_jinja/pitchbend_edit.html
+++ b/templates_jinja/pitchbend_edit.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Pitchbend Pad Editor</h2>
+{% if message %}
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+<form method="post">
+  <input type="hidden" name="action" value="display">
+  <label for="pad_number">Pad Note Number:</label>
+  <input type="number" id="pad_number" name="pad_number" value="46"><br>
+  <label for="notes_data">Notes JSON:</label><br>
+  <textarea id="notes_data" name="notes_data" rows="10" cols="60">{{ request.form.notes_data or '' }}</textarea><br>
+  <button type="submit">Display Notes</button>
+</form>
+{% if notes %}
+<h3>Notes</h3>
+<pre>{{ notes | tojson(indent=2) }}</pre>
+{% endif %}
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -745,3 +745,9 @@ def test_set_inspector_post(client, monkeypatch):
 
 
 
+def test_pitchbend_edit_get(client):
+    resp = client.get('/pitchbend-edit')
+    assert resp.status_code == 200
+    assert b'Pitchbend Pad Editor' in resp.data
+
+


### PR DESCRIPTION
## Summary
- support pitchbend drum pad editing with new core helper functions
- create a PitchbendEditorHandler and template
- add pitchbend editor to navigation
- expose `/pitchbend-edit` route
- test new route

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd2e755f4832584be0a2b027d6c94