### PR TITLE
Add FX chain browser

### DIFF
--- a/core/file_browser.py
+++ b/core/file_browser.py
@@ -75,6 +75,25 @@ def _has_kind(data: Union[dict, list], kind: str) -> bool:
     return False
 
 
+def _check_audio_fx(file_path: str) -> bool:
+    """Return True if ``file_path`` is an audio effect or rack preset."""
+    kinds = [
+        "autoFilter",
+        "channelEq",
+        "chorus",
+        "delay",
+        "phaser",
+        "redux2",
+        "reverb",
+        "saturator",
+        "audioEffectRack",
+    ]
+    for k in kinds:
+        if _check_json_file(file_path, k):
+            return True
+    return False
+
+
 FILTERS: dict[str, Callable[[str], bool]] = {
     "wav": lambda p: p.lower().endswith(".wav"),
     "drift": lambda p: (
@@ -97,6 +116,11 @@ FILTERS: dict[str, Callable[[str], bool]] = {
         or p.lower().endswith(".json")
     )
     and _check_json_file(p, "melodicSampler"),
+    "audiofx": lambda p: (
+        p.lower().endswith(".ablpreset")
+        or p.lower().endswith(".json")
+    )
+    and _check_audio_fx(p),
 }
 
 

--- a/core/fx_browser_handler.py
+++ b/core/fx_browser_handler.py
@@ -1,0 +1,59 @@
+import os
+import json
+from typing import Any, Dict, List
+
+SCHEMA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'static', 'schemas')
+AUDIO_EFFECTS_SCHEMA_PATH = os.path.join(SCHEMA_DIR, 'audio_effects_schemas.json')
+FX_CHAIN_SCHEMA_PATH = os.path.join(SCHEMA_DIR, 'fx_chain_schema.json')
+
+
+def load_audio_effects_schema() -> Dict[str, Any]:
+    """Load metadata for audio effects."""
+    try:
+        with open(AUDIO_EFFECTS_SCHEMA_PATH, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def load_fx_chain_schema() -> Dict[str, Any]:
+    """Load the default FX chain schema."""
+    try:
+        with open(FX_CHAIN_SCHEMA_PATH, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+IGNORED_PARAMS = {'lockId', 'lockSeal'}
+
+
+def _parse_device(device: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a simplified dict with parameters and child devices."""
+    kind = device.get('kind', 'unknown')
+    params: Dict[str, Any] = {}
+    for key, val in device.get('parameters', {}).items():
+        if key in IGNORED_PARAMS:
+            continue
+        if isinstance(val, dict) and 'value' in val:
+            params[key] = val['value']
+        else:
+            params[key] = val
+    children: List[Dict[str, Any]] = []
+    for chain in device.get('chains', []):
+        for dev in chain.get('devices', []):
+            children.append(_parse_device(dev))
+    for dev in device.get('devices', []):
+        children.append(_parse_device(dev))
+    return {'kind': kind, 'parameters': params, 'children': children}
+
+
+def extract_fx_parameters(preset_path: str) -> Dict[str, Any]:
+    """Load an audio effect or chain preset and return parameter info."""
+    try:
+        with open(preset_path, 'r') as f:
+            data = json.load(f)
+        device = _parse_device(data)
+        return {'success': True, 'device': device, 'message': 'Parsed preset'}
+    except Exception as exc:
+        return {'success': False, 'message': f'Error reading preset: {exc}'}

--- a/handlers/fx_browser_handler_class.py
+++ b/handlers/fx_browser_handler_class.py
@@ -1,0 +1,98 @@
+import os
+import json
+from handlers.base_handler import BaseHandler
+from core.file_browser import generate_dir_html
+from core.fx_browser_handler import extract_fx_parameters
+
+# Base directory for factory presets (read-only)
+CORE_LIBRARY_DIR = "/data/CoreLibrary/Audio Effects"
+
+class FxBrowserHandler(BaseHandler):
+    """Handler for browsing audio effect presets and chains."""
+
+    def handle_get(self):
+        base_dir = "/data/UserData/UserLibrary/Audio Effects"
+        if not os.path.exists(base_dir) and os.path.exists("examples/Audio Effects"):
+            base_dir = "examples/Audio Effects"
+        browser_html = generate_dir_html(
+            base_dir,
+            "",
+            "/fx-browser",
+            "preset_select",
+            "select_preset",
+            filter_key="audiofx",
+        )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith("</ul>"):
+            browser_html = browser_html[:-5] + core_li + "</ul>"
+        return {
+            "message": "Select an effect preset or chain",
+            "message_type": "info",
+            "file_browser_html": browser_html,
+            "params_html": "",
+            "selected_preset": None,
+            "browser_root": base_dir,
+            "browser_filter": "audiofx",
+        }
+
+    def handle_post(self, form):
+        action = form.getvalue("action")
+        if action == "reset_preset":
+            return self.handle_get()
+        valid, err = self.validate_action(form, "select_preset")
+        if not valid:
+            return err
+        preset_path = form.getvalue("preset_select")
+        if not preset_path:
+            return self.format_error_response("No preset selected")
+        try:
+            result = extract_fx_parameters(preset_path)
+            if not result["success"]:
+                return self.format_error_response(result["message"])
+            params_html = self.generate_params_html(result["device"])
+            base_dir = "/data/UserData/UserLibrary/Audio Effects"
+            if not os.path.exists(base_dir) and os.path.exists("examples/Audio Effects"):
+                base_dir = "examples/Audio Effects"
+            browser_html = generate_dir_html(
+                base_dir,
+                "",
+                "/fx-browser",
+                "preset_select",
+                "select_preset",
+                filter_key="audiofx",
+            )
+            core_li = (
+                '<li class="dir closed" data-path="Core Library">'
+                '<span>📁 Core Library</span>'
+                '<ul class="hidden"></ul></li>'
+            )
+            if browser_html.endswith("</ul>"):
+                browser_html = browser_html[:-5] + core_li + "</ul>"
+            return {
+                "message": result["message"],
+                "message_type": "success",
+                "file_browser_html": browser_html,
+                "params_html": params_html,
+                "selected_preset": preset_path,
+                "browser_root": base_dir,
+                "browser_filter": "audiofx",
+            }
+        except Exception as exc:
+            return self.format_error_response(f"Error processing preset: {exc}")
+
+    def generate_params_html(self, device, depth=0):
+        indent = depth * 20
+        html = f'<div class="fx-device" style="margin-left:{indent}px">'
+        html += f'<h4>{device.get("kind", "device")}</h4>'
+        html += '<ul>'
+        for name, val in device.get("parameters", {}).items():
+            html += f'<li>{name}: {val}</li>'
+        html += '</ul>'
+        for child in device.get("children", []):
+            html += self.generate_params_html(child, depth + 1)
+        html += '</div>'
+        return html

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -17,6 +17,7 @@
         <!-- <a href="{{ host_prefix }}/filter-viz" class="{% if active_tab == 'filter-viz' %}active{% endif %}">Filter Viz</a> -->
         <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a>
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
+        <a href="{{ host_prefix }}/fx-browser" class="{% if active_tab == 'fx-browser' %}active{% endif %}">FX Browser</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>

--- a/templates_jinja/fx_browser.html
+++ b/templates_jinja/fx_browser.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>FX Browser</h2>
+<p><em>Browse audio effects and chains. Selecting a preset shows its parameters.</em></p>
+{% if message %}
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+{% if not selected_preset %}
+<div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/fx-browser" data-field="preset_select" data-value="select_preset" data-filter="audiofx">
+    {{ file_browser_html | safe }}
+</div>
+{% else %}
+<form method="post" action="{{ host_prefix }}/fx-browser" style="margin-bottom:1em;">
+  <input type="hidden" name="action" value="reset_preset">
+  <button type="submit">Choose Another Preset</button>
+</form>
+<div class="fx-params">
+  {{ params_html | safe }}
+</div>
+{% endif %}
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `fx_browser_handler.py` to parse audio effect parameters
- extend file browser filters with `audiofx`
- add Flask handler and route `/fx-browser`
- include navigation link and template
- support audio effect core library in `/browse-dir`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685960cd2fc083259c5d4fb4eca5b6a4