### PR TITLE
Fix Y zoom limits in piano roll

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1314,6 +1314,13 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.layout=function(){
             if(typeof(this.kbwidth)=="undefined")
                 return;
+            // Limit the vertical zoom so it never exceeds the MIDI note range
+            // and stays within 0-127.
+            const MAX_NOTES = 128;
+            if(this._yrange > MAX_NOTES) this._yrange = MAX_NOTES;
+            if(this._yoffset < 0) this._yoffset = 0;
+            if(this._yoffset > 127) this._yoffset = 127;
+            if(this._yrange > this._yoffset) this._yrange = this._yoffset;
             const proll = this.proll;
             const bodystyle = this.body.style;
             if(this.bgsrc)


### PR DESCRIPTION
## Summary
- prevent vertical zoom from showing outside the 0-127 MIDI note range

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee90abf2c83259a3e9700755f3568