### PR TITLE
Add read-only toggle for Move sets

### DIFF
--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -280,22 +280,42 @@ def save_clip(
         return {"success": False, "message": f"Failed to save clip: {e}"}
 
 def is_read_only(set_path: str) -> bool:
-    """Return True if the set file lacks write permissions."""
+    """Return True if ``set_path`` is not writable."""
     try:
         if not os.path.isfile(set_path):
             return False
-        return os.stat(set_path).st_mode & 0o222 == 0
+        return (os.stat(set_path).st_mode & 0o222) == 0
     except Exception:
         return False
 
 
 def set_read_only(set_path: str, read_only: bool) -> Dict[str, Any]:
-    """Update file permissions to make the set read-only or writable."""
+    """Recursively update permissions to toggle read-only mode for a set."""
     try:
         if not os.path.isfile(set_path):
             return {"success": False, "message": "Set file not found"}
-        os.chmod(set_path, 0o444 if read_only else 0o644)
-        return {"success": True, "message": "Permissions updated", "read_only": read_only}
+
+        root_dir = os.path.dirname(os.path.dirname(set_path))
+        file_mode = 0o444 if read_only else 0o644
+        dir_mode = 0o555 if read_only else 0o755
+
+        for dirpath, dirnames, filenames in os.walk(root_dir):
+            try:
+                os.chmod(dirpath, dir_mode)
+            except Exception:
+                pass
+            for fname in filenames:
+                fpath = os.path.join(dirpath, fname)
+                try:
+                    os.chmod(fpath, file_mode)
+                except Exception:
+                    pass
+
+        return {
+            "success": True,
+            "message": "Permissions updated",
+            "read_only": read_only,
+        }
     except Exception as e:
         return {"success": False, "message": f"Failed to update permissions: {e}"}
 

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from typing import Any, Dict, List, Tuple
 
 from core.set_backup_handler import backup_set, write_latest_timestamp
@@ -286,6 +287,30 @@ def is_read_only(set_path: str) -> bool:
             return False
         return (os.stat(set_path).st_mode & 0o222) == 0
     except Exception:
+        return False
+
+
+def is_synced(set_path: str) -> bool:
+    """Return True if ``set_path`` has cached SHA attributes."""
+    if not os.path.isfile(set_path):
+        return False
+    try:
+        subprocess.check_output(
+            ["getfattr", "--only-values", "-n", "user.cached-sha", set_path],
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.check_output(
+            [
+                "getfattr",
+                "--only-values",
+                "-n",
+                "user.cached-sha-last-write-time",
+                set_path,
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except subprocess.CalledProcessError:
         return False
 
 

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -278,3 +278,24 @@ def save_clip(
         return {"success": True, "message": "Clip saved"}
     except Exception as e:
         return {"success": False, "message": f"Failed to save clip: {e}"}
+
+def is_read_only(set_path: str) -> bool:
+    """Return True if the set file lacks write permissions."""
+    try:
+        if not os.path.isfile(set_path):
+            return False
+        return os.stat(set_path).st_mode & 0o222 == 0
+    except Exception:
+        return False
+
+
+def set_read_only(set_path: str, read_only: bool) -> Dict[str, Any]:
+    """Update file permissions to make the set read-only or writable."""
+    try:
+        if not os.path.isfile(set_path):
+            return {"success": False, "message": "Set file not found"}
+        os.chmod(set_path, 0o444 if read_only else 0o644)
+        return {"success": True, "message": "Permissions updated", "read_only": read_only}
+    except Exception as e:
+        return {"success": False, "message": f"Failed to update permissions: {e}"}
+

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -1,6 +1,5 @@
 import json
 import os
-import subprocess
 from typing import Any, Dict, List, Tuple
 
 from core.set_backup_handler import backup_set, write_latest_timestamp
@@ -287,30 +286,6 @@ def is_read_only(set_path: str) -> bool:
             return False
         return (os.stat(set_path).st_mode & 0o222) == 0
     except Exception:
-        return False
-
-
-def is_synced(set_path: str) -> bool:
-    """Return True if ``set_path`` has cached SHA attributes."""
-    if not os.path.isfile(set_path):
-        return False
-    try:
-        subprocess.check_output(
-            ["getfattr", "--only-values", "-n", "user.cached-sha", set_path],
-            stderr=subprocess.DEVNULL,
-        )
-        subprocess.check_output(
-            [
-                "getfattr",
-                "--only-values",
-                "-n",
-                "user.cached-sha-last-write-time",
-                set_path,
-            ],
-            stderr=subprocess.DEVNULL,
-        )
-        return True
-    except subprocess.CalledProcessError:
         return False
 
 

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -5,6 +5,7 @@ from core.set_inspector_handler import (
     save_envelope,
     set_read_only,
     is_read_only,
+    is_synced,
 )
 from core.list_msets_handler import list_msets
 from core.set_backup_handler import (
@@ -101,6 +102,7 @@ class SetInspectorHandler(BaseHandler):
             "param_ranges_json": "{}",
             "backups": [],
             "read_only": False,
+            "synced": False,
         }
 
     def handle_post(self, form):
@@ -150,6 +152,7 @@ class SetInspectorHandler(BaseHandler):
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
+            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -167,6 +170,7 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
+                "synced": sync_state,
             }
         elif action == "show_clip":
             set_path = form.getvalue("set_path")
@@ -204,6 +208,7 @@ class SetInspectorHandler(BaseHandler):
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
+            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -227,6 +232,7 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
+                "synced": sync_state,
             }
         elif action == "save_envelope":
             set_path = form.getvalue("set_path")
@@ -277,6 +283,7 @@ class SetInspectorHandler(BaseHandler):
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             ro_state = is_read_only(set_path)
+            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -299,6 +306,7 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
+                "synced": sync_state,
             }
         elif action == "save_clip":
             set_path = form.getvalue("set_path")
@@ -370,6 +378,7 @@ class SetInspectorHandler(BaseHandler):
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             ro_state = is_read_only(set_path)
+            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -392,6 +401,7 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
+                "synced": sync_state,
             }
         elif action == "toggle_read_only":
             set_path = form.getvalue("set_path")
@@ -418,6 +428,7 @@ class SetInspectorHandler(BaseHandler):
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
+            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": perm_result.get("message"),
@@ -435,6 +446,7 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
+                "synced": sync_state,
             }
         elif action == "restore_backup":
             set_path = form.getvalue("set_path")
@@ -477,6 +489,7 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
+                "synced": sync_state,
             }
         else:
             return self.format_error_response("Unknown action", pad_grid=pad_grid)

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -5,7 +5,6 @@ from core.set_inspector_handler import (
     save_envelope,
     set_read_only,
     is_read_only,
-    is_synced,
 )
 from core.list_msets_handler import list_msets
 from core.set_backup_handler import (
@@ -102,7 +101,6 @@ class SetInspectorHandler(BaseHandler):
             "param_ranges_json": "{}",
             "backups": [],
             "read_only": False,
-            "synced": False,
         }
 
     def handle_post(self, form):
@@ -152,7 +150,6 @@ class SetInspectorHandler(BaseHandler):
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
-            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -170,7 +167,6 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
-                "synced": sync_state,
             }
         elif action == "show_clip":
             set_path = form.getvalue("set_path")
@@ -208,7 +204,6 @@ class SetInspectorHandler(BaseHandler):
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
-            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -232,7 +227,6 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
-                "synced": sync_state,
             }
         elif action == "save_envelope":
             set_path = form.getvalue("set_path")
@@ -283,7 +277,6 @@ class SetInspectorHandler(BaseHandler):
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             ro_state = is_read_only(set_path)
-            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -306,7 +299,6 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
-                "synced": sync_state,
             }
         elif action == "save_clip":
             set_path = form.getvalue("set_path")
@@ -378,7 +370,6 @@ class SetInspectorHandler(BaseHandler):
             set_name = os.path.basename(os.path.dirname(set_path))
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             ro_state = is_read_only(set_path)
-            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": result.get("message"),
@@ -401,7 +392,6 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
-                "synced": sync_state,
             }
         elif action == "toggle_read_only":
             set_path = form.getvalue("set_path")
@@ -428,7 +418,6 @@ class SetInspectorHandler(BaseHandler):
             pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
-            sync_state = is_synced(set_path)
             return {
                 "pad_grid": pad_grid,
                 "message": perm_result.get("message"),
@@ -446,7 +435,6 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
-                "synced": sync_state,
             }
         elif action == "restore_backup":
             set_path = form.getvalue("set_path")
@@ -489,7 +477,6 @@ class SetInspectorHandler(BaseHandler):
                 "backups": backups,
                 "current_ts": get_current_timestamp(set_path),
                 "read_only": ro_state,
-                "synced": sync_state,
             }
         else:
             return self.format_error_response("Unknown action", pad_grid=pad_grid)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -352,6 +352,7 @@ def set_inspector_route():
         backups=result.get("backups", []),
         current_ts=result.get("current_ts"),
         read_only=result.get("read_only", False),
+        synced=result.get("synced", False),
         active_tab="set-inspector",
     )
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -351,6 +351,7 @@ def set_inspector_route():
         param_ranges_json=result.get("param_ranges_json", "{}"),
         backups=result.get("backups", []),
         current_ts=result.get("current_ts"),
+        read_only=result.get("read_only", False),
         active_tab="set-inspector",
     )
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -352,7 +352,6 @@ def set_inspector_route():
         backups=result.get("backups", []),
         current_ts=result.get("current_ts"),
         read_only=result.get("read_only", False),
-        synced=result.get("synced", False),
         active_tab="set-inspector",
     )
 

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -25,6 +25,13 @@
     {{ clip_grid | safe }}
     <span id="selected-clip-name" style="margin-left:1rem;"></span>
   </form>
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
+    <input type="hidden" name="action" value="toggle_read_only">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="make_read_only" value="{{ 'false' if read_only else 'true' }}">
+    <button type="submit">{{ 'Make Read-Write' if read_only else 'Make Read-Only' }}</button>
+  </form>
+  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }}</p>
   {% if backups %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="restore_backup">
@@ -96,6 +103,13 @@
     <input type="hidden" name="loop_end" id="loop_end_input">
     <button id="saveClipBtn" type="submit">Save Clip</button>
   </form>
+  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
+    <input type="hidden" name="action" value="toggle_read_only">
+    <input type="hidden" name="set_path" value="{{ selected_set }}">
+    <input type="hidden" name="make_read_only" value="{{ 'false' if read_only else 'true' }}">
+    <button type="submit">{{ 'Make Read-Write' if read_only else 'Make Read-Only' }}</button>
+  </form>
+  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }}</p>
   {% if backups %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
     <input type="hidden" name="action" value="restore_backup">

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -29,7 +29,7 @@
     <input type="hidden" name="action" value="toggle_read_only">
     <input type="hidden" name="set_path" value="{{ selected_set }}">
     <input type="hidden" name="make_read_only" value="{{ 'false' if read_only else 'true' }}">
-    <button type="submit">{{ 'Make Read-Write' if read_only else 'Make Read-Only' }}</button>
+    <button type="submit">{{ 'Unlock Set 🔓' if read_only else 'Lock Set 🔒' }}</button>
   </form>
   <p>Status: {{ 'Read-Only' if read_only else 'Editable' }}</p>
   {% if backups %}
@@ -101,15 +101,8 @@
     <input type="hidden" name="region_end" id="region_end_input">
     <input type="hidden" name="loop_start" id="loop_start_input">
     <input type="hidden" name="loop_end" id="loop_end_input">
-    <button id="saveClipBtn" type="submit">Save Clip</button>
+    <button id="saveClipBtn" type="submit" {% if read_only %}disabled{% endif %}>Save Clip</button>
   </form>
-  <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
-    <input type="hidden" name="action" value="toggle_read_only">
-    <input type="hidden" name="set_path" value="{{ selected_set }}">
-    <input type="hidden" name="make_read_only" value="{{ 'false' if read_only else 'true' }}">
-    <button type="submit">{{ 'Make Read-Write' if read_only else 'Make Read-Only' }}</button>
-  </form>
-  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }}</p>
   {% if backups %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-top:0.5rem;">
     <input type="hidden" name="action" value="restore_backup">

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -31,7 +31,7 @@
     <input type="hidden" name="make_read_only" value="{{ 'false' if read_only else 'true' }}">
     <button type="submit">{{ 'Unlock Set 🔓' if read_only else 'Lock Set 🔒' }}</button>
   </form>
-  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }} - {{ 'synced' if synced else 'edited' }}</p>
+  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }}</p>
   {% if backups %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="restore_backup">

--- a/templates_jinja/set_inspector.html
+++ b/templates_jinja/set_inspector.html
@@ -31,7 +31,7 @@
     <input type="hidden" name="make_read_only" value="{{ 'false' if read_only else 'true' }}">
     <button type="submit">{{ 'Unlock Set 🔓' if read_only else 'Lock Set 🔒' }}</button>
   </form>
-  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }}</p>
+  <p>Status: {{ 'Read-Only' if read_only else 'Editable' }} - {{ 'synced' if synced else 'edited' }}</p>
   {% if backups %}
   <form method="post" action="{{ host_prefix }}/set-inspector" style="margin-bottom:1rem;">
     <input type="hidden" name="action" value="restore_backup">

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -171,3 +171,16 @@ def test_pitchbend_edit_preserves_other_automations(tmp_path):
     pb = saved_note["automations"]["PitchBend"]
     assert len(pb) == 1 and pb[0]["time"] == 0.0
     assert abs(pb[0]["value"] - val) < 1e-6
+
+
+def test_set_read_only_round_trip(tmp_path):
+    set_path = tmp_path / "set.abl"
+    create_simple_set(set_path)
+
+    assert not sih.is_read_only(str(set_path))
+    res = sih.set_read_only(str(set_path), True)
+    assert res["success"], res.get("message")
+    assert sih.is_read_only(str(set_path))
+    res = sih.set_read_only(str(set_path), False)
+    assert res["success"], res.get("message")
+    assert not sih.is_read_only(str(set_path))

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import subprocess
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -195,3 +196,19 @@ def test_set_read_only_round_trip(tmp_path):
     for p in (song, sample_file, sample_dir, root, root.parent):
         assert os.stat(p).st_mode & 0o222 != 0
     assert not sih.is_read_only(str(song))
+
+
+def test_is_synced(tmp_path):
+    song = tmp_path / "Song.abl"
+    create_simple_set(song)
+    assert not sih.is_synced(str(song))
+    subprocess.check_call(["setfattr", "-n", "user.cached-sha", "-v", "abc", str(song)])
+    subprocess.check_call([
+        "setfattr",
+        "-n",
+        "user.cached-sha-last-write-time",
+        "-v",
+        "1",
+        str(song),
+    ])
+    assert sih.is_synced(str(song))

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -1,7 +1,6 @@
 import json
 import os
 import sys
-import subprocess
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -196,19 +195,3 @@ def test_set_read_only_round_trip(tmp_path):
     for p in (song, sample_file, sample_dir, root, root.parent):
         assert os.stat(p).st_mode & 0o222 != 0
     assert not sih.is_read_only(str(song))
-
-
-def test_is_synced(tmp_path):
-    song = tmp_path / "Song.abl"
-    create_simple_set(song)
-    assert not sih.is_synced(str(song))
-    subprocess.check_call(["setfattr", "-n", "user.cached-sha", "-v", "abc", str(song)])
-    subprocess.check_call([
-        "setfattr",
-        "-n",
-        "user.cached-sha-last-write-time",
-        "-v",
-        "1",
-        str(song),
-    ])
-    assert sih.is_synced(str(song))


### PR DESCRIPTION
## Summary
- enable changing Song.abl permissions via `set_read_only`
- surface read-only state in Set Inspector
- allow toggling permissions from the clip browser
- show read-only status and toggle button in UI
- test permission helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538da25d288325bcaf4507ba560fb8