### PR TITLE
Add pitchbend edit utilities

### DIFF
--- a/docs/pitchbend_edit_mode.md
+++ b/docs/pitchbend_edit_mode.md
@@ -1,0 +1,58 @@
+# PitchBend Editing Mode for Drum Pads
+
+## Summary
+Extends the existing clip editor to allow editing per-pad PitchBend automation using the piano roll interface. Users can enter a special mode for any drum pad that reinterprets PitchBend values as pitched note blocks.
+
+## Data Model
+No new data structures are introduced. Each note already stores PitchBend automation data:
+
+```json
+{
+  "noteNumber": 46,
+  "startTime": 0.5,
+  "duration": 0.25,
+  "velocity": 127.0,
+  "offVelocity": 0.0,
+  "automations": {
+    "PitchBend": [
+      { "time": 0.0, "value": 341.2916564941406 }
+    ]
+  }
+}
+```
+
+* Only the first PitchBend value at time `0.0` is used.
+* Notes without a PitchBend entry are hidden when pitch editing.
+* Pitch values are calculated relative to C2 with a scale of `170.6458282470703` units per semitone.
+
+## User Flow
+1. The clip editor displays a music-note icon on pad rows containing PitchBend data.
+2. Clicking the icon enters PitchBend Editing Mode for that pad.
+
+## PitchBend Editing Mode
+* Only notes for the selected pad are shown.
+* Notes are positioned vertically according to their PitchBend value relative to C2.
+* Notes are rendered in blue instead of red.
+* Notes behave as step notes with no curves or glides.
+* The grid and editing interactions match normal clip mode.
+* The pad is monophonic—notes cannot overlap.
+* Editing a note updates its start time, duration and PitchBend value.
+
+## Navigation
+* Users can toggle in and out of pitch editing mode without saving.
+* Changes persist in the original note data.
+* The mode acts as a filtered view scoped to a single pad.
+
+## Suggested Implementation
+```javascript
+const semitone = 170.6458282470703;
+const baseNote = 48; // C2
+const pitch = baseNote + pitchBendValue / semitone;
+```
+Introduce two flags in the clip editor state:
+
+```javascript
+pitchEditMode: boolean;
+activePitchPad: number;
+```
+When `pitchEditMode` is true, filter notes to those matching `activePitchPad` and calculate their vertical position from the first PitchBend value.

--- a/docs/pitchbend_edit_mode.md
+++ b/docs/pitchbend_edit_mode.md
@@ -43,6 +43,9 @@ No new data structures are introduced. Each note already stores PitchBend automa
 * Changes persist in the original note data.
 * The mode acts as a filtered view scoped to a single pad.
 
+## UI Access
+When a clip is loaded in the Set Inspector, a "Note View" dropdown appears. The options include **Clip Notes** (default) and each pad that contains PitchBend data. Selecting a pad switches the piano roll into PitchBend Editing Mode for that pad.
+
 ## Suggested Implementation
 ```javascript
 const semitone = 170.6458282470703;

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -1,5 +1,12 @@
 from handlers.base_handler import BaseHandler
-from core.set_inspector_handler import list_clips, get_clip_data, save_envelope
+from core.set_inspector_handler import (
+    list_clips,
+    get_clip_data,
+    save_envelope,
+    save_clip,
+    extract_pitch_edit_notes,
+    apply_pitch_edit_changes,
+)
 from core.list_msets_handler import list_msets
 from core.pad_colors import rgb_string
 from core.config import MSETS_DIRECTORY
@@ -172,7 +179,6 @@ class SetInspectorHandler(BaseHandler):
             pitch_pad_val = form.getvalue("pitch_pad")
             pitch_pad = int(pitch_pad_val) if pitch_pad_val and pitch_pad_val.isdigit() else None
             notes = result.get("notes", [])
-            from core.set_inspector_handler import extract_pitch_edit_notes
             pitch_pads = sorted(
                 {
                     n.get("noteNumber")
@@ -327,7 +333,6 @@ class SetInspectorHandler(BaseHandler):
                 return self.format_error_response("Invalid clip data", pad_grid=pad_grid)
             pitch_pad_val = form.getvalue("pitch_pad")
             pitch_pad = int(pitch_pad_val) if pitch_pad_val and pitch_pad_val.isdigit() else None
-            from core.set_inspector_handler import save_clip, get_clip_data, apply_pitch_edit_changes
             if pitch_pad is not None:
                 clip_data = get_clip_data(set_path, track_idx, clip_idx)
                 if clip_data.get("success"):
@@ -352,7 +357,6 @@ class SetInspectorHandler(BaseHandler):
             envelopes = clip_data.get("envelopes", [])
             param_map = clip_data.get("param_map", {})
             param_context = clip_data.get("param_context", {})
-            from core.set_inspector_handler import extract_pitch_edit_notes
             pitch_pads = sorted(
                 {
                     n.get("noteNumber")

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -27,6 +27,15 @@ export function initSetInspector() {
     });
   }
 
+  const pitchPadForm = document.getElementById('pitchPadForm');
+  const pitchPadSelect = document.getElementById('pitch_pad_select');
+  const pitchPadInput = document.getElementById('pitch_pad_input');
+  if (pitchPadForm && pitchPadSelect) {
+    pitchPadSelect.addEventListener('change', () => {
+      pitchPadForm.submit();
+    });
+  }
+
   const dataDiv = document.getElementById('clipData');
   if (!dataDiv) return;
   const notes = JSON.parse(dataDiv.dataset.notes || '[]');
@@ -436,6 +445,7 @@ export function initSetInspector() {
     if (regionInput) regionInput.value = (piano.xrange / ticksPerBeat).toFixed(6);
     if (loopStartInput) loopStartInput.value = (piano.markstart / ticksPerBeat).toFixed(6);
     if (loopEndInput) loopEndInput.value = (piano.markend / ticksPerBeat).toFixed(6);
+    if (pitchPadInput && pitchPadSelect) pitchPadInput.value = pitchPadSelect.value;
   });
   if (envSelect && envSelect.value) {
     envSelect.dispatchEvent(new Event('change'));

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -47,6 +47,13 @@
     </form>
     - Clip {{ (clip_index + 1) if clip_index is not none else '?' }}
   </nav>
+  <form id="pitchPadForm" method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem; display:inline;">
+    <input type="hidden" name="action" value="show_clip">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+    <label for="pitch_pad_select">Note View:</label>
+    <select id="pitch_pad_select" name="pitch_pad">{{ pitch_opts | safe }}</select>
+  </form>
   <!-- <form method="post" action="{{ host_prefix }}/set-inspector" style="display:inline;">
     <input type="hidden" name="action" value="select_set">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
@@ -71,6 +78,7 @@
     <input type="hidden" name="action" value="save_clip">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
     <input type="hidden" name="clip_select" value="{{ selected_clip }}">
+    <input type="hidden" name="pitch_pad" id="pitch_pad_input" value="{{ pitch_pad if pitch_pad is not none else '' }}">
     <input type="hidden" name="clip_notes" id="clip_notes_input">
     <input type="hidden" name="clip_envelopes" id="clip_envelopes_input">
     <input type="hidden" name="region_end" id="region_end_input">
@@ -78,7 +86,7 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitch-pad='{{ pitch_pad if pitch_pad is not none else '' }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_pitchbend_utils.py
+++ b/tests/test_pitchbend_utils.py
@@ -1,0 +1,41 @@
+import json
+from core.set_inspector_handler import extract_pitch_edit_notes, apply_pitch_edit_changes
+
+
+def test_extract_and_apply_pitch_edit_notes():
+    notes = [
+        {
+            "noteNumber": 46,
+            "startTime": 0.5,
+            "duration": 0.25,
+            "velocity": 127.0,
+            "offVelocity": 0.0,
+            "automations": {
+                "PitchBend": [
+                    {"time": 0.0, "value": 341.2916564941406}
+                ]
+            }
+        },
+        {  # another pad
+            "noteNumber": 47,
+            "startTime": 1.0,
+            "duration": 0.5,
+            "velocity": 100.0,
+            "offVelocity": 0.0,
+            "automations": {}
+        }
+    ]
+
+    pitch_notes = extract_pitch_edit_notes(notes, 46)
+    assert len(pitch_notes) == 1
+    # 341.2917 / 170.6458 = 2 semitones above C2 -> D2 (50)
+    assert pitch_notes[0]["noteNumber"] == 50
+    assert pitch_notes[0]["startTime"] == 0.5
+
+    # modify pitch and apply back
+    edit = [{"noteNumber": 51, "startTime": 0.75, "duration": 0.25, "velocity": 120.0, "offVelocity": 0.0}]
+    updated = apply_pitch_edit_changes(notes, 46, edit)
+    updated_note = updated[0]
+    assert abs(updated_note["automations"]["PitchBend"][0]["value"] - ((51 - 48) * 170.6458282470703)) < 1e-6
+    assert updated_note["startTime"] == 0.75
+    assert updated_note["duration"] == 0.25


### PR DESCRIPTION
## Summary
- introduce helper functions to convert notes for pitchbend editing
- test pitchbend note conversion logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd53d0050832589e8fcb87b2f89c1