### PR TITLE
Implement Drum Mode overlap enforcement

### DIFF
--- a/core/drum_mode.py
+++ b/core/drum_mode.py
@@ -1,0 +1,22 @@
+from typing import List, Dict
+
+
+def enforce_drum_mode(row_notes: List[Dict[str, float]]) -> List[Dict[str, float]]:
+    """Enforce monophonic behavior on a list of notes for one pitch."""
+    row_notes.sort(key=lambda n: n.get("startTime", 0))
+    i = 0
+    while i < len(row_notes) - 1:
+        a = row_notes[i]
+        b = row_notes[i + 1]
+        a_start = float(a.get("startTime", 0))
+        b_start = float(b.get("startTime", 0))
+        a_end = a_start + float(a.get("duration", 0))
+        if a_end > b_start:
+            new_dur = b_start - a_start
+            if new_dur <= 0:
+                row_notes.pop(i)
+                continue
+            a["duration"] = new_dur
+        i += 1
+    return row_notes
+

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -213,6 +213,7 @@ class SetInspectorHandler(BaseHandler):
                 "clip_index": clip_idx,
                 "track_name": result.get("track_name"),
                 "clip_name": result.get("clip_name"),
+                "drum_mode": result.get("drum_mode"),
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
             }
@@ -283,6 +284,7 @@ class SetInspectorHandler(BaseHandler):
                 "clip_index": clip_idx,
                 "track_name": clip_data.get("track_name"),
                 "clip_name": clip_data.get("clip_name"),
+                "drum_mode": clip_data.get("drum_mode"),
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
             }

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -75,6 +75,7 @@
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
     <label for="note_draw_toggle" style="margin-left:1rem;">Draw Notes</label>
     <input id="note_draw_toggle" type="checkbox">
+    {% if drum_mode %}<span id="drumBadge" class="badge">🥁 Drum Mode</span>{% endif %}
   </div>
   <small>Right click to select or transform, use arrow keys to nudge.</small>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
@@ -110,7 +111,7 @@
   </form>
   {% endif %}
   <p>Current version: {{ current_ts }}</p>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-drum-mode='{{ 1 if drum_mode else 0 }}'></div>
   <style>
     .modal { position: fixed; top:0; left:0; width:100%; height:100%; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; z-index:1000; }
     .modal.hidden { display:none; }

--- a/tests/test_drum_mode.py
+++ b/tests/test_drum_mode.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from core.drum_mode import enforce_drum_mode
+
+def test_simple_overlap():
+    notes = [
+        {"startTime": 0.0, "duration": 1.0},
+        {"startTime": 0.5, "duration": 1.0},
+    ]
+    enforce_drum_mode(notes)
+    assert notes[0]["duration"] == 0.5
+
+
+def test_chained_overlap():
+    notes = [
+        {"startTime": 0.0, "duration": 1.0},
+        {"startTime": 0.8, "duration": 0.4},
+        {"startTime": 1.1, "duration": 0.9},
+    ]
+    enforce_drum_mode(notes)
+    assert notes[0]["duration"] == 0.8
+    assert notes[1]["duration"] == pytest.approx(0.3)
+
+
+def test_zero_or_negative():
+    notes = [
+        {"startTime": 0.0, "duration": 0.5},
+        {"startTime": 0.4, "duration": 0.5},
+    ]
+    enforce_drum_mode(notes)
+    assert notes[0]["duration"] == pytest.approx(0.4)
+    assert notes[1]["startTime"] == 0.4


### PR DESCRIPTION
## Summary
- add detection of drumRack devices in `get_clip_data`
- show a 🥁 Drum Mode badge on the clip editor
- enforce monophonic note rows in Drum Mode with JS
- expose helper `enforce_drum_mode` and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f96dce0b48325aac98f00b833ce05