### PR TITLE
Add undo/redo to clip editor

### DIFF
--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -95,6 +95,10 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
+  <div style="margin-top:0.5rem;">
+    <button id="undoBtn" type="button">Undo</button>
+    <button id="redoBtn" type="button" style="margin-left:0.5rem;">Redo</button>
+  </div>
   {% if backups %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
     <input type="hidden" name="action" value="restore_backup">


### PR DESCRIPTION
## Summary
- add Undo/Redo buttons to the set inspector
- keep an undo/redo history in `set_inspector.js`
- snapshot state before edits and restore with keyboard shortcuts or buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f054ba9308325af9152ed8e9614e8