### PR TITLE
Prevent overlapping drum notes

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -37,11 +37,13 @@ export function initSetInspector() {
   const loopStart = parseFloat(dataDiv.dataset.loopStart || '0');
   const loopEnd = parseFloat(dataDiv.dataset.loopEnd || String(region));
   const paramRanges = JSON.parse(dataDiv.dataset.paramRanges || '{}');
+  const isDrumTrack = dataDiv.dataset.drumTrack === 'true';
   const canvas = document.getElementById('clipCanvas');
   const ctx = canvas.getContext('2d');
   const velCanvas = document.getElementById('velocityCanvas');
   const vctx = velCanvas ? velCanvas.getContext('2d') : null;
   const piano = document.getElementById('clipEditor');
+  if (piano) piano.drumtrack = isDrumTrack;
   const timebase = piano ? parseInt(piano.getAttribute('timebase') || '16', 10) : 16;
   const xruler = piano ? parseInt(piano.getAttribute('xruler') || '24', 10) : 24;
   const yruler = piano ? parseInt(piano.getAttribute('yruler') || '24', 10) : 24;
@@ -155,6 +157,30 @@ export function initSetInspector() {
       piano.enable = true;
       piano.editmode = editing ? '' : defaultEditMode;
     }
+  }
+
+  function truncateOverlaps() {
+    if (!isDrumTrack || !piano) return;
+    const seq = piano.sequence || [];
+    const byPitch = {};
+    seq.forEach(ev => {
+      (byPitch[ev.n] = byPitch[ev.n] || []).push(ev);
+    });
+    let out = [];
+    Object.values(byPitch).forEach(list => {
+      list.sort((a, b) => a.t - b.t);
+      for (let i = 0; i < list.length - 1; i++) {
+        const cur = list[i];
+        const nxt = list[i + 1];
+        if (cur.t + cur.g > nxt.t) {
+          cur.g = nxt.t - cur.t;
+        }
+      }
+      out = out.concat(list.filter(ev => ev.g > 0));
+    });
+    out.sort((a, b) => a.t - b.t);
+    piano.sequence = out;
+    piano.redraw();
   }
   if (legendDiv) {
     legendDiv.style.display = 'flex';
@@ -616,6 +642,12 @@ export function initSetInspector() {
   document.addEventListener('mouseup', endDraw);
   document.addEventListener('touchend', endDraw);
 
+  function endEdit() {
+    truncateOverlaps();
+  }
+  document.addEventListener('mouseup', endEdit);
+  document.addEventListener('touchend', endEdit);
+
   canvas.addEventListener('mousedown', startOverlayDrag);
   canvas.addEventListener('touchstart', startOverlayDrag, { passive: false });
   canvas.addEventListener('mousemove', dragOverlay);
@@ -720,6 +752,7 @@ export function initSetInspector() {
       });
       ghostNotes = [];
       removedNotes = [];
+      truncateOverlaps();
       if (piano.redraw) piano.redraw();
       euclidModal.classList.add('hidden');
     }

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -79,7 +79,7 @@
   <small>Right click to select or transform, use arrow keys to nudge. {% if drum_track %}<strong>Drum track detected.</strong> Notes cannot overlap.{% endif %}</small>
   <div style="margin-top:1rem; display:flex; align-items:flex-start;">
     <div style="position:relative; width:900px; height:360px; border:1px solid #ccc;">
-      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false"></webaudio-pianoroll>
+      <webaudio-pianoroll id="clipEditor" width="900" height="300" editmode="dragpoly" wheelzoom="0" xscroll="1" yscroll="1" timebase="16" xrange="{{ (region | default(4.0)) * 4 }}" markstart="{{ (loop_start | default(0.0)) * 4 }}" markend="{{ (loop_end | default(region)) * 4 }}" showcursor="false" drumtrack="{{ 'true' if drum_track else 'false' }}"></webaudio-pianoroll>
       <canvas id="clipCanvas" width="836" height="300" style="position:absolute; left:64px; top:0; pointer-events:none;"></canvas>
       <canvas id="velocityCanvas" width="836" height="60" style="position:absolute; left:64px; top:300px;"></canvas>
     </div>
@@ -110,7 +110,7 @@
   </form>
   {% endif %}
   <p>Current version: {{ current_ts }}</p>
-  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}'></div>
+  <div id="clipData" data-notes='{{ notes | tojson }}' data-envelopes='{{ envelopes | tojson }}' data-region='{{ region | default(4.0) }}' data-loop-start='{{ loop_start | default(0.0) }}' data-loop-end='{{ loop_end | default(region) }}' data-param-ranges='{{ param_ranges_json | safe }}' data-drum-track='{{ "true" if drum_track else "false" }}'></div>
   <style>
     .modal { position: fixed; top:0; left:0; width:100%; height:100%; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; z-index:1000; }
     .modal.hidden { display:none; }

--- a/tests/test_drum_overlap.py
+++ b/tests/test_drum_overlap.py
@@ -1,0 +1,62 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import set_inspector_handler as sih
+
+
+def create_drum_set(path):
+    clip = {
+        "name": "Clip",
+        "notes": [],
+        "envelopes": [],
+        "region": {"end": 4.0},
+    }
+    track = {
+        "name": "Drums",
+        "devices": [{"kind": "drumRack"}],
+        "clipSlots": [{"clip": clip}],
+    }
+    song = {"tracks": [track]}
+    Path(path).write_text(json.dumps(song))
+
+
+def test_truncate_overlapping_notes(tmp_path):
+    set_path = tmp_path / "set.abl"
+    create_drum_set(set_path)
+    notes = [
+        {"noteNumber": 36, "startTime": 0.0, "duration": 1.0, "velocity": 100.0, "offVelocity": 0.0},
+        {"noteNumber": 36, "startTime": 0.5, "duration": 1.0, "velocity": 100.0, "offVelocity": 0.0},
+    ]
+    result = sih.save_clip(str(set_path), 0, 0, notes, [], 4.0, 0.0, 4.0)
+    assert result["success"], result.get("message")
+    data = sih.get_clip_data(str(set_path), 0, 0)
+    out = data["notes"]
+    assert len(out) == 2
+    assert abs(out[0]["duration"] - 0.5) < 1e-6
+    assert out[1]["startTime"] == 0.5
+
+
+def test_overlap_after_reverse(tmp_path):
+    set_path = tmp_path / "set_rev.abl"
+    create_drum_set(set_path)
+    notes = [
+        {"noteNumber": 36, "startTime": 0.0, "duration": 1.5, "velocity": 100.0, "offVelocity": 0.0},
+        {"noteNumber": 36, "startTime": 1.0, "duration": 1.0, "velocity": 100.0, "offVelocity": 0.0},
+        {"noteNumber": 36, "startTime": 2.0, "duration": 1.0, "velocity": 100.0, "offVelocity": 0.0},
+    ]
+    # Reverse around 0-3 range
+    rev = []
+    start, end = 0.0, 3.0
+    for n in notes:
+        rev.append({**n, "startTime": start + end - (n["startTime"] + n["duration"])})
+    result = sih.save_clip(str(set_path), 0, 0, rev, [], 4.0, 0.0, 4.0)
+    assert result["success"], result.get("message")
+    data = sih.get_clip_data(str(set_path), 0, 0)
+    out = data["notes"]
+    assert len(out) == 3
+    assert abs(out[1]["duration"] - 0.5) < 1e-6
+


### PR DESCRIPTION
## Summary
- disallow overlapping notes when editing drum tracks
- expose drum track flag in clip editor
- ensure backend truncates overlapping notes on save
- test truncation logic
- handle overlap after transforms in editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684faf457cdc832587ae50ce37753625