### PR TITLE
Add FX chain editor

### DIFF
--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -73,6 +73,14 @@ def _has_kind(data: Union[dict, list], kind: str) -> bool:
     if isinstance(data, list):
         return any(_has_kind(item, kind) for item in data)
     return False
+FX_KINDS={"autoFilter","channelEq","chorus","compressor","delay","reverb","saturator","phaser","redux2","audioEffectRack"}
+
+def _check_fx_file(p: str) -> bool:
+    for k in FX_KINDS:
+        if _check_json_file(p, k):
+            return True
+    return False
+
 
 
 FILTERS: dict[str, Callable[[str], bool]] = {
@@ -95,8 +103,11 @@ FILTERS: dict[str, Callable[[str], bool]] = {
     "melodicsampler": lambda p: (
         p.lower().endswith(".ablpreset")
         or p.lower().endswith(".json")
-    )
-    and _check_json_file(p, "melodicSampler"),
+    ) and _check_json_file(p, "melodicSampler"),
+    "fx": lambda p: (
+        p.lower().endswith(".ablpreset")
+        or p.lower().endswith(".json")
+    ) and _check_fx_file(p),
 }
 
 

--- a/core/fx_chain_handler.py
+++ b/core/fx_chain_handler.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Utilities for working with audio effect chains."""
+import json
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'static', 'schemas')
+
+
+def load_schema(kind):
+    """Load parameter schema for the given effect kind."""
+    path = os.path.join(SCHEMA_DIR, f'{kind}_schema.json')
+    try:
+        with open(path, 'r') as f:
+            return json.load(f)
+    except Exception as exc:
+        logger.warning('Could not load schema %s: %s', path, exc)
+        return {}
+
+
+def parse_chain(preset_path):
+    """Return effects and macro mapping info from an audio effect preset."""
+    try:
+        with open(preset_path, 'r') as f:
+            data = json.load(f)
+    except Exception as exc:
+        return {'success': False, 'message': f'Error reading preset: {exc}'}
+
+    effects = []
+    macros = {}
+    name = data.get('name', '')
+
+    if data.get('kind') == 'audioEffectRack':
+        chains = data.get('chains', [])
+        if chains:
+            chain = chains[0]
+            for idx, dev in enumerate(chain.get('devices', [])):
+                params = dev.get('parameters', {})
+                effects.append({'kind': dev.get('kind'), 'parameters': params})
+                for p_name, val in params.items():
+                    if isinstance(val, dict) and 'macroMapping' in val:
+                        m = val['macroMapping'].get('macroIndex')
+                        macros[m] = {'effect_index': idx, 'param': p_name}
+    else:
+        effects.append({'kind': data.get('kind'), 'parameters': data.get('parameters', {})})
+
+    return {
+        'success': True,
+        'name': name,
+        'effects': effects,
+        'macros': macros,
+    }
+
+
+def create_chain(name, effects, macros, output_path):
+    """Create a chain preset from effect data and macro mapping."""
+    chain = {
+        "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+        "kind": "audioEffectRack",
+        "name": name,
+        "parameters": {"Enabled": True},
+        "chains": [
+            {
+                "name": "",
+                "color": 0,
+                "devices": [],
+                "mixer": {
+                    "pan": 0.0,
+                    "solo-cue": False,
+                    "speakerOn": True,
+                    "volume": 0.0,
+                    "sends": [],
+                },
+            }
+        ],
+    }
+    for i in range(8):
+        chain["parameters"][f"Macro{i}"] = 0.0
+
+    dev_list = chain["chains"][0]["devices"]
+
+    for eff in effects:
+        dev = {
+            "presetUri": None,
+            "kind": eff["kind"],
+            "name": "",
+            "parameters": eff.get("parameters", {}),
+            "deviceData": {},
+        }
+        dev_list.append(dev)
+
+    for macro_idx, mapping in macros.items():
+        e_idx = mapping["effect_index"]
+        param = mapping["param"]
+        if e_idx >= len(dev_list):
+            continue
+        dev = dev_list[e_idx]
+        val = dev["parameters"].get(param)
+        if val is None:
+            continue
+        if isinstance(val, dict):
+            cur_val = val.get("value")
+        else:
+            cur_val = val
+        schema = load_schema(dev["kind"]).get(param, {})
+        min_v = schema.get("min", 0.0)
+        max_v = schema.get("max", 1.0)
+        dev["parameters"][param] = {
+            "value": cur_val,
+            "macroMapping": {"macroIndex": int(macro_idx), "rangeMin": min_v, "rangeMax": max_v},
+        }
+
+    try:
+        with open(output_path, 'w') as f:
+            json.dump(chain, f, indent=2)
+            f.write('\n')
+        return {"success": True, "path": output_path, "message": "Chain saved"}
+    except Exception as exc:
+        return {"success": False, "message": f"Error writing preset: {exc}"}

--- a/handlers/fx_chain_handler_class.py
+++ b/handlers/fx_chain_handler_class.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+import os
+import json
+import logging
+
+from handlers.base_handler import BaseHandler
+from core.file_browser import generate_dir_html
+from core.fx_chain_handler import parse_chain, create_chain, load_schema
+from core.refresh_handler import refresh_library
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHAIN = os.path.join('examples', 'Audio Effects', 'Dynamics', 'Punch Glue.json')
+SAVE_DIR = '/data/UserData/UserLibrary/Audio Effects'
+
+EFFECT_KINDS = [
+    'autoFilter', 'channelEq', 'chorus', 'compressor', 'delay',
+    'reverb', 'saturator', 'phaser', 'redux2'
+]
+
+class FxChainHandler(BaseHandler):
+    def handle_get(self):
+        base_dir = '/data/UserLibrary/Audio Effects'
+        if not os.path.exists(base_dir) and os.path.exists('examples/Audio Effects'):
+            base_dir = 'examples/Audio Effects'
+        browser_html = generate_dir_html(
+            base_dir,
+            '',
+            '/fx-chain',
+            'preset_select',
+            'select_preset',
+            filter_key='fx'
+        )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith('</ul>'):
+            browser_html = browser_html[:-5] + core_li + '</ul>'
+        return {
+            'file_browser_html': browser_html,
+            'message': '',
+            'selected_preset': None,
+            'browser_root': base_dir,
+            'browser_filter': 'fx',
+            'effect_kinds': EFFECT_KINDS,
+            'chain_data': None,
+            'message_type': 'info',
+        }
+
+    def handle_post(self, form):
+        action = form.getvalue('action')
+        if action == 'select_preset':
+            path = form.getvalue('preset_select')
+            if not path:
+                return self.format_error_response('No preset selected')
+            result = parse_chain(path)
+            if not result.get('success'):
+                return self.format_error_response(result.get('message'))
+            base_dir = '/data/UserLibrary/Audio Effects'
+            if not os.path.exists(base_dir) and os.path.exists('examples/Audio Effects'):
+                base_dir = 'examples/Audio Effects'
+            browser_html = generate_dir_html(
+                base_dir,
+                '',
+                '/fx-chain',
+                'preset_select',
+                'select_preset',
+                filter_key='fx'
+            )
+            core_li = (
+                '<li class="dir closed" data-path="Core Library">'
+                '<span>📁 Core Library</span>'
+                '<ul class="hidden"></ul></li>'
+            )
+            if browser_html.endswith('</ul>'):
+                browser_html = browser_html[:-5] + core_li + '</ul>'
+            return {
+                'file_browser_html': browser_html,
+                'message': 'Loaded preset',
+                'selected_preset': path,
+                'browser_root': base_dir,
+                'browser_filter': 'fx',
+                'effect_kinds': EFFECT_KINDS,
+                'chain_data': result,
+                'message_type': 'success',
+            }
+        if action == 'new_chain':
+            effects = []
+            for i in range(4):
+                kind = form.getvalue(f'effect{i}')
+                if kind:
+                    schema = load_schema(kind)
+                    params = {}
+                    for p, info in schema.items():
+                        if info['type'] == 'number':
+                            params[p] = info.get('min', 0)
+                        elif info['type'] == 'boolean':
+                            params[p] = False
+                        elif info['type'] == 'enum' and info.get('options'):
+                            params[p] = info['options'][0]
+                    effects.append({'kind': kind, 'parameters': params})
+            result = {
+                'success': True,
+                'name': form.getvalue('new_chain_name') or 'New Chain',
+                'effects': effects,
+                'macros': {},
+            }
+            base_dir = '/data/UserLibrary/Audio Effects'
+            if not os.path.exists(base_dir) and os.path.exists('examples/Audio Effects'):
+                base_dir = 'examples/Audio Effects'
+            browser_html = generate_dir_html(
+                base_dir,
+                '',
+                '/fx-chain',
+                'preset_select',
+                'select_preset',
+                filter_key='fx'
+            )
+            core_li = (
+                '<li class="dir closed" data-path="Core Library">'
+                '<span>📁 Core Library</span>'
+                '<ul class="hidden"></ul></li>'
+            )
+            if browser_html.endswith('</ul>'):
+                browser_html = browser_html[:-5] + core_li + '</ul>'
+            return {
+                'file_browser_html': browser_html,
+                'message': 'Create new chain',
+                'selected_preset': None,
+                'browser_root': base_dir,
+                'browser_filter': 'fx',
+                'effect_kinds': EFFECT_KINDS,
+                'chain_data': result,
+                'message_type': 'info',
+            }
+        if action == 'save_chain':
+            name = form.getvalue('chain_name') or 'FX Chain'
+            effects = []
+            for i in range(4):
+                kind = form.getvalue(f'effect{i}_kind')
+                if not kind:
+                    continue
+                schema = load_schema(kind)
+                params = {}
+                for param in schema.keys():
+                    field = f'effect{i}_{param}'
+                    if field in form:
+                        val = form.getvalue(field)
+                        info = schema[param]
+                        if info['type'] == 'number':
+                            try:
+                                val = float(val)
+                            except ValueError:
+                                val = info.get('min', 0)
+                        elif info['type'] == 'boolean':
+                            val = val == 'on'
+                        params[param] = val
+                effects.append({'kind': kind, 'parameters': params})
+            macros = {}
+            for m in range(8):
+                choice = form.getvalue(f'macro{m}')
+                if choice:
+                    idx, param = choice.split(':')
+                    macros[m] = {'effect_index': int(idx), 'param': param}
+            os.makedirs(SAVE_DIR, exist_ok=True)
+            out_path = os.path.join(SAVE_DIR, f'{name}.json')
+            result = create_chain(name, effects, macros, out_path)
+            if result['success']:
+                refresh_library(out_path)
+            return {
+                'file_browser_html': '',
+                'message': result['message'],
+                'selected_preset': out_path if result['success'] else None,
+                'browser_root': SAVE_DIR,
+                'browser_filter': 'fx',
+                'effect_kinds': EFFECT_KINDS,
+                'chain_data': None,
+                'message_type': 'success' if result['success'] else 'error',
+            }
+        return self.format_error_response('Unknown action')

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -48,6 +48,7 @@ from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
 from core.refresh_handler import refresh_library
+from handlers.fx_chain_handler_class import FxChainHandler
 from core.file_browser import generate_dir_html
 
 logging.basicConfig(
@@ -132,6 +133,7 @@ file_placer_handler = FilePlacerHandler()
 refresh_handler = RefreshHandler()
 drum_rack_handler = DrumRackInspectorHandler()
 filter_viz_handler = FilterVizHandler()
+fx_chain_handler = FxChainHandler()
 update_handler = UpdateHandler()
 adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
@@ -762,6 +764,30 @@ def melodic_sampler_params():
         sample_path=sample_path,
         active_tab="melodic-sampler",
     )
+@app.route("/fx-chain", methods=["GET", "POST"])
+def fx_chain():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = fx_chain_handler.handle_post(form)
+    else:
+        result = fx_chain_handler.handle_get()
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    return render_template(
+        "fx_chain.html",
+        message=message,
+        success=success,
+        message_type=message_type,
+        file_browser_html=result.get("file_browser_html"),
+        browser_root=result.get("browser_root"),
+        browser_filter=result.get("browser_filter"),
+        effect_kinds=result.get("effect_kinds"),
+        chain_data=result.get("chain_data"),
+        selected_preset=result.get("selected_preset"),
+        active_tab="fx-chain",
+    )
+
 
 
 @app.route("/chord", methods=["GET"])

--- a/static/schemas/audioEffectRack_schema.json
+++ b/static/schemas/audioEffectRack_schema.json
@@ -1,0 +1,61 @@
+{
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Macro0": {
+    "type": "number",
+    "options": [],
+    "min": 63.35280227661133,
+    "max": 63.35280227661133,
+    "decimals": 4
+  },
+  "Macro1": {
+    "type": "number",
+    "options": [],
+    "min": 63.5,
+    "max": 63.5,
+    "decimals": 1
+  },
+  "Macro2": {
+    "type": "number",
+    "options": [],
+    "min": 63.35280227661133,
+    "max": 63.35280227661133,
+    "decimals": 4
+  },
+  "Macro3": {
+    "type": "number",
+    "options": [],
+    "min": 24.60405158996582,
+    "max": 32.8900260925293,
+    "decimals": 4
+  },
+  "Macro4": {
+    "type": "number",
+    "options": [],
+    "min": 29.73539161682129,
+    "max": 51.38686752319336,
+    "decimals": 4
+  },
+  "Macro5": {
+    "type": "number",
+    "options": [],
+    "min": 44.9728889465332,
+    "max": 85.1494369506836,
+    "decimals": 4
+  },
+  "Macro6": {
+    "type": "number",
+    "options": [],
+    "min": 3.527777910232544,
+    "max": 17.63888931274414,
+    "decimals": 4
+  },
+  "Macro7": {
+    "type": "number",
+    "options": [],
+    "min": 127.0,
+    "max": 127.0
+  }
+}

--- a/static/schemas/autoFilter_schema.json
+++ b/static/schemas/autoFilter_schema.json
@@ -1,0 +1,291 @@
+{
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Envelope_Amount": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "Envelope_Attack": {
+    "type": "number",
+    "options": [],
+    "min": 0.0010000000474974513,
+    "max": 0.0019108913838863373,
+    "decimals": 4
+  },
+  "Envelope_HoldOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "Envelope_Release": {
+    "type": "number",
+    "options": [],
+    "min": 0.13112400472164154,
+    "max": 0.25,
+    "decimals": 4
+  },
+  "Envelope_SahOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "Envelope_SahRate": {
+    "type": "number",
+    "options": [],
+    "min": -4,
+    "max": -4
+  },
+  "Filter_Circuit": {
+    "type": "enum",
+    "options": [
+      "DFM",
+      "SVF"
+    ]
+  },
+  "Filter_DjControl": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "Filter_Drive": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.4000000059604645,
+    "decimals": 4
+  },
+  "Filter_Frequency": {
+    "type": "number",
+    "options": [],
+    "min": 103.5894775390625,
+    "max": 9999.998046875,
+    "decimals": 4
+  },
+  "Filter_Morph": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.296875,
+    "decimals": 4
+  },
+  "Filter_MorphSlope": {
+    "type": "enum",
+    "options": [
+      "24dB"
+    ]
+  },
+  "Filter_Resonance": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.60317462682724,
+    "decimals": 4
+  },
+  "Filter_Slope": {
+    "type": "enum",
+    "options": [
+      "12dB",
+      "24dB"
+    ]
+  },
+  "Filter_Type": {
+    "type": "enum",
+    "options": [
+      "Comb",
+      "DJ",
+      "Low-pass",
+      "Vowel"
+    ]
+  },
+  "Filter_VowelFormant": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.15000000596046448,
+    "decimals": 4
+  },
+  "Filter_VowelPitch": {
+    "type": "number",
+    "options": [],
+    "min": -3,
+    "max": 0
+  },
+  "HiQuality": {
+    "type": "boolean",
+    "options": []
+  },
+  "HostVisualisationRate": {
+    "type": "number",
+    "options": [],
+    "min": 0.019999999552965164,
+    "max": 0.019999999552965164,
+    "decimals": 4
+  },
+  "InternalSideChainGain": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "Lfo_Amount": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.25,
+    "decimals": 2
+  },
+  "Lfo_Frequency": {
+    "type": "number",
+    "options": [],
+    "min": 0.75,
+    "max": 1.0,
+    "decimals": 2
+  },
+  "Lfo_Morph": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "Lfo_Phase": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 90.0,
+    "decimals": 4
+  },
+  "Lfo_PhaseOffset": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "Lfo_QuantizationMode": {
+    "type": "enum",
+    "options": [
+      "None"
+    ]
+  },
+  "Lfo_SahRate": {
+    "type": "number",
+    "options": [],
+    "min": -4,
+    "max": -4
+  },
+  "Lfo_Sixteenth": {
+    "type": "number",
+    "options": [],
+    "min": 16,
+    "max": 16
+  },
+  "Lfo_Smoothing": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "Lfo_Spin": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "Lfo_Steps": {
+    "type": "number",
+    "options": [],
+    "min": 8,
+    "max": 8
+  },
+  "Lfo_StereoMode": {
+    "type": "enum",
+    "options": [
+      "Phase"
+    ]
+  },
+  "Lfo_SyncedRate": {
+    "type": "number",
+    "options": [],
+    "min": 4,
+    "max": 6
+  },
+  "Lfo_Time": {
+    "type": "number",
+    "options": [],
+    "min": 1.0000001192092896,
+    "max": 1.0000001192092896,
+    "decimals": 4
+  },
+  "Lfo_TimeMode": {
+    "type": "enum",
+    "options": [
+      "Rate",
+      "Synced"
+    ]
+  },
+  "Lfo_Waveform": {
+    "type": "enum",
+    "options": [
+      "Sine",
+      "Triangle"
+    ]
+  },
+  "Output": {
+    "type": "number",
+    "options": [],
+    "min": 0.3981052041053772,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "SideChainEq_Freq": {
+    "type": "number",
+    "options": [],
+    "min": 199.99998474121094,
+    "max": 995.3352661132812,
+    "decimals": 4
+  },
+  "SideChainEq_Gain": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "SideChainEq_Mode": {
+    "type": "enum",
+    "options": [
+      "High pass"
+    ]
+  },
+  "SideChainEq_On": {
+    "type": "boolean",
+    "options": []
+  },
+  "SideChainEq_Q": {
+    "type": "number",
+    "options": [],
+    "min": 0.7071067094802856,
+    "max": 3.7638254165649414,
+    "decimals": 4
+  },
+  "SideChainListen": {
+    "type": "boolean",
+    "options": []
+  },
+  "SideChainMono": {
+    "type": "boolean",
+    "options": []
+  },
+  "SoftClipOn": {
+    "type": "boolean",
+    "options": []
+  }
+}

--- a/static/schemas/channelEq_schema.json
+++ b/static/schemas/channelEq_schema.json
@@ -1,0 +1,45 @@
+{
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Gain": {
+    "type": "number",
+    "options": [],
+    "min": 0.7943263053894043,
+    "max": 1.2589285373687744,
+    "decimals": 4
+  },
+  "HighShelfGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.18000000715255737,
+    "max": 2.004319906234741,
+    "decimals": 4
+  },
+  "HighpassOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "LowShelfGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.18000000715255737,
+    "max": 2.5385196208953857,
+    "decimals": 4
+  },
+  "MidFrequency": {
+    "type": "number",
+    "options": [],
+    "min": 572.7157592773438,
+    "max": 4192.9130859375,
+    "decimals": 4
+  },
+  "MidGain": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 2.1601195335388184,
+    "decimals": 4
+  }
+}

--- a/static/schemas/chorus_schema.json
+++ b/static/schemas/chorus_schema.json
@@ -1,0 +1,92 @@
+{
+  "Amount": {
+    "type": "number",
+    "options": [],
+    "min": 0.1031746044754982,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 0.5,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Feedback": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.8014286160469055,
+    "decimals": 4
+  },
+  "HighpassEnabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "HighpassFrequency": {
+    "type": "number",
+    "options": [],
+    "min": 20.0,
+    "max": 90.42745208740234,
+    "decimals": 4
+  },
+  "InvertFeedback": {
+    "type": "boolean",
+    "options": []
+  },
+  "Mode": {
+    "type": "enum",
+    "options": [
+      "Classic",
+      "Ensemble",
+      "Vibrato"
+    ]
+  },
+  "OutputGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.9999999403953552,
+    "max": 1.259763240814209,
+    "decimals": 4
+  },
+  "Rate": {
+    "type": "number",
+    "options": [],
+    "min": 0.23969697952270508,
+    "max": 7.2805609703063965,
+    "decimals": 4
+  },
+  "Shaping": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "VibratoOffset": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 180.0,
+    "decimals": 1
+  },
+  "Warmth": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.26960694789886475,
+    "decimals": 4
+  },
+  "Width": {
+    "type": "number",
+    "options": [],
+    "min": 0.859375,
+    "max": 1.0,
+    "decimals": 4
+  }
+}

--- a/static/schemas/compressor_schema.json
+++ b/static/schemas/compressor_schema.json
@@ -1,0 +1,105 @@
+{
+  "Attack": {
+    "type": "number",
+    "options": [],
+    "min": 0.10000000149011612,
+    "max": 30.000001907348633,
+    "decimals": 4
+  },
+  "AutoReleaseControlOnOff": {
+    "type": "boolean",
+    "options": []
+  },
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "ExpansionRatio": {
+    "type": "number",
+    "options": [],
+    "min": 1.149999976158142,
+    "max": 1.149999976158142,
+    "decimals": 4
+  },
+  "Gain": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "GainCompensation": {
+    "type": "boolean",
+    "options": []
+  },
+  "Knee": {
+    "type": "number",
+    "options": [],
+    "min": 0.10000000149011612,
+    "max": 9.0,
+    "decimals": 4
+  },
+  "LogEnvelope": {
+    "type": "boolean",
+    "options": []
+  },
+  "Model": {
+    "type": "enum",
+    "options": [
+      "Peak",
+      "RMS"
+    ]
+  },
+  "Ratio": {
+    "type": "number",
+    "options": [],
+    "min": 2.0,
+    "max": 8.0
+  },
+  "Release": {
+    "type": "number",
+    "options": [],
+    "min": 30.0,
+    "max": 30.0
+  },
+  "SideChainEq_Freq": {
+    "type": "number",
+    "options": [],
+    "min": 80.0,
+    "max": 80.0
+  },
+  "SideChainEq_Gain": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "SideChainEq_Mode": {
+    "type": "enum",
+    "options": [
+      "High pass"
+    ]
+  },
+  "SideChainEq_On": {
+    "type": "boolean",
+    "options": []
+  },
+  "SideChainEq_Q": {
+    "type": "number",
+    "options": [],
+    "min": 0.4099999964237213,
+    "max": 0.7071067690849304,
+    "decimals": 4
+  },
+  "Threshold": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  }
+}

--- a/static/schemas/delay_schema.json
+++ b/static/schemas/delay_schema.json
@@ -1,0 +1,173 @@
+{
+  "DelayLine_CompatibilityMode": {
+    "type": "enum",
+    "options": [
+      "D"
+    ]
+  },
+  "DelayLine_Link": {
+    "type": "boolean",
+    "options": []
+  },
+  "DelayLine_OffsetL": {
+    "type": "number",
+    "options": [],
+    "min": -0.33000001311302185,
+    "max": 0.07218751311302185,
+    "decimals": 4
+  },
+  "DelayLine_OffsetR": {
+    "type": "number",
+    "options": [],
+    "min": -0.33000001311302185,
+    "max": 0.031218737363815308,
+    "decimals": 4
+  },
+  "DelayLine_PingPong": {
+    "type": "boolean",
+    "options": []
+  },
+  "DelayLine_PingPongDelayTimeL": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "DelayLine_PingPongDelayTimeR": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "DelayLine_SimpleDelayTimeL": {
+    "type": "number",
+    "options": [],
+    "min": 100.0,
+    "max": 100.0
+  },
+  "DelayLine_SimpleDelayTimeR": {
+    "type": "number",
+    "options": [],
+    "min": 100.0,
+    "max": 100.0
+  },
+  "DelayLine_SmoothingMode": {
+    "type": "enum",
+    "options": [
+      "Fade",
+      "Repitch"
+    ]
+  },
+  "DelayLine_SyncL": {
+    "type": "boolean",
+    "options": []
+  },
+  "DelayLine_SyncR": {
+    "type": "boolean",
+    "options": []
+  },
+  "DelayLine_SyncedSixteenthL": {
+    "type": "enum",
+    "options": [
+      "1",
+      "2",
+      "3",
+      "4"
+    ]
+  },
+  "DelayLine_SyncedSixteenthR": {
+    "type": "enum",
+    "options": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5"
+    ]
+  },
+  "DelayLine_TimeL": {
+    "type": "number",
+    "options": [],
+    "min": 0.0010000000474974513,
+    "max": 0.3749999403953552,
+    "decimals": 4
+  },
+  "DelayLine_TimeR": {
+    "type": "number",
+    "options": [],
+    "min": 0.0010000000474974513,
+    "max": 0.40207386016845703,
+    "decimals": 4
+  },
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 0.20000000298023224,
+    "max": 0.7539682388305664,
+    "decimals": 4
+  },
+  "DryWetMode": {
+    "type": "enum",
+    "options": [
+      "Equal-loudness"
+    ]
+  },
+  "EcoProcessing": {
+    "type": "boolean",
+    "options": []
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Feedback": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.7841269969940186,
+    "decimals": 4
+  },
+  "Filter_Bandwidth": {
+    "type": "number",
+    "options": [],
+    "min": 2.401315689086914,
+    "max": 9.0,
+    "decimals": 4
+  },
+  "Filter_Frequency": {
+    "type": "number",
+    "options": [],
+    "min": 173.30467224121094,
+    "max": 4020.581298828125,
+    "decimals": 4
+  },
+  "Filter_On": {
+    "type": "boolean",
+    "options": []
+  },
+  "Freeze": {
+    "type": "boolean",
+    "options": []
+  },
+  "Modulation_AmountFilter": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.84375,
+    "decimals": 4
+  },
+  "Modulation_AmountTime": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.8799999952316284,
+    "decimals": 4
+  },
+  "Modulation_Frequency": {
+    "type": "number",
+    "options": [],
+    "min": 0.2723929286003113,
+    "max": 5.029735088348389,
+    "decimals": 4
+  }
+}

--- a/static/schemas/phaser_schema.json
+++ b/static/schemas/phaser_schema.json
@@ -1,0 +1,197 @@
+{
+  "CenterFrequency": {
+    "type": "number",
+    "options": [],
+    "min": 77.3109130859375,
+    "max": 1543.8038330078125,
+    "decimals": 4
+  },
+  "DoublerDelayTime": {
+    "type": "number",
+    "options": [],
+    "min": 0.026972541585564613,
+    "max": 0.07999999821186066,
+    "decimals": 4
+  },
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 0.5952380895614624,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Feedback": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.7734375,
+    "decimals": 4
+  },
+  "FlangerDelayTime": {
+    "type": "number",
+    "options": [],
+    "min": 0.0015799448592588305,
+    "max": 0.01918903924524784,
+    "decimals": 4
+  },
+  "InvertWet": {
+    "type": "boolean",
+    "options": []
+  },
+  "Mode": {
+    "type": "enum",
+    "options": [
+      "Doubler",
+      "Flanger",
+      "Phaser"
+    ]
+  },
+  "ModulationBlend": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.9453125,
+    "decimals": 4
+  },
+  "Modulation_Amount": {
+    "type": "number",
+    "options": [],
+    "min": 0.3888888955116272,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "Modulation_DutyCycle": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  },
+  "Modulation_EnvelopeAmount": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.828125,
+    "decimals": 4
+  },
+  "Modulation_EnvelopeAttack": {
+    "type": "number",
+    "options": [],
+    "min": 0.006000000052154064,
+    "max": 0.012947656214237213,
+    "decimals": 4
+  },
+  "Modulation_EnvelopeEnabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Modulation_EnvelopeRelease": {
+    "type": "number",
+    "options": [],
+    "min": 0.20000000298023224,
+    "max": 0.20000000298023224,
+    "decimals": 4
+  },
+  "Modulation_Frequency": {
+    "type": "number",
+    "options": [],
+    "min": 0.08778024464845657,
+    "max": 0.6324555277824402,
+    "decimals": 4
+  },
+  "Modulation_Frequency2": {
+    "type": "number",
+    "options": [],
+    "min": 0.010000000707805157,
+    "max": 0.20000000298023224,
+    "decimals": 4
+  },
+  "Modulation_LfoBlend": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.046875,
+    "decimals": 4
+  },
+  "Modulation_PhaseOffset": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 180.0
+  },
+  "Modulation_Spin": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.3359375,
+    "decimals": 4
+  },
+  "Modulation_SpinEnabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Modulation_Sync": {
+    "type": "boolean",
+    "options": []
+  },
+  "Modulation_Sync2": {
+    "type": "boolean",
+    "options": []
+  },
+  "Modulation_SyncedRate": {
+    "type": "number",
+    "options": [],
+    "min": 0,
+    "max": 14
+  },
+  "Modulation_SyncedRate2": {
+    "type": "number",
+    "options": [],
+    "min": 4,
+    "max": 12
+  },
+  "Modulation_Waveform": {
+    "type": "enum",
+    "options": [
+      "Sine",
+      "Triangle"
+    ]
+  },
+  "Notches": {
+    "type": "number",
+    "options": [],
+    "min": 4,
+    "max": 35
+  },
+  "OutputGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.6309606432914734,
+    "max": 1.5243134498596191,
+    "decimals": 4
+  },
+  "SafeBassFrequency": {
+    "type": "number",
+    "options": [],
+    "min": 99.99999237060547,
+    "max": 150.0,
+    "decimals": 4
+  },
+  "Spread": {
+    "type": "number",
+    "options": [],
+    "min": 0.15937499701976776,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "Warmth": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.375,
+    "decimals": 4
+  }
+}

--- a/static/schemas/redux2_schema.json
+++ b/static/schemas/redux2_schema.json
@@ -1,0 +1,62 @@
+{
+  "BitDepth": {
+    "type": "number",
+    "options": [],
+    "min": 1,
+    "max": 16
+  },
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "EcoProcessing": {
+    "type": "boolean",
+    "options": []
+  },
+  "EnablePostFilter": {
+    "type": "boolean",
+    "options": []
+  },
+  "EnablePreFilter": {
+    "type": "boolean",
+    "options": []
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Jitter": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.43392542004585266,
+    "decimals": 4
+  },
+  "PostFilterValue": {
+    "type": "number",
+    "options": [],
+    "min": -2.0,
+    "max": 4.0,
+    "decimals": 3
+  },
+  "QuantizerDcShift": {
+    "type": "boolean",
+    "options": []
+  },
+  "QuantizerShape": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "SampleRate": {
+    "type": "number",
+    "options": [],
+    "min": 3999.999267578125,
+    "max": 40000.0,
+    "decimals": 4
+  }
+}

--- a/static/schemas/reverb_schema.json
+++ b/static/schemas/reverb_schema.json
@@ -1,0 +1,200 @@
+{
+  "AllPassGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.31305554509162903,
+    "max": 0.9599999785423279,
+    "decimals": 4
+  },
+  "AllPassSize": {
+    "type": "number",
+    "options": [],
+    "min": 0.17817460000514984,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "BandFreq": {
+    "type": "number",
+    "options": [],
+    "min": 265.2108154296875,
+    "max": 7123.693359375,
+    "decimals": 4
+  },
+  "BandHighOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "BandLowOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "BandWidth": {
+    "type": "number",
+    "options": [],
+    "min": 2.9791667461395264,
+    "max": 6.875,
+    "decimals": 4
+  },
+  "ChorusOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "CutOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "DecayTime": {
+    "type": "number",
+    "options": [],
+    "min": 600.0001831054688,
+    "max": 19522.20703125,
+    "decimals": 4
+  },
+  "DiffuseDelay": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.9841269850730896,
+    "decimals": 4
+  },
+  "EarlyReflectModDepth": {
+    "type": "number",
+    "options": [],
+    "min": 2.6361758708953857,
+    "max": 55.0,
+    "decimals": 4
+  },
+  "EarlyReflectModFreq": {
+    "type": "number",
+    "options": [],
+    "min": 0.07999999821186066,
+    "max": 1.0627338886260986,
+    "decimals": 4
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "FlatOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "FreezeOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "HighFilterType": {
+    "type": "enum",
+    "options": [
+      "Shelf"
+    ]
+  },
+  "MixDiffuse": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.995300054550171,
+    "decimals": 4
+  },
+  "MixDirect": {
+    "type": "number",
+    "options": [],
+    "min": 0.19685038924217224,
+    "max": 0.5,
+    "decimals": 4
+  },
+  "MixReflect": {
+    "type": "number",
+    "options": [],
+    "min": 0.029999999329447746,
+    "max": 1.995300054550171,
+    "decimals": 4
+  },
+  "PreDelay": {
+    "type": "number",
+    "options": [],
+    "min": 0.949999988079071,
+    "max": 103.61170959472656,
+    "decimals": 4
+  },
+  "RoomSize": {
+    "type": "number",
+    "options": [],
+    "min": 0.26640886068344116,
+    "max": 499.99993896484375,
+    "decimals": 4
+  },
+  "RoomType": {
+    "type": "enum",
+    "options": [
+      "SuperEco"
+    ]
+  },
+  "ShelfHiFreq": {
+    "type": "number",
+    "options": [],
+    "min": 110.05611419677734,
+    "max": 7057.31591796875,
+    "decimals": 4
+  },
+  "ShelfHiGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.21666666865348816,
+    "max": 0.7333333492279053,
+    "decimals": 4
+  },
+  "ShelfHighOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "ShelfLoFreq": {
+    "type": "number",
+    "options": [],
+    "min": 58.900001525878906,
+    "max": 1614.2037353515625,
+    "decimals": 4
+  },
+  "ShelfLoGain": {
+    "type": "number",
+    "options": [],
+    "min": 0.20000000298023224,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "ShelfLowOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "SizeModDepth": {
+    "type": "number",
+    "options": [],
+    "min": 0.019999999552965164,
+    "max": 3.1163108348846436,
+    "decimals": 4
+  },
+  "SizeModFreq": {
+    "type": "number",
+    "options": [],
+    "min": 0.019999999552965164,
+    "max": 5.90379524230957,
+    "decimals": 4
+  },
+  "SizeSmoothing": {
+    "type": "enum",
+    "options": [
+      "Fast"
+    ]
+  },
+  "SpinOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "StereoSeparation": {
+    "type": "number",
+    "options": [],
+    "min": 82.66000366210938,
+    "max": 120.0,
+    "decimals": 4
+  }
+}

--- a/static/schemas/saturator_schema.json
+++ b/static/schemas/saturator_schema.json
@@ -1,0 +1,132 @@
+{
+  "BaseDrive": {
+    "type": "number",
+    "options": [],
+    "min": -24.60000228881836,
+    "max": 29.09999656677246,
+    "decimals": 4
+  },
+  "BassShaperThreshold": {
+    "type": "number",
+    "options": [],
+    "min": -50.0,
+    "max": -40.0
+  },
+  "ColorDepth": {
+    "type": "number",
+    "options": [],
+    "min": -24.0,
+    "max": 13.400001525878906,
+    "decimals": 4
+  },
+  "ColorFrequency": {
+    "type": "number",
+    "options": [],
+    "min": 30.0,
+    "max": 1000.0,
+    "decimals": 4
+  },
+  "ColorOn": {
+    "type": "boolean",
+    "options": []
+  },
+  "ColorWidth": {
+    "type": "number",
+    "options": [],
+    "min": 0.2539682686328888,
+    "max": 0.8897637724876404,
+    "decimals": 4
+  },
+  "DryWet": {
+    "type": "number",
+    "options": [],
+    "min": 0.658730149269104,
+    "max": 1.0,
+    "decimals": 4
+  },
+  "Enabled": {
+    "type": "boolean",
+    "options": []
+  },
+  "Oversampling": {
+    "type": "boolean",
+    "options": []
+  },
+  "PostClip": {
+    "type": "enum",
+    "options": [
+      "off",
+      "on"
+    ]
+  },
+  "PostDrive": {
+    "type": "number",
+    "options": [],
+    "min": -28.295522689819336,
+    "max": 0.0,
+    "decimals": 4
+  },
+  "PreDcFilter": {
+    "type": "boolean",
+    "options": []
+  },
+  "PreDrive": {
+    "type": "number",
+    "options": [],
+    "min": -10.857142448425293,
+    "max": 22.11023712158203,
+    "decimals": 4
+  },
+  "Type": {
+    "type": "enum",
+    "options": [
+      "Analog Clip",
+      "Bass Shaper",
+      "Digital Clip",
+      "Hard Curve",
+      "Medium Curve",
+      "Sinoid Fold",
+      "Soft Sine",
+      "Waveshaper"
+    ]
+  },
+  "WsCurve": {
+    "type": "number",
+    "options": [],
+    "min": 0.05000000074505806,
+    "max": 0.10199999809265137,
+    "decimals": 4
+  },
+  "WsDamp": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.046875,
+    "decimals": 4
+  },
+  "WsDepth": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 1.0
+  },
+  "WsDrive": {
+    "type": "number",
+    "options": [],
+    "min": 1.0,
+    "max": 1.0
+  },
+  "WsLin": {
+    "type": "number",
+    "options": [],
+    "min": 0.5,
+    "max": 0.5,
+    "decimals": 1
+  },
+  "WsPeriod": {
+    "type": "number",
+    "options": [],
+    "min": 0.0,
+    "max": 0.0
+  }
+}

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -19,6 +19,7 @@
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
+        <a href="{{ host_prefix }}/fx-chain" class="{% if active_tab == 'fx-chain' %}active{% endif %}">FX Chain</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>
         <a href="{{ host_prefix }}/adsr" class="{% if active_tab == 'adsr' %}active{% endif %}">ADSR</a> -->
         <!-- <a href="{{ host_prefix }}/lfo" class="{% if active_tab == 'lfo' %}active{% endif %}">LFO</a> -->

--- a/templates_jinja/fx_chain.html
+++ b/templates_jinja/fx_chain.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>FX Chain Editor</h2>
+{% if message %}
+<p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+{% if not chain_data %}
+<div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/fx-chain" data-field="preset_select" data-value="select_preset" data-filter="fx">
+    {{ file_browser_html | safe }}
+</div>
+<form method="post" action="{{ host_prefix }}/fx-chain">
+  <input type="hidden" name="action" value="new_chain">
+  <label>Name: <input type="text" name="new_chain_name"></label><br>
+  {% for i in range(4) %}
+  <label>Effect {{ i+1 }}:
+    <select name="effect{{ i }}">
+      <option value="">None</option>
+      {% for kind in effect_kinds %}
+      <option value="{{ kind }}">{{ kind }}</option>
+      {% endfor %}
+    </select>
+  </label><br>
+  {% endfor %}
+  <button type="submit">Create New Chain</button>
+</form>
+{% else %}
+<form method="post" action="{{ host_prefix }}/fx-chain">
+  <input type="hidden" name="action" value="save_chain">
+  <label>Name: <input type="text" name="chain_name" value="{{ chain_data.name }}"></label><br>
+  {% for eff in chain_data.effects %}
+    {% set idx = loop.index0 %}
+    <h3>Effect {{ idx+1 }} - {{ eff.kind }}</h3>
+    <input type="hidden" name="effect{{ idx }}_kind" value="{{ eff.kind }}">
+    {% for p,val in eff.parameters.items() %}
+      <label>{{ p }}:<input type="text" name="effect{{ idx }}_{{ p }}" value="{{ val.value if val is mapping else val }}"></label><br>
+    {% endfor %}
+  {% endfor %}
+  <h3>Macro Mappings</h3>
+  {% for i in range(8) %}
+    <label>Macro {{ i }}:
+      <select name="macro{{ i }}">
+        <option value="">None</option>
+        {% for eff in chain_data.effects %}
+          {% set idx = loop.index0 %}
+          {% for p in eff.parameters.keys() %}
+            {% set val = idx|string + ':' + p %}
+            <option value="{{ val }}" {% if chain_data.macros[i] and chain_data.macros[i].effect_index == idx and chain_data.macros[i].param == p %}selected{% endif %}>Effect {{ idx+1 }} {{ p }}</option>
+          {% endfor %}
+        {% endfor %}
+      </select>
+    </label><br>
+  {% endfor %}
+  <button type="submit">Save Chain</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -748,3 +748,37 @@ def test_set_inspector_post(client, monkeypatch):
 
 
 
+
+def test_fx_chain_get(client, monkeypatch):
+    def fake_get():
+        return {
+            'file_browser_html': '<ul></ul>',
+            'message': '',
+            'selected_preset': None,
+            'browser_root': '/tmp',
+            'browser_filter': 'fx',
+            'effect_kinds': [],
+            'chain_data': None,
+        }
+    monkeypatch.setattr(move_webserver.fx_chain_handler, 'handle_get', fake_get)
+    resp = client.get('/fx-chain')
+    assert resp.status_code == 200
+    assert b'class="file-browser"' in resp.data
+
+
+def test_fx_chain_post(client, monkeypatch):
+    def fake_post(form):
+        return {
+            'message': 'ok',
+            'message_type': 'success',
+            'file_browser_html': '<ul></ul>',
+            'browser_root': '/tmp',
+            'browser_filter': 'fx',
+            'effect_kinds': [],
+            'chain_data': {'effects': []},
+            'selected_preset': 'x',
+        }
+    monkeypatch.setattr(move_webserver.fx_chain_handler, 'handle_post', fake_post)
+    resp = client.post('/fx-chain', data={'action': 'select_preset', 'preset_select': 'x'})
+    assert resp.status_code == 200
+    assert b'ok' in resp.data

--- a/utility-scripts/generate_audio_fx_schemas.py
+++ b/utility-scripts/generate_audio_fx_schemas.py
@@ -1,0 +1,81 @@
+import json
+import glob
+import os
+from decimal import Decimal
+
+SCHEMA_DIR = os.path.join('static', 'schemas')
+
+
+def count_decimals(value):
+    d = Decimal(str(value)).normalize()
+    return abs(d.as_tuple().exponent) if d.as_tuple().exponent < 0 else 0
+
+
+def update_param(entry, value):
+    if isinstance(value, bool):
+        entry['type'] = 'boolean'
+    elif isinstance(value, (int, float)):
+        entry['type'] = 'number'
+        entry['min'] = value if entry['min'] is None else min(entry['min'], value)
+        entry['max'] = value if entry['max'] is None else max(entry['max'], value)
+        dec = min(count_decimals(value), 4)
+        entry['decimals'] = max(entry.get('decimals', 0), dec)
+    elif isinstance(value, str):
+        if entry['type'] not in ('enum', 'string'):
+            entry['type'] = 'enum'
+        entry.setdefault('options', set()).add(value)
+
+
+def traverse(obj, schemas):
+    if isinstance(obj, dict):
+        kind = obj.get('kind')
+        if kind and 'parameters' in obj:
+            params = schemas.setdefault(kind, {})
+            for name, val in obj['parameters'].items():
+                if isinstance(val, dict) and 'value' in val:
+                    val = val['value']
+                entry = params.setdefault(name, {'type': None, 'min': None, 'max': None})
+                update_param(entry, val)
+        for v in obj.values():
+            traverse(v, schemas)
+    elif isinstance(obj, list):
+        for item in obj:
+            traverse(item, schemas)
+
+
+def build_schemas(paths):
+    schemas = {}
+    for path in paths:
+        with open(path) as f:
+            data = json.load(f)
+        traverse(data, schemas)
+    final = {}
+    for kind, params in schemas.items():
+        out = {}
+        for name, info in sorted(params.items()):
+            entry = {'type': info['type'], 'options': []}
+            if info['type'] == 'number':
+                entry['min'] = info['min']
+                entry['max'] = info['max']
+                if info.get('decimals'):
+                    entry['decimals'] = info['decimals']
+            elif info['type'] == 'enum':
+                entry['options'] = sorted(info['options'])
+            out[name] = entry
+        final[kind] = out
+    return final
+
+
+def main():
+    paths = glob.glob(os.path.join('examples', 'Audio Effects', '**', '*.json'), recursive=True)
+    schemas = build_schemas(paths)
+    os.makedirs(SCHEMA_DIR, exist_ok=True)
+    for kind, schema in schemas.items():
+        out_path = os.path.join(SCHEMA_DIR, f'{kind}_schema.json')
+        with open(out_path, 'w') as f:
+            json.dump(schema, f, indent=2)
+        print(f'Generated {kind} schema with {len(schema)} parameters')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a script to generate audio FX schemas
- generate JSON schemas for each included effect type
- extend file browser filters to recognise FX presets
- implement FX chain utilities and handler class
- create FX chain editing page and route
- provide basic tests for the new route

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594f1ae0448325993fe9ac17f5fbd6