### PR TITLE
Add FX chain macro editor

### DIFF
--- a/core/fx_chain_handler.py
+++ b/core/fx_chain_handler.py
@@ -1,0 +1,114 @@
+import json
+import logging
+from typing import Any, Dict, List
+
+from .fx_browser_handler import load_fx_chain_schema
+from .synth_preset_inspector_handler import (
+    update_preset_macro_names,
+    update_preset_parameter_mappings,
+)
+from .synth_param_editor_handler import update_macro_values
+
+logger = logging.getLogger(__name__)
+
+IGNORED_PARAMS = {"lockId", "lockSeal"}
+
+
+def build_fx_chain_from_preset(preset_path: str) -> Dict[str, Any]:
+    """Return an FX chain preset from ``preset_path``.
+
+    If the preset is a single effect, wrap it in the default FX chain schema.
+    """
+    with open(preset_path, "r") as f:
+        data = json.load(f)
+
+    if data.get("kind") == "audioEffectRack":
+        return data
+
+    chain = load_fx_chain_schema()
+    if chain.get("chains"):
+        chain["chains"][0]["devices"] = [data]
+    return chain
+
+
+def extract_fx_parameters(preset_path: str) -> Dict[str, Any]:
+    """Return parameter names, values and paths from an effect or chain."""
+    try:
+        with open(preset_path, "r") as f:
+            data = json.load(f)
+
+        params: List[Dict[str, Any]] = []
+        paths: Dict[str, str] = {}
+
+        def walk(obj: Any, path: str = ""):
+            if isinstance(obj, dict):
+                if path.endswith("parameters"):
+                    for key, val in obj.items():
+                        if key in IGNORED_PARAMS or key.startswith("Macro"):
+                            continue
+                        value = val.get("value") if isinstance(val, dict) else val
+                        params.append({"name": key, "value": value})
+                        paths.setdefault(key, f"{path}.{key}")
+                for k, v in obj.items():
+                    walk(v, f"{path}.{k}" if path else k)
+            elif isinstance(obj, list):
+                for i, item in enumerate(obj):
+                    walk(item, f"{path}[{i}]")
+
+        walk(data)
+
+        return {
+            "success": True,
+            "parameters": params,
+            "parameter_paths": paths,
+            "message": f"Found {len(params)} parameters",
+        }
+    except Exception as exc:
+        logger.error("Error extracting FX parameters: %s", exc)
+        return {"success": False, "message": f"Error: {exc}", "parameters": []}
+
+
+def save_fx_chain_with_macros(
+    source_preset: str,
+    macros: List[Dict[str, Any]],
+    dest_path: str,
+) -> Dict[str, Any]:
+    """Create an FX chain from ``source_preset`` with macro assignments."""
+    try:
+        chain = build_fx_chain_from_preset(source_preset)
+        with open(dest_path, "w") as f:
+            json.dump(chain, f, indent=2)
+            f.write("\n")
+
+        name_updates: Dict[int, str] = {}
+        value_updates: Dict[int, str] = {}
+        for m in macros:
+            idx = int(m.get("index", 0))
+            if "name" in m:
+                name_updates[idx] = m.get("name", "")
+            if "value" in m:
+                value_updates[idx] = str(m["value"])
+            for p in m.get("parameters", []):
+                upd = {
+                    idx: {
+                        "parameter_path": p.get("path"),
+                        "rangeMin": p.get("rangeMin"),
+                        "rangeMax": p.get("rangeMax"),
+                    }
+                }
+                res = update_preset_parameter_mappings(dest_path, upd)
+                if not res["success"]:
+                    return res
+
+        if name_updates:
+            res = update_preset_macro_names(dest_path, name_updates)
+            if not res["success"]:
+                return res
+        if value_updates:
+            res = update_macro_values(dest_path, value_updates, dest_path)
+            if not res["success"]:
+                return res
+        return {"success": True, "path": dest_path, "message": "Saved FX chain"}
+    except Exception as exc:
+        logger.error("Failed to save FX chain: %s", exc)
+        return {"success": False, "message": f"Error saving chain: {exc}"}

--- a/handlers/fx_chain_editor_handler_class.py
+++ b/handlers/fx_chain_editor_handler_class.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+import os
+import json
+
+from handlers.base_handler import BaseHandler
+from core.file_browser import generate_dir_html
+from core.fx_chain_handler import (
+    extract_fx_parameters,
+    save_fx_chain_with_macros,
+)
+from core.synth_preset_inspector_handler import extract_macro_information
+from core.refresh_handler import refresh_library
+
+CORE_LIBRARY_DIR = "/data/CoreLibrary/Audio Effects"
+USER_LIBRARY_DIR = "/data/UserData/UserLibrary/Audio Effects"
+if not os.path.exists(USER_LIBRARY_DIR) and os.path.exists("examples/Audio Effects"):
+    USER_LIBRARY_DIR = "examples/Audio Effects"
+
+
+class FxChainEditorHandler(BaseHandler):
+    def handle_get(self):
+        browser_html = generate_dir_html(
+            USER_LIBRARY_DIR,
+            "",
+            "/fx-chain",
+            "preset_select",
+            "select_preset",
+            filter_key="audiofx",
+        )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith("</ul>"):
+            browser_html = browser_html[:-5] + core_li + "</ul>"
+        return {
+            "message": "Select an effect preset or chain",
+            "message_type": "info",
+            "file_browser_html": browser_html,
+            "params_html": "",
+            "selected_preset": None,
+            "browser_root": USER_LIBRARY_DIR,
+            "browser_filter": "audiofx",
+            "macro_knobs_html": "",
+            "macros_json": "[]",
+            "available_params_json": "[]",
+            "param_paths_json": "{}",
+            "new_preset_name": "",
+        }
+
+    def handle_post(self, form):
+        action = form.getvalue("action")
+        if action == "reset_preset":
+            return self.handle_get()
+
+        preset_path = form.getvalue("preset_select")
+        if not preset_path:
+            return self.format_error_response("No preset selected")
+
+        message = ""
+        if action == "save_chain":
+            macros_data_str = form.getvalue("macros_data") or "[]"
+            try:
+                macros = json.loads(macros_data_str)
+            except Exception:
+                macros = []
+            new_name = form.getvalue("new_preset_name")
+            if not new_name:
+                new_name = os.path.basename(preset_path)
+            if not new_name.endswith(".ablpreset") and not new_name.endswith(".json"):
+                new_name += ".ablpreset"
+            output_path = os.path.join(USER_LIBRARY_DIR, new_name)
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            result = save_fx_chain_with_macros(preset_path, macros, output_path)
+            if not result["success"]:
+                return self.format_error_response(result["message"])
+            refresh_success, refresh_message = refresh_library()
+            message = result["message"]
+            if refresh_success:
+                message += " Library refreshed."
+            else:
+                message += f" Library refresh failed: {refresh_message}"
+            preset_path = output_path
+        elif action == "select_preset":
+            message = f"Selected preset: {os.path.basename(preset_path)}"
+        else:
+            return self.format_error_response("Unknown action")
+
+        param_info = extract_fx_parameters(preset_path)
+        params_html = ""
+        available_params_json = "[]"
+        param_paths_json = "{}"
+        if param_info["success"]:
+            mapped_info = {}
+            macro_info = extract_macro_information(preset_path)
+            if macro_info["success"]:
+                mapped_info = macro_info.get("mapped_parameters", {})
+                macro_knobs_html = self.generate_macro_knobs_html(macro_info["macros"])
+                macros_json = json.dumps(macro_info["macros"])
+            else:
+                macro_knobs_html = ""
+                macros_json = "[]"
+            params_html = self.generate_params_html(param_info["parameters"], mapped_info)
+            available_params_json = json.dumps([p["name"] for p in param_info["parameters"]])
+            param_paths_json = json.dumps(param_info.get("parameter_paths", {}))
+        else:
+            macro_info = extract_macro_information(preset_path)
+            macro_knobs_html = self.generate_macro_knobs_html(macro_info.get("macros", []))
+            macros_json = json.dumps(macro_info.get("macros", []))
+
+        browser_html = generate_dir_html(
+            USER_LIBRARY_DIR,
+            "",
+            "/fx-chain",
+            "preset_select",
+            "select_preset",
+            filter_key="audiofx",
+        )
+        core_li = (
+            '<li class="dir closed" data-path="Core Library">'
+            '<span>📁 Core Library</span>'
+            '<ul class="hidden"></ul></li>'
+        )
+        if browser_html.endswith("</ul>"):
+            browser_html = browser_html[:-5] + core_li + "</ul>"
+        return {
+            "message": message,
+            "message_type": "success",
+            "file_browser_html": browser_html,
+            "params_html": params_html,
+            "selected_preset": preset_path,
+            "browser_root": USER_LIBRARY_DIR,
+            "browser_filter": "audiofx",
+            "macro_knobs_html": macro_knobs_html,
+            "macros_json": macros_json,
+            "available_params_json": available_params_json,
+            "param_paths_json": param_paths_json,
+            "new_preset_name": os.path.basename(preset_path),
+        }
+
+    def generate_params_html(self, params, mapped):
+        html = []
+        for p in params:
+            name = p.get("name")
+            value = p.get("value")
+            cls = "param-item"
+            if name in mapped:
+                cls += f" param-mapped macro-{mapped[name]['macro_index']}"
+            html.append(f'<div class="{cls}" data-name="{name}">{name}: {value}</div>')
+        return "".join(html)
+
+    def generate_macro_knobs_html(self, macros):
+        if not macros:
+            macros = []
+        by_index = {m["index"]: m for m in macros}
+        html = ['<div class="macro-knob-row">']
+        for i in range(8):
+            info = by_index.get(i, {"name": f"Macro {i}", "value": 0.0})
+            name = info.get("name", f"Macro {i}")
+            label_class = ""
+            if not name or name == f"Macro {i}":
+                params = info.get("parameters") or []
+                if len(params) == 1:
+                    pname = params[0].get("name", f"Knob {i + 1}")
+                    name = pname
+                    label_class = " placeholder"
+                else:
+                    name = f"Knob {i + 1}"
+            val = info.get("value", 0.0)
+            try:
+                val = float(val)
+            except Exception:
+                val = 0.0
+            display_val = round(val, 1)
+            classes = ["macro-knob"]
+            if info.get("parameters"):
+                classes.append(f"macro-{i}")
+            cls_str = " ".join(classes)
+            html.append(
+                f'<div class="{cls_str}" data-index="{i}">'
+                f'<span class="macro-label{label_class}" data-index="{i}">{name}</span>'
+                f'<input id="macro_{i}_dial" type="range" class="macro-dial input-knob" '
+                f'data-target="macro_{i}_value" data-display="macro_{i}_disp" '
+                f'value="{display_val}" min="0" max="127" step="0.1" data-decimals="1">'
+                f'<span id="macro_{i}_disp" class="macro-number"></span>'
+                f'<input type="hidden" name="macro_{i}_value" value="{display_val}">' 
+                f'</div>'
+            )
+        html.append('</div>')
+        return ''.join(html)

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -48,6 +48,7 @@ from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
 from handlers.fx_browser_handler_class import FxBrowserHandler
+from handlers.fx_chain_editor_handler_class import FxChainEditorHandler
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -139,6 +140,7 @@ cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
 set_inspector_handler = SetInspectorHandler()
 fx_browser_handler = FxBrowserHandler()
+fx_chain_handler = FxChainEditorHandler()
 
 
 @app.before_request
@@ -802,6 +804,52 @@ def fx_browser():
         preset_selected=preset_selected,
         selected_preset=selected_preset,
         active_tab="fx-browser",
+    )
+
+
+@app.route("/fx-chain", methods=["GET", "POST"])
+def fx_chain():
+    if request.method == "POST":
+        form = SimpleForm(request.form.to_dict())
+        result = fx_chain_handler.handle_post(form)
+    else:
+        if "preset" in request.args:
+            form = SimpleForm({"action": "select_preset", "preset_select": request.args.get("preset")})
+            result = fx_chain_handler.handle_post(form)
+        else:
+            result = fx_chain_handler.handle_get()
+
+    message = result.get("message")
+    message_type = result.get("message_type")
+    success = message_type != "error" if message_type else False
+    browser_html = result.get("file_browser_html")
+    browser_root = result.get("browser_root")
+    browser_filter = result.get("browser_filter")
+    params_html = result.get("params_html", "")
+    selected_preset = result.get("selected_preset")
+    preset_selected = bool(selected_preset)
+    new_preset_name = result.get("new_preset_name", "")
+    macro_knobs_html = result.get("macro_knobs_html", "")
+    macros_json = result.get("macros_json", "[]")
+    available_params_json = result.get("available_params_json", "[]")
+    param_paths_json = result.get("param_paths_json", "{}")
+    return render_template(
+        "fx_chain_editor.html",
+        message=message,
+        success=success,
+        message_type=message_type,
+        file_browser_html=browser_html,
+        browser_root=browser_root,
+        browser_filter=browser_filter,
+        params_html=params_html,
+        preset_selected=preset_selected,
+        selected_preset=selected_preset,
+        macro_knobs_html=macro_knobs_html,
+        macros_json=macros_json,
+        available_params_json=available_params_json,
+        param_paths_json=param_paths_json,
+        new_preset_name=new_preset_name,
+        active_tab="fx-chain",
     )
 
 

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -18,6 +18,7 @@
         <a href="{{ host_prefix }}/wavetable-params" class="{% if active_tab == 'wavetable-params' %}active{% endif %}">Wavetable</a>
         <a href="{{ host_prefix }}/melodic-sampler" class="{% if active_tab == 'melodic-sampler' %}active{% endif %}">Melodic Sampler</a>
         <a href="{{ host_prefix }}/fx-browser" class="{% if active_tab == 'fx-browser' %}active{% endif %}">FX Browser</a>
+        <a href="{{ host_prefix }}/fx-chain" class="{% if active_tab == 'fx-chain' %}active{% endif %}">FX Chain</a>
         <a href="{{ host_prefix }}/reverse" class="{% if active_tab == 'reverse' %}active{% endif %}">Reverse</a>
         <a href="{{ host_prefix }}/set-inspector" class="{% if active_tab == 'set-inspector' %}active{% endif %}">Set Inspector</a>
         <!-- <a href="{{ host_prefix }}/cyc-env" class="{% if active_tab == 'cyc-env' %}active{% endif %}">Cyc Env</a>

--- a/templates_jinja/fx_chain_editor.html
+++ b/templates_jinja/fx_chain_editor.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>FX Chain Builder</h2>
+<p><em>Select an effect or chain preset and assign macro knobs.</em></p>
+{% if message %}
+  <p class="{{ message_type if message_type else ('success' if success else 'error') }}">{{ message }}</p>
+{% endif %}
+{% if not preset_selected %}
+<div class="file-browser" data-root="{{ browser_root }}" data-action="{{ host_prefix }}/fx-chain" data-field="preset_select" data-value="select_preset" data-filter="audiofx">
+    {{ file_browser_html | safe }}
+</div>
+{% else %}
+<form method="post" action="{{ host_prefix }}/fx-chain" id="fx-chain-form">
+  <input type="hidden" name="action" id="action-input" value="save_chain">
+  <input type="hidden" name="preset_select" value="{{ selected_preset }}">
+  <label>File Name: <input type="text" name="new_preset_name" id="new-preset-name" value="{{ new_preset_name }}"></label>
+  <div class="macro-knobs-section">
+      <h3>Macros</h3>
+      {{ macro_knobs_html | safe }}
+  </div>
+  <input type="hidden" name="macros_data" id="macros-data-input" value='{{ macros_json }}'>
+  <input type="hidden" id="available-params-input" value='{{ available_params_json }}'>
+  <input type="hidden" id="param-paths-input" value='{{ param_paths_json }}'>
+  <div id="macro-sidebar" class="macro-sidebar hidden">
+      <h3 id="macro-sidebar-title"></h3>
+      <label>Custom Name: <input type="text" id="macro-name-input" placeholder="No name specified"></label>
+      <div class="macro-assigned-list"></div>
+      <div class="macro-add-section">
+          <button type="button" id="macro-add-param">Add</button>
+      </div>
+      <button type="button" id="macro-sidebar-close">Close</button>
+  </div>
+  <div id="sidebar-overlay" class="sidebar-overlay hidden"></div>
+  <div class="param-list">
+      {{ params_html | safe }}
+  </div>
+  <div class="preset-actions">
+      <button type="submit" id="save-chain-btn">Save Chain</button>
+      <button type="submit" onclick="document.getElementById('action-input').value='reset_preset';">Choose Another</button>
+  </div>
+</form>
+{% endif %}
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ host_prefix }}/static/file_browser.js"></script>
+<script src="{{ host_prefix }}/static/macro_sidebar.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `fx_chain_handler` core logic for building FX chains and assigning macros
- create `FxChainEditorHandler` to edit FX chains in the web UI
- add new template for editing FX chains
- wire up new route `/fx-chain` and navigation link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597abf146c832587e2f8a23184fd5e