### PR TITLE
Implement backup restore for Set Inspector

### DIFF
--- a/core/set_backup_handler.py
+++ b/core/set_backup_handler.py
@@ -1,0 +1,58 @@
+import os
+import shutil
+from datetime import datetime
+
+BACKUP_EXT = '.ablbak'
+
+
+def backup_set(set_path: str) -> str:
+    """Create a timestamped backup of the given set file and keep last 10."""
+    if not os.path.isfile(set_path):
+        raise FileNotFoundError(f"{set_path} not found")
+
+    backup_dir = os.path.join(os.path.dirname(set_path), 'backups')
+    os.makedirs(backup_dir, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%dT%H%M%S%f')
+    backup_name = os.path.basename(set_path) + f'.{timestamp}' + BACKUP_EXT
+    backup_path = os.path.join(backup_dir, backup_name)
+    shutil.copy2(set_path, backup_path)
+
+    backups = sorted(
+        [f for f in os.listdir(backup_dir) if f.endswith(BACKUP_EXT)],
+        key=lambda f: os.path.getmtime(os.path.join(backup_dir, f)),
+        reverse=True,
+    )
+    for old in backups[10:]:
+        try:
+            os.remove(os.path.join(backup_dir, old))
+        except Exception:
+            pass
+    return backup_path
+
+
+def list_backups(set_path: str):
+    """Return a list of backups with display names sorted newest first."""
+    backup_dir = os.path.join(os.path.dirname(set_path), 'backups')
+    if not os.path.isdir(backup_dir):
+        return []
+    backups = sorted(
+        [f for f in os.listdir(backup_dir) if f.endswith(BACKUP_EXT)],
+        key=lambda f: os.path.getmtime(os.path.join(backup_dir, f)),
+        reverse=True,
+    )[:10]
+    result = []
+    for name in backups:
+        path = os.path.join(backup_dir, name)
+        ts = datetime.fromtimestamp(os.path.getmtime(path)).strftime('%Y-%m-%d %H:%M:%S')
+        result.append({'name': name, 'display': ts})
+    return result
+
+
+def restore_backup(set_path: str, backup_name: str) -> bool:
+    """Restore the specified backup over the set file."""
+    backup_dir = os.path.join(os.path.dirname(set_path), 'backups')
+    backup_path = os.path.join(backup_dir, backup_name)
+    if not os.path.isfile(backup_path):
+        return False
+    shutil.copy2(backup_path, set_path)
+    return True

--- a/core/set_backup_handler.py
+++ b/core/set_backup_handler.py
@@ -50,7 +50,10 @@ def list_backups(set_path: str):
 
 def restore_backup(set_path: str, backup_name: str) -> bool:
     """Restore the specified backup over the set file."""
-    backup_dir = os.path.join(os.path.dirname(set_path), 'backups')
+    backup_dir = os.path.join(os.path.dirname(set_path), "backups")
+    # Prevent path traversal by only allowing base names
+    if os.path.basename(backup_name) != backup_name:
+        return False
     backup_path = os.path.join(backup_dir, backup_name)
     if not os.path.isfile(backup_path):
         return False

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -1,6 +1,7 @@
 import json
 import os
 from typing import Any, Dict, List
+from core.set_backup_handler import backup_set
 from core.synth_preset_inspector_handler import (
     load_drift_schema,
     load_wavetable_schema,
@@ -163,6 +164,8 @@ def save_envelope(
         else:
             envelopes.append({"parameterId": parameter_id, "breakpoints": breakpoints})
 
+        backup_set(set_path)
+        backup_set(set_path)
         with open(set_path, "w") as f:
             json.dump(song, f, indent=2)
 

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -165,7 +165,6 @@ def save_envelope(
             envelopes.append({"parameterId": parameter_id, "breakpoints": breakpoints})
 
         backup_set(set_path)
-        backup_set(set_path)
         with open(set_path, "w") as f:
             json.dump(song, f, indent=2)
 
@@ -197,6 +196,7 @@ def save_clip(
         region_info["end"] = region_end
         region_info["loop"] = {"start": loop_start, "end": loop_end}
 
+        backup_set(set_path)
         with open(set_path, "w") as f:
             json.dump(song, f, indent=2)
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -348,6 +348,7 @@ def set_inspector_route():
         loop_start=result.get("loop_start", 0.0),
         loop_end=result.get("loop_end", result.get("region")),
         param_ranges_json=result.get("param_ranges_json", "{}"),
+        backups=result.get("backups", []),
         active_tab="set-inspector",
     )
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -25,6 +25,19 @@
     {{ clip_grid | safe }}
     <span id="selected-clip-name" style="margin-left:1rem;"></span>
   </form>
+  {% if backups %}
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+    <input type="hidden" name="action" value="restore_backup">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <label for="backup_select">Restore backup:</label>
+    <select name="backup_file" id="backup_select">
+      {% for b in backups %}
+        <option value="{{ b.name }}">{{ b.display }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit">Restore</button>
+  </form>
+  {% endif %}
   <!-- <form method="get" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <button type="submit">Choose Another Set</button>
   </form> -->
@@ -81,6 +94,19 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
+  {% if backups %}
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
+    <input type="hidden" name="action" value="restore_backup">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <label for="backup_select2">Restore backup:</label>
+    <select name="backup_file" id="backup_select2">
+      {% for b in backups %}
+        <option value="{{ b.name }}">{{ b.display }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit">Restore</button>
+  </form>
+  {% endif %}
   <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
   {% endif %}
 {% endblock %}

--- a/tests/test_set_backup.py
+++ b/tests/test_set_backup.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.set_backup_handler import backup_set, list_backups, restore_backup
+
+
+def test_backup_and_restore(tmp_path):
+    set_file = tmp_path / "Song.abl"
+    set_file.write_text("{\"tempo\":120}")
+    # create multiple backups
+    for i in range(11):
+        set_file.write_text(f"version{i}")
+        backup_set(str(set_file))
+    backups = list_backups(str(set_file))
+    assert len(backups) == 10
+    latest = backups[0]['name']
+    # corrupt file then restore
+    set_file.write_text("corrupt")
+    assert restore_backup(str(set_file), latest)
+    assert set_file.read_text() != "corrupt"


### PR DESCRIPTION
## Summary
- add new helper `set_backup_handler` to manage backups
- create backups when saving clips or envelopes
- show backup list on Set Inspector page and allow restore
- test backup logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `pytest tests/test_set_backup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684e79c23e008325824b680804671ac3