### PR TITLE
Add probability and loop condition features

### DIFF
--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -673,8 +673,9 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
         this.expandProbability=function(percent){
             const maxBars=8;
             const ticksPerBar=this.timebase;
-            const regionBars=this.markend/ticksPerBar;
-            const loopsToGen=Math.floor(maxBars/regionBars);
+            const regionBars=(this.markend-this.markstart)/ticksPerBar;
+            const startBar=this.markstart/ticksPerBar;
+            const loopsToGen=Math.floor((maxBars-startBar)/regionBars);
             if(loopsToGen<1){
                 alert('Loop length too long for 8 bars');
                 return;
@@ -691,14 +692,16 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             });
             this.sequence.sort((a,b)=>a.t-b.t);
             this.truncateOverlaps();
+            this.markend=this.markstart+loopsToGen*regionBars*ticksPerBar;
             this.redraw();
         };
 
         this.expandEveryN=function(N,offset){
             const maxBars=8;
             const ticksPerBar=this.timebase;
-            const regionBars=this.markend/ticksPerBar;
-            const loopsToGen=Math.floor(maxBars/regionBars);
+            const regionBars=(this.markend-this.markstart)/ticksPerBar;
+            const startBar=this.markstart/ticksPerBar;
+            const loopsToGen=Math.floor((maxBars-startBar)/regionBars);
             if(loopsToGen<1){
                 alert('Loop length too long for 8 bars');
                 return;
@@ -714,6 +717,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
             });
             this.sequence.sort((a,b)=>a.t-b.t);
             this.truncateOverlaps();
+            this.markend=this.markstart+loopsToGen*regionBars*ticksPerBar;
             this.redraw();
         };
         this.moveSelectedNote=function(dt,dn){

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -151,6 +151,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
     border-radius:4px;
     position: relative;
     z-index:1001;
+}
 #probability-modal.hidden,#everyn-modal.hidden{display:none;}
 #wac-gridres{
     position:absolute;

--- a/static/webaudio-pianoroll.js
+++ b/static/webaudio-pianoroll.js
@@ -132,7 +132,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
     opacity:0.5;
     pointer-events:none;
 }
-#probability-modal, #everyn-modal {
+.modal {
     /* Modal styling borrowed from templates */
     position: fixed;
     top: 0;
@@ -151,8 +151,7 @@ customElements.define("webaudio-pianoroll", class Pianoroll extends HTMLElement 
     border-radius:4px;
     position: relative;
     z-index:1001;
-}
-.modal.hidden{display:none;}
+#probability-modal.hidden,#everyn-modal.hidden{display:none;}
 #wac-gridres{
     position:absolute;
     top:30px;


### PR DESCRIPTION
## Summary
- extend Pianoroll menu with Probability and Every Nᵗʰ Loop actions
- add modal dialogs and styling for new conditional triggers
- implement expansion algorithms for probability and loop selection
- wire up modal logic in `ready()` and expose helper methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdc6a69348325998f59a58b6a47df