### PR TITLE
Fix focus loss after grid change

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -889,6 +889,8 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 this.snap=v;
                 this.grid=v;
                 this.redraw();
+                // Return focus to the piano roll so keyboard shortcuts work
+                this.canvas.focus();
             }
         };
         this.setupImage=function(){


### PR DESCRIPTION
## Summary
- keep keyboard shortcuts working by focusing the canvas again when the grid resolution changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e62084dec83259e298a43d18b7b15