### PR TITLE
Prevent overlapping drum notes

### DIFF
--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -110,7 +110,7 @@
   </form>
   {% endif %}
   <p>Current version: {{ current_ts }}</p>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-drum-track='{{ "true" if drum_track else "false" }}'></div>
   <style>
     .modal { position: fixed; top:0; left:0; width:100%; height:100%; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; z-index:1000; }
     .modal.hidden { display:none; }

--- a/tests/test_drum_overlap.py
+++ b/tests/test_drum_overlap.py
@@ -1,0 +1,40 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import set_inspector_handler as sih
+
+
+def create_drum_set(path):
+    clip = {
+        "name": "Clip",
+        "notes": [],
+        "envelopes": [],
+        "region": {"end": 4.0},
+    }
+    track = {
+        "name": "Drums",
+        "devices": [{"kind": "drumRack"}],
+        "clipSlots": [{"clip": clip}],
+    }
+    song = {"tracks": [track]}
+    Path(path).write_text(json.dumps(song))
+
+
+def test_truncate_overlapping_notes(tmp_path):
+    set_path = tmp_path / "set.abl"
+    create_drum_set(set_path)
+    notes = [
+        {"noteNumber": 36, "startTime": 0.0, "duration": 1.0, "velocity": 100.0, "offVelocity": 0.0},
+        {"noteNumber": 36, "startTime": 0.5, "duration": 1.0, "velocity": 100.0, "offVelocity": 0.0},
+    ]
+    result = sih.save_clip(str(set_path), 0, 0, notes, [], 4.0, 0.0, 4.0)
+    assert result["success"], result.get("message")
+    data = sih.get_clip_data(str(set_path), 0, 0)
+    out = data["notes"]
+    assert len(out) == 2
+    assert abs(out[0]["duration"] - 0.5) < 1e-6
+    assert out[1]["startTime"] == 0.5


### PR DESCRIPTION
## Summary
- disallow overlapping notes when editing drum tracks
- expose drum track flag in clip editor
- ensure backend truncates overlapping notes on save
- test truncation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684faf457cdc832587ae50ce37753625