### PR TITLE
Add repeating Euclidean fill option

### DIFF
--- a/core/euclidean.py
+++ b/core/euclidean.py
@@ -26,8 +26,12 @@ def apply_euclidean_fill(
     pulses: int,
     rotate: int,
     grid: float,
+    repeat: bool = False,
 ) -> List[Dict[str, Any]]:
-    """Return new notes list with Euclidean pattern applied to the given row."""
+    """Return new notes list with Euclidean pattern applied to the given row.
+
+    If ``repeat`` is True, the generated pattern is repeated until ``loop_end``.
+    """
     onsets = euclidean_rhythm(steps, pulses, rotate)
     new_notes = [
         n
@@ -37,17 +41,25 @@ def apply_euclidean_fill(
             and loop_start <= n.get("startTime", 0) < loop_end
         )
     ]
-    for step in onsets:
-        start = loop_start + step * grid
-        new_notes.append(
-            {
-                "noteNumber": note_number,
-                "startTime": start,
-                "duration": grid,
-                "velocity": 100,
-                "offVelocity": 0,
-            }
-        )
+    pattern_len = steps * grid
+    base = 0.0
+    while True:
+        for step in onsets:
+            start = loop_start + base + step * grid
+            if start >= loop_end:
+                break
+            new_notes.append(
+                {
+                    "noteNumber": note_number,
+                    "startTime": start,
+                    "duration": grid,
+                    "velocity": 100,
+                    "offVelocity": 0,
+                }
+            )
+        if not repeat or loop_start + base + pattern_len >= loop_end:
+            break
+        base += pattern_len
     new_notes.sort(key=lambda x: x["startTime"])
     return new_notes
 

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -547,6 +547,7 @@ export function initSetInspector() {
   const lenInput = document.getElementById('euclid_length');
   const pulsesInput = document.getElementById('euclid_pulses');
   const rotateInput = document.getElementById('euclid_rotate');
+  const repeatBox = document.getElementById('euclid_repeat');
   if (euclidModal) {
     const okBtn = document.getElementById('euclid_ok');
     const cancelBtn = document.getElementById('euclid_cancel');
@@ -559,15 +560,24 @@ export function initSetInspector() {
       const rot = Math.max(0, Math.min(parseInt(rotateInput.value), steps - 1));
       const row = parseInt(euclidModal.dataset.row || '60');
       const ons = euclideanRhythm(steps, pulses, rot);
-      ons.forEach(st => {
-        ghostNotes.push({
-          noteNumber: row,
-          startTime: (piano.markstart + st * piano.grid) / ticksPerBeat,
-          duration: piano.grid / ticksPerBeat,
-          velocity: 100,
-          offVelocity: 0
+      const repeat = repeatBox && repeatBox.checked;
+      const startT = piano.markstart;
+      const endT = piano.markend;
+      const patLen = steps * piano.grid;
+      for (let base = 0; ; base += patLen) {
+        ons.forEach(st => {
+          const t = startT + base + st * piano.grid;
+          if (t >= endT) return;
+          ghostNotes.push({
+            noteNumber: row,
+            startTime: t / ticksPerBeat,
+            duration: piano.grid / ticksPerBeat,
+            velocity: 100,
+            offVelocity: 0
+          });
         });
-      });
+        if (!repeat || startT + base + patLen >= endT) break;
+      }
       draw();
     }
 
@@ -577,7 +587,7 @@ export function initSetInspector() {
       timer = setTimeout(updatePreview, 150);
     }
 
-    [lenInput, pulsesInput, rotateInput].forEach(el => el && el.addEventListener('input', debounced));
+    [lenInput, pulsesInput, rotateInput, repeatBox].forEach(el => el && el.addEventListener('input', debounced));
 
     function openModal(row) {
       euclidModal.dataset.row = row;
@@ -585,6 +595,7 @@ export function initSetInspector() {
       lenInput.value = steps;
       pulsesInput.value = Math.max(1, Math.min(Math.floor(steps / 2), steps));
       rotateInput.value = 0;
+      if (repeatBox) repeatBox.checked = false;
       removedNotes = piano.sequence.filter(ev => ev.n === row && ev.t >= piano.markstart && ev.t < piano.markend);
       if (removedNotes.length) {
         piano.sequence = piano.sequence.filter(ev => !removedNotes.includes(ev));

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -124,6 +124,7 @@
       <label>Loop length: <input type="number" id="euclid_length" min="1" max="64"></label>
       <label>Pulses: <input type="number" id="euclid_pulses" min="1" max="64"></label>
       <label>Rotate: <input type="number" id="euclid_rotate" min="0" max="63" value="0"></label>
+      <label><input type="checkbox" id="euclid_repeat"> Repeat in loop</label>
       <div style="margin-top:0.5rem;">
         <button id="euclid_ok" type="button">OK</button>
         <button id="euclid_cancel" type="button">Cancel</button>

--- a/tests/test_euclidean.py
+++ b/tests/test_euclidean.py
@@ -21,3 +21,10 @@ def test_apply_fill_overwrites_only_row():
     assert any(n["noteNumber"] == 61 for n in new_notes)
     starts = [n["startTime"] for n in new_notes if n["noteNumber"] == 60]
     assert starts == [0.25, 0.75]
+
+
+def test_repeat_in_loop():
+    notes = []
+    new_notes = apply_euclidean_fill(notes, 60, 0.0, 4.0, 5, 2, 0, 0.25, repeat=True)
+    starts = [n["startTime"] for n in new_notes if n["noteNumber"] == 60]
+    assert starts == [0.5, 1.0, 1.75, 2.25, 3.0, 3.5]

--- a/tests/test_set_inspector_euclid.py
+++ b/tests/test_set_inspector_euclid.py
@@ -8,6 +8,7 @@ INSPECTOR_JS = Path(__file__).resolve().parents[1] / 'static' / 'set_inspector.j
 def test_euclid_modal_present():
     html = TEMPLATE.read_text()
     assert 'id="euclidModal"' in html
+    assert 'id="euclid_repeat"' in html
     js = SCRIPT.read_text()
     assert 'data-action="euclid"' in js
     inspector = INSPECTOR_JS.read_text()


### PR DESCRIPTION
## Summary
- support repeating Euclidean patterns until loop end
- expose repeat option in Euclidean fill modal
- preview Euclidean repeats in the Set Inspector UI
- test that repeating works in Python logic and HTML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, mido, requests, flask)*

------
https://chatgpt.com/codex/tasks/task_e_684f156a9da883259eb047730238483b