### PR TITLE
Fix pitchbend automation replacement and extend tests

### DIFF
--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -626,8 +626,7 @@ export function initSetInspector() {
     const seqIdx = overlayNotes[overlayDragging].index;
     const evObj = piano.sequence[seqIdx];
     if (!evObj.a) evObj.a = {};
-    if (!evObj.a.PitchBend) evObj.a.PitchBend = [{ time: 0, value: 0 }];
-    evObj.a.PitchBend[0].value = noteNumberToPitchbend(note);
+    evObj.a.PitchBend = [{ time: 0, value: noteNumberToPitchbend(note) }];
     recomputeOverlay();
     if (piano.redraw) piano.redraw();
     else draw();


### PR DESCRIPTION
## Summary
- ensure pitchbend overlay replaces all pitchbend data for a note
- cover overlay edit behaviour in JS tests
- check automation preservation when saving clips

## Testing
- `pytest tests/test_pitchbend_overlay.py::test_edit_replaces_automation_and_preserves_others tests/test_set_inspector_handler.py::test_pitchbend_edit_preserves_other_automations -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd0f1f59c8325848145f6f1483e08