### PR TITLE
Add draw mode to piano roll

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -126,7 +126,15 @@ export function initSetInspector() {
     return minV >= 0 && maxV <= 1 && (env.rangeMin !== 0 || env.rangeMax !== 1);
   }
 
-  const defaultEditMode = piano ? (piano.editmode || piano.getAttribute('editmode') || 'drawpoly') : 'drawpoly';
+  let defaultEditMode = piano ? (piano.editmode || piano.getAttribute('editmode') || 'dragpoly') : 'dragpoly';
+  const drawToggle = document.getElementById('note_draw_toggle');
+  if (drawToggle) {
+    drawToggle.checked = defaultEditMode.startsWith('draw');
+    drawToggle.addEventListener('change', () => {
+      defaultEditMode = drawToggle.checked ? 'drawpoly' : 'dragpoly';
+      updateControls();
+    });
+  }
 
   function updateControls() {
     if (canvas) {

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -126,7 +126,7 @@ export function initSetInspector() {
     return minV >= 0 && maxV <= 1 && (env.rangeMin !== 0 || env.rangeMax !== 1);
   }
 
-  const defaultEditMode = piano ? (piano.editmode || piano.getAttribute('editmode') || 'dragpoly') : 'dragpoly';
+  const defaultEditMode = piano ? (piano.editmode || piano.getAttribute('editmode') || 'drawpoly') : 'drawpoly';
 
   function updateControls() {
     if (canvas) {

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -997,7 +997,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                     this.dragging={o:"m"};
                     break;
                 default:
-                    if(this.editmode=="dragmono"||this.editmode=="dragpoly")
+                    if(this.editmode=="dragmono"||this.editmode=="dragpoly"||this.editmode=="drawmono"||this.editmode=="drawpoly")
                         this.dragging={o:"A",p:this.downpos,p2:this.downpos,t1:this.downht.t,n1:this.downht.n};
                     break;
                 }

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -737,7 +737,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         };
         this.editGridMove=function(pos){
             const ht=this.hitTest(pos);
-            if(this.dragging.o=="G"){ 
+            if(this.dragging.o=="G"){
                 switch(this.dragging.m){
                 case "1":
                     const px=((ht.t/this.snap)|0)*this.snap;
@@ -752,6 +752,27 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                         this.delNote(ht.i);
                     break;
                 }
+            }
+        };
+        this.editDrawDown=function(pos){
+            const ht=this.hitTest(pos);
+            if(ht.t>=0){
+                const pt=((ht.t/this.snap)|0)*this.snap;
+                if(this.editmode=="drawmono")
+                    this.delAreaNote(pt,this.grid,ht.i);
+                if(ht.m=="s")
+                    this.addNote(pt,ht.n|0,this.grid,this.defvelo);
+                this.dragging={o:"W"};
+            }
+        };
+        this.editDrawMove=function(pos){
+            const ht=this.hitTest(pos);
+            if(this.dragging.o=="W"&&ht.t>=0){
+                const px=((ht.t/this.snap)|0)*this.snap;
+                if(this.editmode=="drawmono")
+                    this.delAreaNote(px,this.grid,ht.i);
+                if(ht.m=="s")
+                    this.addNote(px,ht.n|0,this.grid,this.defvelo);
             }
         };
         this.setListener=function(el,mode){
@@ -1015,6 +1036,10 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             case "gridmono":
                 this.editGridDown(this.downpos);
                 break;
+            case "drawpoly":
+            case "drawmono":
+                this.editDrawDown(this.downpos);
+                break;
             case "dragpoly":
             case "dragmono":
                 this.editDragDown(this.downpos);
@@ -1116,6 +1141,10 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             case "gridpoly":
             case "gridmono":
                 this.editGridMove(pos);
+                break;
+            case "drawpoly":
+            case "drawmono":
+                this.editDrawMove(pos);
                 break;
             case "dragpoly":
             case "dragmono":

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -62,7 +62,7 @@
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:360px; border:1px solid #ccc;">
-      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
+      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="drawpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
       <canvas id="clipCanvas" width="836" height="300" style="position:absolute; left:64px; top:0; pointer-events:none;"></canvas>
       <canvas id="velocityCanvas" width="836" height="60" style="position:absolute; left:64px; top:300px;"></canvas>
     </div>

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -55,14 +55,16 @@
   <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-left:1rem; display:inline;">
     <button type="submit">Choose Another Set</button>
   </form> -->
-  <div style="margin-top:1rem; display:flex; align-items:center;">
+  <div style="margin-top:1rem; display:flex; align-items:center; gap:0.5rem;">
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
+    <label for="note_draw_toggle" style="margin-left:1rem;">Draw Notes</label>
+    <input id="note_draw_toggle" type="checkbox">
   </div>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:360px; border:1px solid #ccc;">
-      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="drawpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
+      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
       <canvas id="clipCanvas" width="836" height="300" style="position:absolute; left:64px; top:0; pointer-events:none;"></canvas>
       <canvas id="velocityCanvas" width="836" height="60" style="position:absolute; left:64px; top:300px;"></canvas>
     </div>


### PR DESCRIPTION
## Summary
- add new `drawpoly`/`drawmono` edit modes
- hook draw mode into pointer handlers
- default to drawpoly in set inspector

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e4cdab6bc832596eb6672f0d1435b