### PR TITLE
Fix clip editor dragging to maintain note offset

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -572,7 +572,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             for(let i=0;i<l;++i){
                 const ev=this.sequence[i];
                 if(ev.f){
-                    ev.t=(((ev.ot+dt)/this.snap+.5)|0)*this.snap;
+                    ev.t=Math.max(0, ev.ot + dt);
                     ev.n=ev.on+dn;
                 }
             }


### PR DESCRIPTION
## Summary
- change note move logic in `webaudio-pianoroll.js` so dragged notes keep their offset from the grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e45e62dd88325bb46d0c8093c08e7