### PR TITLE
Add quantize shortcut and velocity validation

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -158,11 +158,11 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
 <img id="wac-markend" class="marker" src="${this.markendsrc}"/>
 <img id="wac-cursor" class="marker" src="${this.cursorsrc}"/>
 <div id="wac-menu">
-<div data-action="delete">Delete</div>
+<div data-action="delete">Delete (Del)</div>
 <div data-action="duplicate">Duplicate</div>
 <div data-action="double">×2 duration</div>
 <div data-action="half">÷2 duration</div>
-<div data-action="quantize">Quantize to grid</div>
+<div data-action="quantize">Quantize to grid (Q)</div>
 <div data-action="velocity">Velocity...</div>
 </div>
 <select id="wac-gridres"></select>
@@ -555,7 +555,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         };
 
         this.adjustVelocitySelectedNotes=function(v){
-            if(isNaN(v)) return;
+            if(isNaN(v) || v < 1 || v > 127) return;
             for(const ev of this.sequence){
                 if(ev.f)
                     ev.v=v;
@@ -909,6 +909,11 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             case 40://down
                 this.transposeSelectedNotes(-1);
                 this.sortSequence();
+                this.redraw();
+                e.preventDefault();
+                break;
+            case 81://q - quantize
+                this.quantizeSelectedNotes();
                 this.redraw();
                 e.preventDefault();
                 break;


### PR DESCRIPTION
## Summary
- enable `q` as a shortcut to quantize selected notes in the clip editor
- show key hints for Delete and Quantize in the context menu
- clamp velocity input to the 1-127 MIDI range

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684e46affeb08325830821a5ca67905c