### PR TITLE
Add pitch bend editing in clip editor

### DIFF
--- a/static/pitchbend_overlay.js
+++ b/static/pitchbend_overlay.js
@@ -1,19 +1,28 @@
 export const BASE_NOTE = 36;
 export const SEMI_UNIT = 170.6458282470703;
 
-export function computeOverlayNotes(sequence, selectedRow, ticksPerBeat) {
+export function computeOverlayNotes(sequence, selectedRow, ticksPerBeat, overrides = null, seed = false) {
   const overlay = [];
   if (selectedRow === null || selectedRow === undefined) return overlay;
   if (!sequence || !ticksPerBeat) return overlay;
-  sequence.forEach(ev => {
+  sequence.forEach((ev, idx) => {
     if (ev.n !== selectedRow) return;
     const pb = ev.a && ev.a.PitchBend;
-    if (!pb || !pb.length) return;
-    const value = pb[0].value;
-    const semis = Math.round(value / SEMI_UNIT);
+    let semis = 0;
+    if (pb && pb.length) {
+      semis = Math.round(pb[0].value / SEMI_UNIT);
+    }
+    const id = ev.id ?? idx;
+    if (overrides && overrides[id] !== undefined) {
+      semis = overrides[id];
+    } else if (seed && overrides) {
+      overrides[id] = semis;
+    }
     const viz = BASE_NOTE + semis;
     if (viz < 0 || viz > 127) return;
     overlay.push({
+      id,
+      semitone: semis,
       noteNumber: viz,
       startTime: ev.t / ticksPerBeat,
       duration: ev.g / ticksPerBeat

--- a/tests/test_pitchbend_overlay.py
+++ b/tests/test_pitchbend_overlay.py
@@ -9,7 +9,7 @@ def run_node(notes, row, ticks=96):
     script = f"""
 import {{computeOverlayNotes, BASE_NOTE, SEMI_UNIT}} from 'file://{JS_PATH.as_posix()}';
 const notes = {json.dumps(notes)};
-const result = computeOverlayNotes(notes, {row}, {ticks});
+const result = computeOverlayNotes(notes, {row}, {ticks}, undefined, false);
 console.log(JSON.stringify({{'overlay': result, 'BASE_NOTE': BASE_NOTE, 'SEMI_UNIT': SEMI_UNIT}}));
 """
     proc = subprocess.run(['node', '--input-type=module', '-e', script], capture_output=True, text=True, check=True)


### PR DESCRIPTION
## Summary
- support pitch bend overrides in `computeOverlayNotes`
- track note ids and pitch override state in the clip editor
- allow dragging pitch bend overlays to adjust semitones
- persist pitch bend automation when saving clips
- update pitchbend overlay tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f2c242b18832587cf80a5bac740f0