### PR TITLE
Add pitch-bend editing dropdown to clip editor

### DIFF
--- a/core/midi_pattern_generator.py
+++ b/core/midi_pattern_generator.py
@@ -145,8 +145,19 @@ def note_name_to_midi(note_name: str) -> int:
     
     # Calculate MIDI number (C4 = 60)
     midi_number = (octave + 1) * 12 + note_map[base_note] + offset
-    
+
     return midi_number
+
+
+def midi_to_note_name(midi_number: int) -> str:
+    """Convert MIDI number to note name using sharps for accidentals."""
+    if not 0 <= midi_number <= 127:
+        raise ValueError(f"Invalid MIDI number: {midi_number}")
+
+    note_names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+    name = note_names[midi_number % 12]
+    octave = midi_number // 12 - 1
+    return f"{name}{octave}"
 
 def create_c_major_downbeats(beats: int = 4) -> List[Dict[str, Any]]:
     """

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -81,6 +81,8 @@ class SetInspectorHandler(BaseHandler):
             "selected_set": None,
             "clip_grid": "",
             "clip_options": "",
+            "pitch_pad_options": "",
+            "pitch_pad_numbers": "[]",
             "selected_clip": None,
             "notes": [],
             "envelopes": [],
@@ -142,6 +144,8 @@ class SetInspectorHandler(BaseHandler):
                 "selected_set": set_path,
                 "set_name": set_name,
                 "clip_grid": clip_grid,
+                "pitch_pad_options": "",
+                "pitch_pad_numbers": "[]",
                 "selected_clip": None,
                 "notes": [],
                 "envelopes": [],
@@ -182,6 +186,12 @@ class SetInspectorHandler(BaseHandler):
                 for e in envelopes
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
+            pitch_pad_nums = sorted({n.get("noteNumber") for n in result.get("notes", []) if "pitchBend" in n})
+            pitch_pad_opts = ''.join(
+                f'<option value="{num}">Note {num}</option>'
+                for num in pitch_pad_nums
+            )
+            pitch_pad_opts = '<option value="">Normal Notes</option>' + pitch_pad_opts
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             return {
@@ -192,6 +202,8 @@ class SetInspectorHandler(BaseHandler):
                 "set_name": set_name,
                 "clip_grid": clip_grid,
                 "clip_options": env_opts,
+                "pitch_pad_options": pitch_pad_opts,
+                "pitch_pad_numbers": json.dumps(pitch_pad_nums),
                 "selected_clip": clip_val,
                 "notes": result.get("notes", []),
                 "envelopes": envelopes,
@@ -249,6 +261,12 @@ class SetInspectorHandler(BaseHandler):
                 for e in envelopes
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
+            pitch_pad_nums = sorted({n.get("noteNumber") for n in clip_data.get("notes", []) if "pitchBend" in n})
+            pitch_pad_opts = ''.join(
+                f'<option value="{num}">Note {num}</option>'
+                for num in pitch_pad_nums
+            )
+            pitch_pad_opts = '<option value="">Normal Notes</option>' + pitch_pad_opts
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             return {
@@ -259,6 +277,8 @@ class SetInspectorHandler(BaseHandler):
                 "set_name": set_name,
                 "clip_grid": clip_grid,
                 "clip_options": env_opts,
+                "pitch_pad_options": pitch_pad_opts,
+                "pitch_pad_numbers": json.dumps(pitch_pad_nums),
                 "selected_clip": clip_val,
                 "notes": clip_data.get("notes", []),
                 "envelopes": envelopes,
@@ -337,6 +357,12 @@ class SetInspectorHandler(BaseHandler):
                 for e in envelopes
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
+            pitch_pad_nums = sorted({n.get("noteNumber") for n in clip_data.get("notes", []) if "pitchBend" in n})
+            pitch_pad_opts = ''.join(
+                f'<option value="{num}">Note {num}</option>'
+                for num in pitch_pad_nums
+            )
+            pitch_pad_opts = '<option value="">Normal Notes</option>' + pitch_pad_opts
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             return {
@@ -347,6 +373,8 @@ class SetInspectorHandler(BaseHandler):
                 "set_name": set_name,
                 "clip_grid": clip_grid,
                 "clip_options": env_opts,
+                "pitch_pad_options": pitch_pad_opts,
+                "pitch_pad_numbers": json.dumps(pitch_pad_nums),
                 "selected_clip": clip_val,
                 "notes": clip_data.get("notes", []),
                 "envelopes": envelopes,

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -1,6 +1,7 @@
 from handlers.base_handler import BaseHandler
 from core.set_inspector_handler import list_clips, get_clip_data, save_envelope
 from core.list_msets_handler import list_msets
+from core.midi_pattern_generator import midi_to_note_name
 from core.pad_colors import rgb_string
 from core.config import MSETS_DIRECTORY
 import json
@@ -188,7 +189,7 @@ class SetInspectorHandler(BaseHandler):
             env_opts = '<option value="">No Envelope</option>' + env_opts
             pitch_pad_nums = sorted({n.get("noteNumber") for n in result.get("notes", []) if "pitchBend" in n})
             pitch_pad_opts = ''.join(
-                f'<option value="{num}">Note {num}</option>'
+                f'<option value="{num}">{midi_to_note_name(num)}</option>'
                 for num in pitch_pad_nums
             )
             pitch_pad_opts = '<option value="">Normal Notes</option>' + pitch_pad_opts
@@ -263,7 +264,7 @@ class SetInspectorHandler(BaseHandler):
             env_opts = '<option value="">No Envelope</option>' + env_opts
             pitch_pad_nums = sorted({n.get("noteNumber") for n in clip_data.get("notes", []) if "pitchBend" in n})
             pitch_pad_opts = ''.join(
-                f'<option value="{num}">Note {num}</option>'
+                f'<option value="{num}">{midi_to_note_name(num)}</option>'
                 for num in pitch_pad_nums
             )
             pitch_pad_opts = '<option value="">Normal Notes</option>' + pitch_pad_opts
@@ -359,7 +360,7 @@ class SetInspectorHandler(BaseHandler):
             env_opts = '<option value="">No Envelope</option>' + env_opts
             pitch_pad_nums = sorted({n.get("noteNumber") for n in clip_data.get("notes", []) if "pitchBend" in n})
             pitch_pad_opts = ''.join(
-                f'<option value="{num}">Note {num}</option>'
+                f'<option value="{num}">{midi_to_note_name(num)}</option>'
                 for num in pitch_pad_nums
             )
             pitch_pad_opts = '<option value="">Normal Notes</option>' + pitch_pad_opts

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -36,6 +36,8 @@ export function initSetInspector() {
   const loopEnd = parseFloat(dataDiv.dataset.loopEnd || String(region));
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
   const pitchPads = JSON.parse(dataDiv.dataset.pitchpads || '[]');
+  const PITCH_BASE = 48; // C3
+  const PITCH_SCALE = 170.6458282470703; // units per semitone
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
   const velCanvas = document.getElementById('velocityCanvas');
@@ -96,7 +98,7 @@ export function initSetInspector() {
     const padNotes = baseNotes.filter(n => n.noteNumber === pad);
     piano.sequence = padNotes.map(n => ({
       t: Math.round(n.startTime * ticksPerBeat),
-      n: Math.round(36 + (n.pitchBend || 0) / 170.6458282470703),
+      n: Math.round(PITCH_BASE + (n.pitchBend || 0) / PITCH_SCALE),
       g: Math.round(n.duration * ticksPerBeat),
       v: Math.round(n.velocity || 100),
       pb: n.pitchBend || 0
@@ -562,7 +564,7 @@ export function initSetInspector() {
         duration: ev.g / ticksPerBeat,
         velocity: ev.v ?? 100.0,
         offVelocity: 0.0,
-        pitchBend: (ev.n - 36) * 170.6458282470703
+        pitchBend: (ev.n - PITCH_BASE) * PITCH_SCALE
       }));
       baseNotes = others.concat(newPad);
     } else {

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -58,6 +58,8 @@
   <div style="margin-top:1rem; display:flex; align-items:center; gap:0.5rem;">
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
+    <label for="pitch_pad_select" style="margin-left:1rem;">Pitch Pad:</label>
+    <select id="pitch_pad_select">{{ pitch_pad_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
     <label for="note_draw_toggle" style="margin-left:1rem;">Draw Notes</label>
     <input id="note_draw_toggle" type="checkbox">
@@ -81,7 +83,7 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-pitchpads='{{ pitch_pad_numbers | safe }}'></div>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/tests/test_midi_helpers.py
+++ b/tests/test_midi_helpers.py
@@ -5,6 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from core.midi_pattern_generator import (
     note_name_to_midi,
+    midi_to_note_name,
     create_scale_pattern,
     create_rhythm_pattern,
 )
@@ -22,6 +23,20 @@ def test_note_name_to_midi_invalid():
         note_name_to_midi("H2")
     with pytest.raises(ValueError):
         note_name_to_midi("C?")
+
+
+def test_midi_to_note_name_basic():
+    assert midi_to_note_name(60) == "C4"
+    assert midi_to_note_name(75) == "D#5"
+    assert midi_to_note_name(58) == "A#3"
+
+
+def test_midi_to_note_name_invalid():
+    import pytest
+    with pytest.raises(ValueError):
+        midi_to_note_name(-1)
+    with pytest.raises(ValueError):
+        midi_to_note_name(128)
 
 
 def test_create_scale_pattern_descending():


### PR DESCRIPTION
## Summary
- extend Set Inspector handler to expose notes with pitch bend data
- show Pitch Pad dropdown next to envelope select
- keep list of pitch-enabled pads in clipData
- implement pitch-editing mode in JS

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e60f03dd48325803c70f1e884f021