### PR TITLE
Enable pitchbend overlay dragging

### DIFF
--- a/static/pitchbend_overlay.js
+++ b/static/pitchbend_overlay.js
@@ -1,11 +1,15 @@
 export const BASE_NOTE = 36;
 export const SEMI_UNIT = 170.6458282470703;
 
+export function noteNumberToPitchbend(n) {
+  return (n - BASE_NOTE) * SEMI_UNIT;
+}
+
 export function computeOverlayNotes(sequence, selectedRow, ticksPerBeat) {
   const overlay = [];
   if (selectedRow === null || selectedRow === undefined) return overlay;
   if (!sequence || !ticksPerBeat) return overlay;
-  sequence.forEach(ev => {
+  sequence.forEach((ev, idx) => {
     if (ev.n !== selectedRow) return;
     const pb = ev.a && ev.a.PitchBend;
     if (!pb || !pb.length) return;
@@ -14,6 +18,7 @@ export function computeOverlayNotes(sequence, selectedRow, ticksPerBeat) {
     const viz = BASE_NOTE + semis;
     if (viz < 0 || viz > 127) return;
     overlay.push({
+      index: idx,
       noteNumber: viz,
       startTime: ev.t / ticksPerBeat,
       duration: ev.g / ticksPerBeat

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -1,5 +1,5 @@
 import { euclideanRhythm } from "./euclid.js";
-import { computeOverlayNotes } from "./pitchbend_overlay.js";
+import { computeOverlayNotes, noteNumberToPitchbend } from "./pitchbend_overlay.js";
 export function initSetInspector() {
   // Show selected set name when choosing a pad
   const grid = document.querySelector('#setSelectForm .pad-grid');
@@ -80,6 +80,7 @@ export function initSetInspector() {
   let overlayNotes = [];
   let overlayRow = null;
   let overlayActive = false;
+  let overlayDragging = null;
   let removedNotes = [];
 
   if (piano) {
@@ -562,6 +563,51 @@ export function initSetInspector() {
     velDragging = false;
   }
 
+  function overlayNoteAt(x, y) {
+    if (!overlayActive || !overlayNotes.length || !piano) return -1;
+    const stepw = canvas.width / piano.xrange;
+    const steph = canvas.height / piano.yrange;
+    for (let i = 0; i < overlayNotes.length; i++) {
+      const n = overlayNotes[i];
+      const t = n.startTime * ticksPerBeat;
+      const x0 = (t - piano.xoffset) * stepw;
+      const w = n.duration * ticksPerBeat * stepw;
+      const y0 = canvas.height - (n.noteNumber - piano.yoffset) * steph;
+      if (x >= x0 && x <= x0 + w && y <= y0 && y >= y0 - steph) return i;
+    }
+    return -1;
+  }
+
+  function startOverlayDrag(ev) {
+    if (!overlayActive) return;
+    const { x, y } = canvasPos(ev);
+    const idx = overlayNoteAt(x, y);
+    if (idx < 0) return;
+    overlayDragging = idx;
+    ev.preventDefault();
+  }
+
+  function dragOverlay(ev) {
+    if (overlayDragging === null) return;
+    const { y } = canvasPos(ev);
+    const steph = canvas.height / piano.yrange;
+    let note = piano.yoffset + Math.floor((canvas.height - y) / steph);
+    note = Math.max(0, Math.min(127, note));
+    const seqIdx = overlayNotes[overlayDragging].index;
+    const evObj = piano.sequence[seqIdx];
+    if (!evObj.a) evObj.a = {};
+    if (!evObj.a.PitchBend) evObj.a.PitchBend = [{ time: 0, value: 0 }];
+    evObj.a.PitchBend[0].value = noteNumberToPitchbend(note);
+    recomputeOverlay();
+    if (piano.redraw) piano.redraw();
+    else draw();
+    ev.preventDefault();
+  }
+
+  function endOverlayDrag() {
+    overlayDragging = null;
+  }
+
   canvas.addEventListener('mousedown', startDraw);
   canvas.addEventListener('touchstart', startDraw);
   canvas.addEventListener('mousemove', continueDraw);
@@ -569,6 +615,13 @@ export function initSetInspector() {
   canvas.addEventListener('mouseleave', () => { if (!drawing && valueDiv) valueDiv.textContent = ''; });
   document.addEventListener('mouseup', endDraw);
   document.addEventListener('touchend', endDraw);
+
+  canvas.addEventListener('mousedown', startOverlayDrag);
+  canvas.addEventListener('touchstart', startOverlayDrag);
+  canvas.addEventListener('mousemove', dragOverlay);
+  canvas.addEventListener('touchmove', dragOverlay);
+  document.addEventListener('mouseup', endOverlayDrag);
+  document.addEventListener('touchend', endOverlayDrag);
 
   if (velCanvas) {
     velCanvas.addEventListener('mousedown', startVel);


### PR DESCRIPTION
## Summary
- expose `noteNumberToPitchbend()` and include event index when computing overlay notes
- allow dragging cyan pitchbend overlay notes in the set inspector
- test conversion helper and event indexing

## Testing
- `pytest -q`
- `pytest tests/test_pitchbend_overlay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f93bf85488325a74b89cbb2677a02