### PR TITLE
Fix euclid fill 1/32 resolution bug

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -601,9 +601,9 @@ export function initSetInspector() {
       piano.sequence = piano.sequence.filter(ev => !(ev.n === row && ev.t >= startT && ev.t < endT));
       ghostNotes.forEach(n => {
         piano.sequence.push({
-          t: Math.round(n.startTime * ticksPerBeat),
+          t: n.startTime * ticksPerBeat,
           n: row,
-          g: Math.round(n.duration * ticksPerBeat),
+          g: n.duration * ticksPerBeat,
           v: n.velocity
         });
       });


### PR DESCRIPTION
## Summary
- keep fractional tick values when applying Euclidean fill

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f15b479f483258bfb31afa7928c98