### PR TITLE
Add raw .abl restoration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tools for extending the Ableton Move. This project provides a companion webserve
 Here’s what you can do with Extending Move:
 
 - **Set Restoration**
-  - Upload and restore Move Sets (.ablbundle)
+  - Upload and restore Move Sets (.ablbundle or .abl)
   - Choose target pad and color
 
 - **Drift, Wavetable and melodicSampler Preset Editor**

--- a/handlers/restore_handler_class.py
+++ b/handlers/restore_handler_class.py
@@ -2,7 +2,7 @@ import os
 import logging
 from handlers.base_handler import BaseHandler
 from core.list_msets_handler import list_msets
-from core.restore_handler import restore_ablbundle
+from core.restore_handler import restore_ablbundle, restore_abl
 from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS, rgb_string
 import json
 
@@ -43,7 +43,11 @@ class RestoreHandler(BaseHandler):
 
     def handle_post(self, form):
         """
-        Handles POST requests to restore an uploaded .ablbundle file.
+        Handles POST requests to restore an uploaded set file.
+
+        The upload can be either a ``.ablbundle`` archive or a raw ``.abl`` set
+        file. The correct restore routine is chosen based on the file
+        extension.
         """
         valid, error_response = self.validate_action(form, "restore_ablbundle")
         if not valid:
@@ -110,7 +114,10 @@ class RestoreHandler(BaseHandler):
             return error_response
 
         try:
-            result = restore_ablbundle(filepath, pad_selected, pad_color)
+            if filepath.lower().endswith('.ablbundle'):
+                result = restore_ablbundle(filepath, pad_selected, pad_color)
+            else:
+                result = restore_abl(filepath, pad_selected, pad_color)
             self.cleanup_upload(filepath)
             if result["success"]:
                 # Add 1 to pad_selected for display since we subtracted 1 earlier

--- a/templates_jinja/restore.html
+++ b/templates_jinja/restore.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>Restore Move Set (.ablbundle)</h2>
+<h2>Restore Move Set (.ablbundle or .abl)</h2>
 {% if message %}
   <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
 {% endif %}
 <form action="{{ host_prefix }}/restore" method="post" enctype="multipart/form-data">
-    <label for="ablbundle">Select .ablbundle file:</label>
-    <input type="file" name="ablbundle" accept=".ablbundle" required>
+    <label for="ablbundle">Select set file:</label>
+    <input type="file" name="ablbundle" accept=".ablbundle,.abl" required>
     <br>
     <label for="mset_color_dropdown">Pad color:</label>
     {{ color_options | safe }}


### PR DESCRIPTION
## Summary
- support uploading plain `.abl` files for set restoration
- detect file extension and restore accordingly
- update UI to allow `.abl` selection
- mention `.abl` support in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1a2670a483258e98fc84d959e4e6