### PR TITLE
Clamp Y zoom in pianoroll

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -190,6 +190,14 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.updateTimer=function(){
             this.tick2time=4*60/this.tempo/this.timebase;
         };
+        this.clampYRange=function(){
+            if(this._yrange>128)
+                this._yrange=128;
+            if(this._yoffset<0)
+                this._yoffset=0;
+            if(this._yoffset+this._yrange>128)
+                this._yoffset=128-this._yrange;
+        };
         this.play=function(actx,playcallback,tick){
             function Interval(){
                 const current=this.actx.currentTime;
@@ -1314,6 +1322,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.layout=function(){
             if(typeof(this.kbwidth)=="undefined")
                 return;
+            this.clampYRange();
             const proll = this.proll;
             const bodystyle = this.body.style;
             if(this.bgsrc)


### PR DESCRIPTION
## Summary
- prevent zooming out beyond MIDI note range

## Testing
- `pytest tests/test_midi_helpers.py::test_note_name_to_midi_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_684eebf453588325a4ad233c9316d5ae