### PR TITLE
Enable shift-click selection in clip editor

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -692,9 +692,15 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             }
             return obj;
         };
-        this.editDragDown=function(pos){
+        this.editDragDown=function(pos, shiftSelect){
             const ht=this.hitTest(pos);
             let ev;
+            if(shiftSelect && (ht.m=="N" || ht.m=="n")){
+                ev=this.sequence[ht.i];
+                ev.f = !ev.f;
+                this.redraw();
+                return;
+            }
             if(ht.m=="N"){
                 ev=this.sequence[ht.i];
                 this.dragging={o:"D",m:"N",i:ht.i,t:ht.t,n:ev.n,dt:ht.t-ev.t};
@@ -1172,7 +1178,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
                 break;
             case "dragpoly":
             case "dragmono":
-                this.editDragDown(this.downpos);
+                this.editDragDown(this.downpos, e.shiftKey);
                 break;
             }
             this.press = 1;

--- a/tests/test_set_inspector_euclid.py
+++ b/tests/test_set_inspector_euclid.py
@@ -13,3 +13,8 @@ def test_euclid_modal_present():
     assert 'data-action="euclid"' in js
     inspector = INSPECTOR_JS.read_text()
     assert 'globalAlpha = 0.6' in inspector
+
+
+def test_shift_click_selection():
+    js = SCRIPT.read_text()
+    assert 'shiftSelect' in js


### PR DESCRIPTION
## Summary
- allow multi-select in the piano roll via shift-click
- test for the new shift click selection feature

## Testing
- `pytest -k set_inspector_euclid -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f243d508083258af8b3d3cab975ce