### PR TITLE
Add random fill option for piano roll

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1040,6 +1040,11 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 case "N":
                 case "B":
                 case "E":
+                case "n":
+                    if(this.downht.m=="n"){
+                        this.clearSel();
+                        this.sequence[this.downht.i].f=1;
+                    }
                     this.menuGlobal=false;
                     this.menuDelete.classList.remove('disabled');
                     this.menuNoteRow=this.downht.n|0;
@@ -1105,6 +1110,11 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 case "N":
                 case "B":
                 case "E":
+                case "n":
+                    if(this.downht.m=="n"){
+                        this.clearSel();
+                        this.sequence[this.downht.i].f=1;
+                    }
                     this.menuGlobal=false;
                     this.menuDelete.classList.remove('disabled');
                     this.menuNoteRow=this.downht.n|0;

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1087,9 +1087,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 case "s":
                     this.menuGlobal=true;
                     this.clearSel();
-                    this.menuDelete.classList.add('disabled');
-                    this.popMenu(this.downpos);
-                    this.dragging={o:"m"};
+                    this.dragging={o:"A",p:this.downpos,p2:this.downpos,t1:this.downht.t,n1:this.downht.n,right:true};
                     break;
                 default:
                     if(this.editmode=="dragmono"||this.editmode=="dragpoly"||this.editmode=="drawmono"||this.editmode=="drawpoly")
@@ -1301,9 +1299,19 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 this.redraw();
             }
             if(this.dragging.o=="A"){
-                this.selAreaNote(this.dragging.t1,this.dragging.t2,this.dragging.n1,this.dragging.n2);
-                this.dragging={o:null};
-                this.redraw();
+                const moved=Math.abs(this.dragging.p.x-pos.x)+Math.abs(this.dragging.p.y-pos.y);
+                if(this.dragging.right && moved<4){
+                    this.menuDelete.classList.add('disabled');
+                    this.popMenu(this.dragging.p);
+                    this.dragging={o:"m"};
+                    this.menuGlobal=true;
+                    this.redraw();
+                    return false;
+                }else{
+                    this.selAreaNote(this.dragging.t1,this.dragging.t2,this.dragging.n1,this.dragging.n2);
+                    this.dragging={o:null};
+                    this.redraw();
+                }
             }
 //            if(this.dragging.o=="D"){
                 if(this.editmode=="dragmono"){

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -580,13 +580,14 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
 
         this.randomFillRow=function(note){
             for(let i=this.sequence.length-1;i>=0;--i){
-                if(this.sequence[i].n===note)
+                const ev=this.sequence[i];
+                if(ev.n===note && ev.t>=this.markstart && ev.t<this.markend)
                     this.sequence.splice(i,1);
             }
-            const steps=Math.floor(this.xrange/this.grid);
+            const steps=Math.floor((this.markend-this.markstart)/this.grid);
             for(let s=0;s<steps;++s){
                 if(Math.random()<0.5){
-                    const t=s*this.grid;
+                    const t=this.markstart+s*this.grid;
                     this.addNote(t,note,this.grid,this.defvelo);
                 }
             }
@@ -1045,6 +1046,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                     break;
                 case "s":
                     this.menuGlobal=true;
+                    this.clearSel();
                     this.menuDelete.classList.add('disabled');
                     this.popMenu(this.downpos);
                     this.dragging={o:"m"};
@@ -1084,6 +1086,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                     break;
                 case "s":
                     this.menuGlobal=true;
+                    this.clearSel();
                     this.menuDelete.classList.add('disabled');
                     this.popMenu(this.downpos);
                     this.dragging={o:"m"};

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -421,7 +421,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.hitTest=function(pos){
             const ht={t:0,n:0,i:-1,m:" "};
             const l=this.sequence.length;
-            if(pos.t==this.menu){
+            if(this.menu.contains(pos.t)){
                 ht.m="m";
                 return ht;
             }
@@ -863,6 +863,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             this.menu=this.elem.children[5];
             this.menuDelete=this.menu.children[0];
             this.menuGlobal=false;
+            this.menuNoteRow=0;
             this.gridselect=this.elem.children[6];
             this.rcMenu={x:0, y:0, width:0, height:0};
             this.lastx=0;
@@ -1041,6 +1042,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 case "E":
                     this.menuGlobal=false;
                     this.menuDelete.classList.remove('disabled');
+                    this.menuNoteRow=this.downht.n|0;
                     this.popMenu(this.downpos);
                     this.dragging={o:"m"};
                     break;
@@ -1048,6 +1050,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                     this.menuGlobal=true;
                     this.clearSel();
                     this.menuDelete.classList.add('disabled');
+                    this.menuNoteRow=this.downht.n|0;
                     this.popMenu(this.downpos);
                     this.dragging={o:"m"};
                     break;
@@ -1062,6 +1065,23 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 e = ev.touches[0];
             else
                 e = ev;
+
+            if(this.menu.style.display=="block" && !this.menu.contains(e.target)){
+                this.menu.style.display="none";
+                this.rcMenu={x:0,y:0,width:0,height:0};
+                this.menuDelete.classList.remove('disabled');
+                this.menuGlobal=false;
+                window.removeEventListener('mousemove',this.bindpointermove,false);
+                window.removeEventListener('touchend',this.bindcancel,false);
+                window.removeEventListener('mouseup',this.bindcancel,false);
+            }
+
+            if(this.menu.style.display=="block" && this.menu.contains(e.target)){
+                this.downpos=this.getPos(e);
+                this.downht={m:"m"};
+                this.dragging={o:"m"};
+                return;
+            }
             this.rcTarget=this.canvas.getBoundingClientRect();
             this.downpos=this.getPos(e);
             this.downht=this.hitTest(this.downpos);
@@ -1081,12 +1101,14 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 case "E":
                     this.menuGlobal=false;
                     this.menuDelete.classList.remove('disabled');
+                    this.menuNoteRow=this.downht.n|0;
                     this.popMenu(this.downpos);
                     this.dragging={o:"m"};
                     break;
                 case "s":
                     this.menuGlobal=true;
                     this.clearSel();
+                    this.menuNoteRow=this.downht.n|0;
                     this.dragging={o:"A",p:this.downpos,p2:this.downpos,t1:this.downht.t,n1:this.downht.n,right:true};
                     break;
                 default:
@@ -1286,7 +1308,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                         this.quantizeSelectedNotes();
                         break;
                     case 'randomfill':
-                        this.randomFillRow(this.downht.n|0);
+                        this.randomFillRow(this.menuNoteRow);
                         break;
                     case 'velocity':
                         const v=parseInt(prompt('Velocity (1-127):','100'),10);
@@ -1302,6 +1324,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 const moved=Math.abs(this.dragging.p.x-pos.x)+Math.abs(this.dragging.p.y-pos.y);
                 if(this.dragging.right && moved<4){
                     this.menuDelete.classList.add('disabled');
+                    this.menuNoteRow=this.dragging.n1|0;
                     this.popMenu(this.dragging.p);
                     this.dragging={o:"m"};
                     this.menuGlobal=true;

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -166,6 +166,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
 <div data-action="double">×2 duration</div>
 <div data-action="half">÷2 duration</div>
 <div data-action="quantize">Quantize to grid (Q)</div>
+<div data-action="randomfill">Random fill row</div>
 <!-- <div data-action="velocity">Velocity...</div> -->
 </div>
 <select id="wac-gridres"></select>
@@ -563,6 +564,22 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 if(ev.f)
                     ev.v=v;
             }
+            this.redraw();
+        };
+
+        this.randomFillRow=function(note){
+            for(let i=this.sequence.length-1;i>=0;--i){
+                if(this.sequence[i].n===note)
+                    this.sequence.splice(i,1);
+            }
+            const steps=Math.floor(this.xrange/this.grid);
+            for(let s=0;s<steps;++s){
+                if(Math.random()<0.5){
+                    const t=s*this.grid;
+                    this.addNote(t,note,this.grid,this.defvelo);
+                }
+            }
+            this.sortSequence();
             this.redraw();
         };
         this.moveSelectedNote=function(dt,dn){
@@ -1232,6 +1249,9 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                         break;
                     case 'quantize':
                         this.quantizeSelectedNotes();
+                        break;
+                    case 'randomfill':
+                        this.randomFillRow(this.downht.n|0);
                         break;
                     case 'velocity':
                         const v=parseInt(prompt('Velocity (1-127):','100'),10);

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1074,8 +1074,12 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 window.removeEventListener('mousemove',this.bindpointermove,false);
                 window.removeEventListener('touchend',this.bindcancel,false);
                 window.removeEventListener('mouseup',this.bindcancel,false);
-                if(e.button==2||e.ctrlKey)
+                if(e.button==2||e.ctrlKey){
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    window.addEventListener("contextmenu",this.bindcontextmenu);
                     return;
+                }
             }
 
             if(this.menu.style.display=="block" && this.menu.contains(e.target)){

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1074,6 +1074,8 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 window.removeEventListener('mousemove',this.bindpointermove,false);
                 window.removeEventListener('touchend',this.bindcancel,false);
                 window.removeEventListener('mouseup',this.bindcancel,false);
+                if(e.button==2||e.ctrlKey)
+                    return;
             }
 
             if(this.menu.style.display=="block" && this.menu.contains(e.target)){

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1286,9 +1286,9 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 clearInterval(this.longtaptimer);
             const pos=this.getPos(e);
             if(this.dragging.o=="m"){
-                this.menu.style.display="none";
-                this.rcMenu={x:0,y:0,width:0,height:0};
                 if(pos.t && this.menu.contains(pos.t)){
+                    this.menu.style.display="none";
+                    this.rcMenu={x:0,y:0,width:0,height:0};
                     const act=pos.t.dataset.action;
                     switch(act){
                     case 'delete':
@@ -1321,10 +1321,10 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                         this.adjustVelocitySelectedNotes(v);
                         break;
                     }
+                    this.menuDelete.classList.remove('disabled');
+                    this.menuGlobal=false;
+                    this.redraw();
                 }
-                this.menuDelete.classList.remove('disabled');
-                this.menuGlobal=false;
-                this.redraw();
             }
             if(this.dragging.o=="A"){
                 const moved=Math.abs(this.dragging.p.x-pos.x)+Math.abs(this.dragging.p.y-pos.y);


### PR DESCRIPTION
## Summary
- extend webaudio-pianoroll context menu with "Random fill row"
- implement `randomFillRow` to create grid-aligned random notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684eec5b9be4832591eac9e2e45dc33a