### PR TITLE
Add draw toggle emoji button

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -140,9 +140,13 @@ export function initSetInspector() {
   let defaultEditMode = piano ? (piano.editmode || piano.getAttribute('editmode') || 'dragpoly') : 'dragpoly';
   const drawToggle = document.getElementById('note_draw_toggle');
   if (drawToggle) {
-    drawToggle.checked = defaultEditMode.startsWith('draw');
-    drawToggle.addEventListener('change', () => {
-      defaultEditMode = drawToggle.checked ? 'drawpoly' : 'dragpoly';
+    function updateDrawIcon() {
+      drawToggle.textContent = defaultEditMode.startsWith('draw') ? '✏️' : '🎹';
+    }
+    updateDrawIcon();
+    drawToggle.addEventListener('click', () => {
+      defaultEditMode = defaultEditMode.startsWith('draw') ? 'dragpoly' : 'drawpoly';
+      updateDrawIcon();
       updateControls();
     });
   }

--- a/static/style.css
+++ b/static/style.css
@@ -1263,3 +1263,9 @@ button#macro-add-param {
 .page-wavetable-params .param-item.param-mapped {
     opacity: 0.6;
 }
+
+#note_draw_toggle {
+    background-color: transparent;
+    padding: 0px;
+    margin-top: 0px;
+}

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -73,8 +73,8 @@
     <label for="envelope_select">Envelope:</label>
     <select id="envelope_select">{{ clip_options | safe }}</select>
     <span id="envValue" style="margin-left:0.5rem; font-size:0.8em;"></span>
-    <label for="note_draw_toggle" style="margin-left:1rem;">Draw Notes</label>
-    <input id="note_draw_toggle" type="checkbox">
+    <label for="note_draw_toggle" style="margin-left:1rem;">Note Mode:</label>
+    <button id="note_draw_toggle" type="button">🎹</button>
   </div>
   <small>Right click to select or transform, use arrow keys to nudge. {% if drum_track %}<strong>Drum track detected.</strong> Notes cannot overlap.{% endif %}</small>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">


### PR DESCRIPTION
## Summary
- switch draw notes checkbox to a button
- show a keyboard or pencil emoji depending on mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb04e1fb08325bdb94e532370e378