### PR TITLE
Update envelope editor visuals

### DIFF
--- a/static/adsr.js
+++ b/static/adsr.js
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
+    ctx.lineWidth = 2;
     ctx.moveTo(0, h - i * h);
     let x = (a / total) * w;
     ctx.lineTo(x, h - p * h);
@@ -31,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const relStart = w - (r / total) * w;
     ctx.lineTo(relStart, h - s * h);
     ctx.lineTo(w, h - f * h);
-    ctx.strokeStyle = '#f00';
+    ctx.strokeStyle = '#FFA500';
     ctx.stroke();
   }
 

--- a/static/cyc_env.js
+++ b/static/cyc_env.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
+    ctx.lineWidth = 2;
     const steps = 100;
     const peakPos = Math.min(Math.max((tilt - 0.2) / 0.8, 0), 1);
     const riseEnd = peakPos * (1 - hold);
@@ -45,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ctx.lineTo(x, yPix);
       }
     }
-    ctx.strokeStyle = '#f00';
+    ctx.strokeStyle = '#FFA500';
     ctx.stroke();
   }
 

--- a/static/lfo.js
+++ b/static/lfo.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
     ctx.beginPath();
+    ctx.lineWidth = 2;
 
     const minRate = parseFloat(rateEl.min || '0');
     const maxRate = parseFloat(rateEl.max || '1');
@@ -50,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const y = h - val * h;
       if (i === 0) ctx.moveTo(i, y); else ctx.lineTo(i, y);
     }
-    ctx.strokeStyle = '#f00';
+    ctx.strokeStyle = '#FFA500';
     ctx.stroke();
   }
 

--- a/static/param_adsr.js
+++ b/static/param_adsr.js
@@ -32,6 +32,7 @@ export function initParamAdsr() {
       const h = canvas.height;
       ctx.clearRect(0, 0, w, h);
       ctx.beginPath();
+      ctx.lineWidth = 2;
       ctx.moveTo(0, h - i * h);
       let x = (a / total) * w;
       ctx.lineTo(x, h - p * h);
@@ -40,7 +41,7 @@ export function initParamAdsr() {
       const relStart = w - (r / total) * w;
       ctx.lineTo(relStart, h - s * h);
       ctx.lineTo(w, h - f * h);
-      ctx.strokeStyle = '#f00';
+      ctx.strokeStyle = '#FFA500';
       ctx.stroke();
     }
 

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -232,7 +232,8 @@ export function initSetInspector() {
       env = envInfo;
     }
     if (!env || !env.breakpoints || !env.breakpoints.length) return;
-    ctx.strokeStyle = '#FF4136';
+    ctx.strokeStyle = '#FFA500';
+    ctx.lineWidth = 2;
     ctx.beginPath();
     const needsScale = isNormalized(env);
     env.breakpoints.forEach((bp, i) => {


### PR DESCRIPTION
## Summary
- use orange stroke and thicker line width in envelope editors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e76b97b408325a2b94fbfc382248e