### PR TITLE
Fix Euclidean fill preview

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -1333,7 +1333,8 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                         this.quantizeSelectedNotes();
                         break;
                     case 'euclid':
-                        this.dispatchEvent(new CustomEvent('euclidfill', { detail: { row: this.downht.n|0 } }));
+                        this.dispatchEvent(new CustomEvent('euclidfill', { detail: { row: this.menuNoteRow } }));
+                        break;
                     case 'randomfill':
                         this.randomFillRow(this.menuNoteRow);
                         break;


### PR DESCRIPTION
## Summary
- fix Euclidean fill context menu handling in `webaudio-pianoroll.js`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f10b5eac08325aff42e3d271879f4