### PR TITLE
Enable note editing in pitchbend overlay

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -395,13 +395,8 @@ export function initSetInspector() {
   if (piano && piano.redraw) {
     const origRedraw = piano.redraw.bind(piano);
     piano.redraw = function(...args) {
-      let bak = null;
-      if (overlayActive) {
-        bak = this.sequence;
-        this.sequence = [];
-      }
       origRedraw(...args);
-      if (bak) this.sequence = bak;
+      if (overlayActive) recomputeOverlay();
       if (this.updateKbHighlight) this.updateKbHighlight();
       draw();
     };
@@ -700,7 +695,7 @@ export function initSetInspector() {
         }
         recomputeOverlay();
         if (piano) {
-          piano.editmode = overlayActive ? '' : defaultEditMode;
+          piano.editmode = defaultEditMode;
           if (piano.setHighlightRow) piano.setHighlightRow(overlayActive ? overlayRow : null);
           piano.redraw();
         }

--- a/tests/test_set_inspector_euclid.py
+++ b/tests/test_set_inspector_euclid.py
@@ -15,7 +15,7 @@ def test_euclid_modal_present():
     assert 'wac-kb-highlight' in js
     inspector = INSPECTOR_JS.read_text()
     assert 'globalAlpha = 0.6' in inspector
-    assert 'piano.editmode = overlayActive ?' in inspector
+    assert 'piano.editmode = defaultEditMode' in inspector
 
 
 def test_shift_click_selection():


### PR DESCRIPTION
## Summary
- allow piano roll notes to remain editable when the pitchbend overlay is active
- update overlay recomputation logic in `set_inspector.js`
- adjust tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f41a1c0648325b4a2951a43dc0824