### PR TITLE
Add clip editor context menu functions

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -73,7 +73,8 @@ export function initSetInspector() {
     piano.sequence = notes.map(n => ({
       t: Math.round(n.startTime * ticksPerBeat),
       n: n.noteNumber,
-      g: Math.round(n.duration * ticksPerBeat)
+      g: Math.round(n.duration * ticksPerBeat),
+      v: n.velocity || 100
     }));
     if (!piano.hasAttribute('xrange')) piano.xrange = region * ticksPerBeat;
     if (!piano.hasAttribute('markstart')) piano.markstart = loopStart * ticksPerBeat;
@@ -415,7 +416,7 @@ export function initSetInspector() {
         noteNumber: ev.n,
         startTime: ev.t / ticksPerBeat,
         duration: ev.g / ticksPerBeat,
-        velocity: 100.0,
+        velocity: ev.v ?? 100.0,
         offVelocity: 0.0
       })));
     }


### PR DESCRIPTION
## Summary
- extend `webaudio-pianoroll.js` to support more context menu actions
- preserve note velocity when editing clips
- update `set_inspector.js` to load and save note velocities
- add duplicate, duration, quantize and velocity options to the clip editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3a44bfec8325a813c735b54d80e8