### PR TITLE
Improve clip editor utilities

### DIFF
--- a/static/pitchbend_overlay.js
+++ b/static/pitchbend_overlay.js
@@ -1,3 +1,9 @@
+/**
+ * Helper functions for the pitch bend overlay displayed in the clip editor.
+ *
+ * ``BASE_NOTE`` and ``SEMI_UNIT`` mirror the values used by Ableton Live to
+ * convert between pitch bend values and semitone offsets.
+ */
 export const BASE_NOTE = 36;
 export const SEMI_UNIT = 170.6458282470703;
 
@@ -6,6 +12,7 @@ export function noteNumberToPitchbend(n) {
 }
 
 export function computeOverlayNotes(sequence, selectedRow, ticksPerBeat) {
+  // Generate an array of note objects visualising pitch bend edits.
   const overlay = [];
   if (selectedRow === null || selectedRow === undefined) return overlay;
   if (!sequence || !ticksPerBeat) return overlay;

--- a/static/set_inspector.js
+++ b/static/set_inspector.js
@@ -1,3 +1,13 @@
+/**
+ * Main client side logic for the clip editor used by the Set Inspector.
+ *
+ * Features provided by this script:
+ *   - Shift‑click note selection and drag editing (via webaudio-pianoroll)
+ *   - Euclidean rhythm preview/fill modal
+ *   - Pitch bend overlay for quick transposition preview
+ *   - Drum track aware note truncation to avoid overlaps
+ *   - Velocity editing and envelope drawing
+ */
 import { euclideanRhythm } from "./euclid.js";
 import { computeOverlayNotes, noteNumberToPitchbend } from "./pitchbend_overlay.js";
 export function initSetInspector() {

--- a/tests/test_set_inspector_utils.py
+++ b/tests/test_set_inspector_utils.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import set_inspector_handler as sih
+
+
+def test_collect_param_ids_and_track_display():
+    devices = [
+        {"kind": "drumCell", "Gain": {"id": 1}},
+        {"kind": "drift", "parameters": {"Vol": {"id": 2, "customName": "Volume"}}},
+    ]
+    mapping = {}
+    ctx = {}
+    sih._collect_param_ids.pad_counter = [1]
+    sih._collect_param_ids(devices, mapping, ctx)
+    assert mapping[1] == "Gain" and ctx[1] == "Pad1"
+    assert mapping[2] == "Volume" and ctx[2] == "Track"
+
+    track = {"name": "My Track", "devices": [{"name": "FirstDevice"}]}
+    assert sih._track_display_name(track, 0) == "FirstDevice"
+    assert sih._track_display_name({}, 1) == "Track 2"
+
+
+def test_contains_drum_rack():
+    track = {"devices": [{"kind": "drumRack", "chains": []}]}
+    assert sih._contains_drum_rack(track)
+    assert not sih._contains_drum_rack({"devices": [{"kind": "drift"}]})


### PR DESCRIPTION
## Summary
- clarify set inspector core utilities
- document clip editor JS and pitchbend overlay helpers
- add unit tests for helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685037efd5648325a4d5d6ab95adbae9