### PR TITLE
Add FX chain macro test preset generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Come talk to us on [Discord](https://discord.gg/yP7SjqDrZG).
 - Clone or download the repository.
 - Run utility-scripts/setup-ssh-and-install-on-move.command
 - Follow the instructions!
+- Optional: run `utility-scripts/generate_fx_macro_presets.py` to create
+  macro test presets for all included audio effects.
   
 ## Features
 

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 001 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 001 - DryWet.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 002 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 002 - Enabled.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 003 - Envelope_Amount.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 003 - Envelope_Amount.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Envelope_Amount"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 004 - Envelope_Attack.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 004 - Envelope_Attack.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Envelope_Attack"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": {
+              "value": 0.0010000000474974513,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 005 - Envelope_HoldOn.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 005 - Envelope_HoldOn.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Envelope_HoldOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 006 - Envelope_Release.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 006 - Envelope_Release.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Envelope_Release"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": {
+              "value": 0.25,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 007 - Envelope_SahOn.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 007 - Envelope_SahOn.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Envelope_SahOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 008 - Envelope_SahRate.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 008 - Envelope_SahRate.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Envelope_SahRate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": {
+              "value": -4,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 009 - Filter_Circuit.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 009 - Filter_Circuit.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Circuit"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": {
+              "value": "SVF",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 010 - Filter_DjControl.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 010 - Filter_DjControl.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_DjControl"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 011 - Filter_Drive.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 011 - Filter_Drive.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Drive"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 012 - Filter_Frequency.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 012 - Filter_Frequency.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Frequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": {
+              "value": 9999.998046875,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 013 - Filter_Morph.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 013 - Filter_Morph.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Morph"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 014 - Filter_MorphSlope.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 014 - Filter_MorphSlope.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_MorphSlope"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": {
+              "value": "24dB",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 015 - Filter_Resonance.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 015 - Filter_Resonance.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Resonance"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 016 - Filter_Slope.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 016 - Filter_Slope.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Slope"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": {
+              "value": "24dB",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 017 - Filter_Type.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 017 - Filter_Type.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Type"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": {
+              "value": "Low-pass",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 018 - Filter_VowelFormant.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 018 - Filter_VowelFormant.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_VowelFormant"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 019 - Filter_VowelPitch.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 019 - Filter_VowelPitch.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_VowelPitch"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": {
+              "value": 0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 020 - HiQuality.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 020 - HiQuality.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HiQuality"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 021 - HostVisualisationRate.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 021 - HostVisualisationRate.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HostVisualisationRate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": {
+              "value": 0.019999999552965164,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 022 - InternalSideChainGain.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 022 - InternalSideChainGain.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "InternalSideChainGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 023 - Lfo_Amount.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 023 - Lfo_Amount.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Amount"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 024 - Lfo_Frequency.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 024 - Lfo_Frequency.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Frequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 025 - Lfo_Morph.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 025 - Lfo_Morph.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Morph"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 026 - Lfo_Phase.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 026 - Lfo_Phase.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Phase"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 027 - Lfo_PhaseOffset.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 027 - Lfo_PhaseOffset.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_PhaseOffset"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 028 - Lfo_QuantizationMode.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 028 - Lfo_QuantizationMode.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_QuantizationMode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": {
+              "value": "None",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 029 - Lfo_SahRate.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 029 - Lfo_SahRate.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_SahRate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": {
+              "value": -4,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 030 - Lfo_Sixteenth.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 030 - Lfo_Sixteenth.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Sixteenth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": {
+              "value": 16,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 031 - Lfo_Smoothing.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 031 - Lfo_Smoothing.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Smoothing"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 032 - Lfo_Spin.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 032 - Lfo_Spin.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Spin"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 033 - Lfo_Steps.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 033 - Lfo_Steps.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Steps"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": {
+              "value": 8,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 034 - Lfo_StereoMode.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 034 - Lfo_StereoMode.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_StereoMode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": {
+              "value": "Phase",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 035 - Lfo_SyncedRate.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 035 - Lfo_SyncedRate.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_SyncedRate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": {
+              "value": 4,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 036 - Lfo_Time.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 036 - Lfo_Time.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Time"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": {
+              "value": 1.0000001192092896,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 037 - Lfo_TimeMode.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 037 - Lfo_TimeMode.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_TimeMode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": {
+              "value": "Rate",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 038 - Lfo_Waveform.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 038 - Lfo_Waveform.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Lfo_Waveform"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": {
+              "value": "Sine",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 039 - Output.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 039 - Output.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Output"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 040 - SideChainEq_Freq.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 040 - SideChainEq_Freq.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainEq_Freq"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": {
+              "value": 199.99998474121094,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 041 - SideChainEq_Gain.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 041 - SideChainEq_Gain.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainEq_Gain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 042 - SideChainEq_Mode.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 042 - SideChainEq_Mode.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainEq_Mode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": {
+              "value": "High pass",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 043 - SideChainEq_On.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 043 - SideChainEq_On.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainEq_On"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 044 - SideChainEq_Q.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 044 - SideChainEq_Q.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainEq_Q"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": {
+              "value": 0.7071067094802856,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 045 - SideChainListen.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 045 - SideChainListen.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainListen"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainMono": true,
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 046 - SideChainMono.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 046 - SideChainMono.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SideChainMono"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SoftClipOn": false
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Auto Filter/Auto Filter - 047 - SoftClipOn.ablpreset
+++ b/examples/FX Macro Presets/Auto Filter/Auto Filter - 047 - SoftClipOn.ablpreset
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SoftClipOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "autoFilter",
+          "name": "Default Filter",
+          "parameters": {
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Envelope_Amount": 0.0,
+            "Envelope_Attack": 0.0010000000474974513,
+            "Envelope_HoldOn": true,
+            "Envelope_Release": 0.25,
+            "Envelope_SahOn": false,
+            "Envelope_SahRate": -4,
+            "Filter_Circuit": "SVF",
+            "Filter_DjControl": 0.0,
+            "Filter_Drive": 0.0,
+            "Filter_Frequency": 9999.998046875,
+            "Filter_Morph": 0.0,
+            "Filter_MorphSlope": "24dB",
+            "Filter_Resonance": 0.0,
+            "Filter_Slope": "24dB",
+            "Filter_Type": "Low-pass",
+            "Filter_VowelFormant": 0.0,
+            "Filter_VowelPitch": 0,
+            "HiQuality": false,
+            "HostVisualisationRate": 0.019999999552965164,
+            "InternalSideChainGain": 1.0,
+            "Lfo_Amount": 0.0,
+            "Lfo_Frequency": 1.0,
+            "Lfo_Morph": 0.0,
+            "Lfo_Phase": 0.0,
+            "Lfo_PhaseOffset": 0.0,
+            "Lfo_QuantizationMode": "None",
+            "Lfo_SahRate": -4,
+            "Lfo_Sixteenth": 16,
+            "Lfo_Smoothing": 0.0,
+            "Lfo_Spin": 0.0,
+            "Lfo_Steps": 8,
+            "Lfo_StereoMode": "Phase",
+            "Lfo_SyncedRate": 4,
+            "Lfo_Time": 1.0000001192092896,
+            "Lfo_TimeMode": "Rate",
+            "Lfo_Waveform": "Sine",
+            "Output": 1.0,
+            "SideChainEq_Freq": 199.99998474121094,
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": false,
+            "SideChainEq_Q": 0.7071067094802856,
+            "SideChainListen": false,
+            "SideChainMono": true,
+            "SoftClipOn": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 001 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 001 - Enabled.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Gain": 1.0,
+            "HighShelfGain": 1.0,
+            "HighpassOn": false,
+            "LowShelfGain": 1.0,
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 002 - Gain.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 002 - Gain.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Gain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": true,
+            "Gain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighShelfGain": 1.0,
+            "HighpassOn": false,
+            "LowShelfGain": 1.0,
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 003 - HighShelfGain.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 003 - HighShelfGain.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HighShelfGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": 1.0,
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 004 - HighpassOn.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 004 - HighpassOn.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HighpassOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": 1.0,
+            "HighpassOn": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "LowShelfGain": 1.0,
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 005 - LowShelfGain.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 005 - LowShelfGain.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "LowShelfGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": 1.0,
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 006 - MidFrequency.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 006 - MidFrequency.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "MidFrequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": 1.0,
+            "HighpassOn": false,
+            "LowShelfGain": 1.0,
+            "MidFrequency": {
+              "value": 1500.0001220703125,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MidGain": 1.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Channel EQ/Channel EQ - 007 - MidGain.ablpreset
+++ b/examples/FX Macro Presets/Channel EQ/Channel EQ - 007 - MidGain.ablpreset
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "MidGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "channelEq",
+          "name": "Default EQ",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": 1.0,
+            "HighpassOn": false,
+            "LowShelfGain": 1.0,
+            "MidFrequency": 1500.0001220703125,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 001 - Amount.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 001 - Amount.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Amount"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": {
+              "value": 0.4047619104385376,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 002 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 002 - DryWet.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": {
+              "value": 0.7460317611694336,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 003 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 003 - Enabled.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 004 - Feedback.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 004 - Feedback.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Feedback"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": {
+              "value": 0.22785714268684387,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 005 - HighpassEnabled.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 005 - HighpassEnabled.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HighpassEnabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 006 - HighpassFrequency.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 006 - HighpassFrequency.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HighpassFrequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": {
+              "value": 20.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 007 - InvertFeedback.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 007 - InvertFeedback.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "InvertFeedback"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 008 - Mode.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 008 - Mode.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Mode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": {
+              "value": "Classic",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 009 - OutputGain.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 009 - OutputGain.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "OutputGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": {
+              "value": 1.259763240814209,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 010 - Rate.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 010 - Rate.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Rate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": {
+              "value": 0.5483837127685547,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 011 - Shaping.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 011 - Shaping.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Shaping"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 012 - VibratoOffset.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 012 - VibratoOffset.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "VibratoOffset"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Warmth": 0.011545630171895027,
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 013 - Warmth.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 013 - Warmth.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Warmth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": {
+              "value": 0.011545630171895027,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Width": 0.859375
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 014 - Width.ablpreset
+++ b/examples/FX Macro Presets/Chorus-Ensemble/Chorus-Ensemble - 014 - Width.ablpreset
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Width"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "chorus",
+          "name": "Chorus Subtle Funk",
+          "parameters": {
+            "Amount": 0.4047619104385376,
+            "DryWet": 0.7460317611694336,
+            "Enabled": true,
+            "Feedback": 0.22785714268684387,
+            "HighpassEnabled": true,
+            "HighpassFrequency": 20.0,
+            "InvertFeedback": false,
+            "Mode": "Classic",
+            "OutputGain": 1.259763240814209,
+            "Rate": 0.5483837127685547,
+            "Shaping": 0.0,
+            "VibratoOffset": 0.0,
+            "Warmth": 0.011545630171895027,
+            "Width": {
+              "value": 0.859375,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 001 - DelayLine_CompatibilityMode.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 001 - DelayLine_CompatibilityMode.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_CompatibilityMode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": {
+              "value": "D",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 002 - DelayLine_Link.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 002 - DelayLine_Link.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_Link"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 003 - DelayLine_OffsetL.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 003 - DelayLine_OffsetL.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_OffsetL"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 004 - DelayLine_OffsetR.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 004 - DelayLine_OffsetR.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_OffsetR"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 005 - DelayLine_PingPong.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 005 - DelayLine_PingPong.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_PingPong"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 006 - DelayLine_PingPongDelayTimeL.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 006 - DelayLine_PingPongDelayTimeL.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_PingPongDelayTimeL"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 007 - DelayLine_PingPongDelayTimeR.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 007 - DelayLine_PingPongDelayTimeR.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_PingPongDelayTimeR"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 008 - DelayLine_SimpleDelayTimeL.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 008 - DelayLine_SimpleDelayTimeL.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SimpleDelayTimeL"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": {
+              "value": 100.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 009 - DelayLine_SimpleDelayTimeR.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 009 - DelayLine_SimpleDelayTimeR.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SimpleDelayTimeR"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": {
+              "value": 100.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 010 - DelayLine_SmoothingMode.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 010 - DelayLine_SmoothingMode.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SmoothingMode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": {
+              "value": "Repitch",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 011 - DelayLine_SyncL.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 011 - DelayLine_SyncL.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SyncL"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 012 - DelayLine_SyncR.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 012 - DelayLine_SyncR.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SyncR"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 013 - DelayLine_SyncedSixteenthL.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 013 - DelayLine_SyncedSixteenthL.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SyncedSixteenthL"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": {
+              "value": "4",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 014 - DelayLine_SyncedSixteenthR.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 014 - DelayLine_SyncedSixteenthR.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_SyncedSixteenthR"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": {
+              "value": "4",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 015 - DelayLine_TimeL.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 015 - DelayLine_TimeL.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_TimeL"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": {
+              "value": 0.0012234988389536738,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 016 - DelayLine_TimeR.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 016 - DelayLine_TimeR.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DelayLine_TimeR"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": {
+              "value": 0.0017748335376381874,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 017 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 017 - DryWet.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": {
+              "value": 0.4523809552192688,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 018 - DryWetMode.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 018 - DryWetMode.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWetMode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": {
+              "value": "Equal-loudness",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 019 - EcoProcessing.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 019 - EcoProcessing.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "EcoProcessing"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 020 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 020 - Enabled.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 021 - Feedback.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 021 - Feedback.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Feedback"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": {
+              "value": 0.7690476179122925,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 022 - Filter_Bandwidth.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 022 - Filter_Bandwidth.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Bandwidth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": {
+              "value": 3.590909242630005,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 023 - Filter_Frequency.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 023 - Filter_Frequency.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_Frequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": {
+              "value": 2379.816650390625,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 024 - Filter_On.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 024 - Filter_On.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Filter_On"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 025 - Freeze.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 025 - Freeze.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Freeze"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 026 - Modulation_AmountFilter.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 026 - Modulation_AmountFilter.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_AmountFilter"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": {
+              "value": 0.84375,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 027 - Modulation_AmountTime.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 027 - Modulation_AmountTime.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_AmountTime"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Frequency": 3.1956372261047363
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Delay/Delay - 028 - Modulation_Frequency.ablpreset
+++ b/examples/FX Macro Presets/Delay/Delay - 028 - Modulation_Frequency.ablpreset
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Frequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "delay",
+          "name": "Fast Phase",
+          "parameters": {
+            "DelayLine_CompatibilityMode": "D",
+            "DelayLine_Link": true,
+            "DelayLine_OffsetL": 0.0,
+            "DelayLine_OffsetR": 0.0,
+            "DelayLine_PingPong": true,
+            "DelayLine_PingPongDelayTimeL": 1.0,
+            "DelayLine_PingPongDelayTimeR": 1.0,
+            "DelayLine_SimpleDelayTimeL": 100.0,
+            "DelayLine_SimpleDelayTimeR": 100.0,
+            "DelayLine_SmoothingMode": "Repitch",
+            "DelayLine_SyncL": false,
+            "DelayLine_SyncR": false,
+            "DelayLine_SyncedSixteenthL": "4",
+            "DelayLine_SyncedSixteenthR": "4",
+            "DelayLine_TimeL": 0.0012234988389536738,
+            "DelayLine_TimeR": 0.0017748335376381874,
+            "DryWet": 0.4523809552192688,
+            "DryWetMode": "Equal-loudness",
+            "EcoProcessing": true,
+            "Enabled": true,
+            "Feedback": 0.7690476179122925,
+            "Filter_Bandwidth": 3.590909242630005,
+            "Filter_Frequency": 2379.816650390625,
+            "Filter_On": true,
+            "Freeze": false,
+            "Modulation_AmountFilter": 0.84375,
+            "Modulation_AmountTime": 0.0,
+            "Modulation_Frequency": {
+              "value": 3.1956372261047363,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 001 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 001 - Enabled.ablpreset
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": {
+      "value": true,
+      "macroMapping": {
+        "macroIndex": 0
+      }
+    },
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Enabled"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 002 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 002 - Enabled.ablpreset
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": {
+      "value": true,
+      "macroMapping": {
+        "macroIndex": 0
+      }
+    },
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Enabled"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 003 - Gain.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 003 - Gain.ablpreset
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Gain"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 004 - HighShelfGain.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 004 - HighShelfGain.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "HighShelfGain"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 005 - HighpassOn.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 005 - HighpassOn.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "HighpassOn"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 006 - LowShelfGain.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 006 - LowShelfGain.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "LowShelfGain"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 007 - MidFrequency.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 007 - MidFrequency.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "MidFrequency"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": {
+              "value": 579.9998779296875,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 008 - MidGain.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 008 - MidGain.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "MidGain"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 009 - Attack.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 009 - Attack.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Attack"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": {
+              "value": 5.000001430511475,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 010 - AutoReleaseControlOnOff.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 010 - AutoReleaseControlOnOff.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "AutoReleaseControlOnOff"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 011 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 011 - DryWet.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "DryWet"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 012 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 012 - Enabled.ablpreset
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": {
+      "value": true,
+      "macroMapping": {
+        "macroIndex": 0
+      }
+    },
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Enabled"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 013 - ExpansionRatio.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 013 - ExpansionRatio.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "ExpansionRatio"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": {
+              "value": 1.149999976158142,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 014 - Gain.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 014 - Gain.ablpreset
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Gain"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 015 - GainCompensation.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 015 - GainCompensation.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "GainCompensation"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 016 - Knee.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 016 - Knee.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Knee"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": {
+              "value": 3.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 017 - LogEnvelope.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 017 - LogEnvelope.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "LogEnvelope"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 018 - Model.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 018 - Model.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Model"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": {
+              "value": "RMS",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 019 - Ratio.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 019 - Ratio.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Ratio"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": {
+              "value": 2.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 020 - Release.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 020 - Release.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Release"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 021 - SideChainEq_Freq.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 021 - SideChainEq_Freq.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "SideChainEq_Freq"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 022 - SideChainEq_Gain.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 022 - SideChainEq_Gain.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "SideChainEq_Gain"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 023 - SideChainEq_Mode.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 023 - SideChainEq_Mode.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "SideChainEq_Mode"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": {
+              "value": "High pass",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 024 - SideChainEq_On.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 024 - SideChainEq_On.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "SideChainEq_On"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 025 - SideChainEq_Q.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 025 - SideChainEq_Q.ablpreset
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "SideChainEq_Q"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": {
+              "value": 0.7071067690849304,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 5,
+                "rangeMin": 0.003162277629598975,
+                "rangeMax": 1.0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Dynamics/Dynamics - 026 - Threshold.ablpreset
+++ b/examples/FX Macro Presets/Dynamics/Dynamics - 026 - Threshold.ablpreset
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Gentle",
+  "lockId": 1001,
+  "lockSeal": -100211998,
+  "parameters": {
+    "Enabled": true,
+    "Macro0": {
+      "value": 63.35280227661133,
+      "customName": "Threshold"
+    },
+    "Macro1": 63.5,
+    "Macro2": 63.35280227661133,
+    "Macro3": {
+      "value": 24.60405158996582,
+      "customName": "Comp Hi Pass"
+    },
+    "Macro4": {
+      "value": 37.87466812133789,
+      "customName": "Release"
+    },
+    "Macro5": {
+      "value": 44.9728889465332,
+      "customName": "Threshold"
+    },
+    "Macro6": 3.527777910232544,
+    "Macro7": {
+      "value": 127.0,
+      "customName": "Comp Dry/Wet"
+    }
+  },
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "presetUri": null,
+          "kind": "channelEq",
+          "name": "",
+          "parameters": {
+            "Enabled": true,
+            "Gain": 1.0,
+            "HighShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 2,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "HighpassOn": false,
+            "LowShelfGain": {
+              "value": 0.9999999403953552,
+              "macroMapping": {
+                "macroIndex": 0,
+                "rangeMin": 0.18000000715255737,
+                "rangeMax": 5.599999904632568
+              }
+            },
+            "MidFrequency": 579.9998779296875,
+            "MidGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 1,
+                "rangeMin": 0.25,
+                "rangeMax": 4.0
+              }
+            }
+          },
+          "deviceData": {}
+        },
+        {
+          "presetUri": null,
+          "kind": "compressor",
+          "name": "",
+          "parameters": {
+            "Attack": 5.000001430511475,
+            "AutoReleaseControlOnOff": false,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 0.0,
+                "rangeMax": 1.0
+              }
+            },
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 7,
+                "rangeMin": 1.0,
+                "rangeMax": 127.0
+              }
+            },
+            "ExpansionRatio": 1.149999976158142,
+            "Gain": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 6,
+                "rangeMin": 0.0,
+                "rangeMax": 36.0
+              }
+            },
+            "GainCompensation": false,
+            "Knee": 3.0,
+            "LogEnvelope": true,
+            "Model": "RMS",
+            "Ratio": 2.0,
+            "Release": {
+              "value": 30.0,
+              "macroMapping": {
+                "macroIndex": 4,
+                "rangeMin": 1.0,
+                "rangeMax": 1000.0
+              }
+            },
+            "SideChainEq_Freq": {
+              "value": 80.0,
+              "macroMapping": {
+                "macroIndex": 3,
+                "rangeMin": 30.0,
+                "rangeMax": 15000.0
+              }
+            },
+            "SideChainEq_Gain": 0.0,
+            "SideChainEq_Mode": "High pass",
+            "SideChainEq_On": true,
+            "SideChainEq_Q": 0.7071067690849304,
+            "Threshold": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.0,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 001 - CenterFrequency.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 001 - CenterFrequency.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "CenterFrequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": {
+              "value": 999.9998779296875,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 002 - DoublerDelayTime.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 002 - DoublerDelayTime.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DoublerDelayTime"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": {
+              "value": 0.026972541585564613,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 003 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 003 - DryWet.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": {
+              "value": 0.7063491940498352,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 004 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 004 - Enabled.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 005 - Feedback.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 005 - Feedback.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Feedback"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": {
+              "value": 0.2199999988079071,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 006 - FlangerDelayTime.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 006 - FlangerDelayTime.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "FlangerDelayTime"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": {
+              "value": 0.002500000176951289,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 007 - InvertWet.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 007 - InvertWet.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "InvertWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 008 - Mode.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 008 - Mode.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Mode"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": {
+              "value": "Doubler",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 009 - ModulationBlend.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 009 - ModulationBlend.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ModulationBlend"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 010 - Modulation_Amount.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 010 - Modulation_Amount.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Amount"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": {
+              "value": 0.3888888955116272,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 011 - Modulation_DutyCycle.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 011 - Modulation_DutyCycle.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_DutyCycle"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 012 - Modulation_EnvelopeAmount.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 012 - Modulation_EnvelopeAmount.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_EnvelopeAmount"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 013 - Modulation_EnvelopeAttack.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 013 - Modulation_EnvelopeAttack.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_EnvelopeAttack"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": {
+              "value": 0.006000000052154064,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 014 - Modulation_EnvelopeEnabled.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 014 - Modulation_EnvelopeEnabled.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_EnvelopeEnabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 015 - Modulation_EnvelopeRelease.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 015 - Modulation_EnvelopeRelease.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_EnvelopeRelease"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": {
+              "value": 0.20000000298023224,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 016 - Modulation_Frequency.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 016 - Modulation_Frequency.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Frequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": {
+              "value": 0.6324555277824402,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 017 - Modulation_Frequency2.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 017 - Modulation_Frequency2.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Frequency2"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": {
+              "value": 0.20000000298023224,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 018 - Modulation_LfoBlend.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 018 - Modulation_LfoBlend.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_LfoBlend"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 019 - Modulation_PhaseOffset.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 019 - Modulation_PhaseOffset.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_PhaseOffset"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 020 - Modulation_Spin.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 020 - Modulation_Spin.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Spin"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 021 - Modulation_SpinEnabled.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 021 - Modulation_SpinEnabled.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_SpinEnabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 022 - Modulation_Sync.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 022 - Modulation_Sync.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Sync"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 023 - Modulation_Sync2.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 023 - Modulation_Sync2.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Sync2"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 024 - Modulation_SyncedRate.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 024 - Modulation_SyncedRate.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_SyncedRate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": {
+              "value": 2,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 025 - Modulation_SyncedRate2.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 025 - Modulation_SyncedRate2.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_SyncedRate2"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": {
+              "value": 4,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 026 - Modulation_Waveform.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 026 - Modulation_Waveform.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Modulation_Waveform"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": {
+              "value": "Triangle",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 027 - Notches.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 027 - Notches.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Notches"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": {
+              "value": 4,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 028 - OutputGain.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 028 - OutputGain.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "OutputGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": {
+              "value": 1.5243134498596191,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 029 - SafeBassFrequency.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 029 - SafeBassFrequency.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SafeBassFrequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": {
+              "value": 99.99999237060547,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Spread": 0.5,
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 030 - Spread.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 030 - Spread.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Spread"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": {
+              "value": 0.5,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Warmth": 0.1349206417798996
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 031 - Warmth.ablpreset
+++ b/examples/FX Macro Presets/Phaser-Flanger/Phaser-Flanger - 031 - Warmth.ablpreset
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Warmth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "phaser",
+          "name": "Doubler Ether",
+          "parameters": {
+            "CenterFrequency": 999.9998779296875,
+            "DoublerDelayTime": 0.026972541585564613,
+            "DryWet": 0.7063491940498352,
+            "Enabled": true,
+            "Feedback": 0.2199999988079071,
+            "FlangerDelayTime": 0.002500000176951289,
+            "InvertWet": false,
+            "Mode": "Doubler",
+            "ModulationBlend": 0.0,
+            "Modulation_Amount": 0.3888888955116272,
+            "Modulation_DutyCycle": 0.0,
+            "Modulation_EnvelopeAmount": 0.0,
+            "Modulation_EnvelopeAttack": 0.006000000052154064,
+            "Modulation_EnvelopeEnabled": true,
+            "Modulation_EnvelopeRelease": 0.20000000298023224,
+            "Modulation_Frequency": 0.6324555277824402,
+            "Modulation_Frequency2": 0.20000000298023224,
+            "Modulation_LfoBlend": 0.0,
+            "Modulation_PhaseOffset": 0.0,
+            "Modulation_Spin": 0.0,
+            "Modulation_SpinEnabled": false,
+            "Modulation_Sync": false,
+            "Modulation_Sync2": true,
+            "Modulation_SyncedRate": 2,
+            "Modulation_SyncedRate2": 4,
+            "Modulation_Waveform": "Triangle",
+            "Notches": 4,
+            "OutputGain": 1.5243134498596191,
+            "SafeBassFrequency": 99.99999237060547,
+            "Spread": 0.5,
+            "Warmth": {
+              "value": 0.1349206417798996,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 001 - BitDepth.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 001 - BitDepth.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BitDepth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": {
+              "value": 16,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 002 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 002 - DryWet.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 003 - EcoProcessing.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 003 - EcoProcessing.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "EcoProcessing"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 004 - EnablePostFilter.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 004 - EnablePostFilter.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "EnablePostFilter"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 005 - EnablePreFilter.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 005 - EnablePreFilter.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "EnablePreFilter"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 006 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 006 - Enabled.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 007 - Jitter.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 007 - Jitter.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Jitter"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 008 - PostFilterValue.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 008 - PostFilterValue.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "PostFilterValue"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 009 - QuantizerDcShift.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 009 - QuantizerDcShift.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "QuantizerDcShift"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "QuantizerShape": 0.0,
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 010 - QuantizerShape.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 010 - QuantizerShape.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "QuantizerShape"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SampleRate": 40000.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Redux/Redux - 011 - SampleRate.ablpreset
+++ b/examples/FX Macro Presets/Redux/Redux - 011 - SampleRate.ablpreset
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SampleRate"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "redux2",
+          "name": "Default Redux",
+          "parameters": {
+            "BitDepth": 16,
+            "DryWet": 1.0,
+            "EcoProcessing": true,
+            "EnablePostFilter": false,
+            "EnablePreFilter": false,
+            "Enabled": true,
+            "Jitter": 0.0,
+            "PostFilterValue": 0.0,
+            "QuantizerDcShift": false,
+            "QuantizerShape": 0.0,
+            "SampleRate": {
+              "value": 40000.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 001 - AllPassGain.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 001 - AllPassGain.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "AllPassGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": {
+              "value": 0.6000000238418579,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 002 - AllPassSize.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 002 - AllPassSize.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "AllPassSize"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": {
+              "value": 0.4000000059604645,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 003 - BandFreq.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 003 - BandFreq.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BandFreq"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": {
+              "value": 830.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 004 - BandHighOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 004 - BandHighOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BandHighOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 005 - BandLowOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 005 - BandLowOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BandLowOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 006 - BandWidth.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 006 - BandWidth.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BandWidth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": {
+              "value": 5.849999904632568,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 007 - ChorusOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 007 - ChorusOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ChorusOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 008 - CutOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 008 - CutOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "CutOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 009 - DecayTime.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 009 - DecayTime.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DecayTime"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": {
+              "value": 1200.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 010 - DiffuseDelay.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 010 - DiffuseDelay.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DiffuseDelay"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": {
+              "value": 0.5,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 011 - EarlyReflectModDepth.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 011 - EarlyReflectModDepth.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "EarlyReflectModDepth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": {
+              "value": 17.5,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 012 - EarlyReflectModFreq.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 012 - EarlyReflectModFreq.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "EarlyReflectModFreq"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": {
+              "value": 0.2976999878883362,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 013 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 013 - Enabled.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 014 - FlatOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 014 - FlatOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "FlatOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 015 - FreezeOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 015 - FreezeOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "FreezeOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 016 - HighFilterType.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 016 - HighFilterType.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "HighFilterType"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": {
+              "value": "Shelf",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 017 - MixDiffuse.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 017 - MixDiffuse.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "MixDiffuse"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 018 - MixDirect.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 018 - MixDirect.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "MixDirect"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": {
+              "value": 0.3499999940395355,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 019 - MixReflect.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 019 - MixReflect.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "MixReflect"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 020 - PreDelay.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 020 - PreDelay.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "PreDelay"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": {
+              "value": 2.5,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 021 - RoomSize.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 021 - RoomSize.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "RoomSize"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": {
+              "value": 100.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 022 - RoomType.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 022 - RoomType.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "RoomType"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": {
+              "value": "SuperEco",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 023 - ShelfHiFreq.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 023 - ShelfHiFreq.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ShelfHiFreq"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": {
+              "value": 4500.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 024 - ShelfHiGain.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 024 - ShelfHiGain.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ShelfHiGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": {
+              "value": 0.699999988079071,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 025 - ShelfHighOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 025 - ShelfHighOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ShelfHighOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 026 - ShelfLoFreq.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 026 - ShelfLoFreq.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ShelfLoFreq"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": {
+              "value": 90.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 027 - ShelfLoGain.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 027 - ShelfLoGain.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ShelfLoGain"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 028 - ShelfLowOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 028 - ShelfLowOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ShelfLowOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 029 - SizeModDepth.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 029 - SizeModDepth.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SizeModDepth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": {
+              "value": 0.019999999552965164,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 030 - SizeModFreq.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 030 - SizeModFreq.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SizeModFreq"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": {
+              "value": 0.019999999552965164,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 031 - SizeSmoothing.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 031 - SizeSmoothing.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SizeSmoothing"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": {
+              "value": "Fast",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "SpinOn": true,
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 032 - SpinOn.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 032 - SpinOn.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "SpinOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "StereoSeparation": 100.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Reverb/Reverb - 033 - StereoSeparation.ablpreset
+++ b/examples/FX Macro Presets/Reverb/Reverb - 033 - StereoSeparation.ablpreset
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "StereoSeparation"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "reverb",
+          "name": "Default Reverb",
+          "parameters": {
+            "AllPassGain": 0.6000000238418579,
+            "AllPassSize": 0.4000000059604645,
+            "BandFreq": 830.0,
+            "BandHighOn": false,
+            "BandLowOn": true,
+            "BandWidth": 5.849999904632568,
+            "ChorusOn": true,
+            "CutOn": true,
+            "DecayTime": 1200.0,
+            "DiffuseDelay": 0.5,
+            "EarlyReflectModDepth": 17.5,
+            "EarlyReflectModFreq": 0.2976999878883362,
+            "Enabled": true,
+            "FlatOn": true,
+            "FreezeOn": false,
+            "HighFilterType": "Shelf",
+            "MixDiffuse": 1.0,
+            "MixDirect": 0.3499999940395355,
+            "MixReflect": 1.0,
+            "PreDelay": 2.5,
+            "RoomSize": 100.0,
+            "RoomType": "SuperEco",
+            "ShelfHiFreq": 4500.0,
+            "ShelfHiGain": 0.699999988079071,
+            "ShelfHighOn": true,
+            "ShelfLoFreq": 90.0,
+            "ShelfLoGain": 1.0,
+            "ShelfLowOn": true,
+            "SizeModDepth": 0.019999999552965164,
+            "SizeModFreq": 0.019999999552965164,
+            "SizeSmoothing": "Fast",
+            "SpinOn": true,
+            "StereoSeparation": {
+              "value": 100.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 001 - BaseDrive.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 001 - BaseDrive.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BaseDrive"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 002 - BassShaperThreshold.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 002 - BassShaperThreshold.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "BassShaperThreshold"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": {
+              "value": -50.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 003 - ColorDepth.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 003 - ColorDepth.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ColorDepth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 004 - ColorFrequency.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 004 - ColorFrequency.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ColorFrequency"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": {
+              "value": 1000.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 005 - ColorOn.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 005 - ColorOn.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ColorOn"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 006 - ColorWidth.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 006 - ColorWidth.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "ColorWidth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": {
+              "value": 0.30000001192092896,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 007 - DryWet.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 007 - DryWet.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "DryWet"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 008 - Enabled.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 008 - Enabled.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Enabled"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": {
+              "value": true,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 009 - Oversampling.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 009 - Oversampling.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Oversampling"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 010 - PostClip.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 010 - PostClip.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "PostClip"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": {
+              "value": "off",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 011 - PostDrive.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 011 - PostDrive.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "PostDrive"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 012 - PreDcFilter.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 012 - PreDcFilter.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "PreDcFilter"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": {
+              "value": false,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 013 - PreDrive.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 013 - PreDrive.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "PreDrive"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 014 - Type.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 014 - Type.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "Type"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": {
+              "value": "Analog Clip",
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 015 - WsCurve.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 015 - WsCurve.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "WsCurve"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": {
+              "value": 0.05000000074505806,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 016 - WsDamp.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 016 - WsDamp.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "WsDamp"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 017 - WsDepth.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 017 - WsDepth.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "WsDepth"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 018 - WsDrive.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 018 - WsDrive.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "WsDrive"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": {
+              "value": 1.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "WsLin": 0.5,
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 019 - WsLin.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 019 - WsLin.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "WsLin"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": {
+              "value": 0.5,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            },
+            "WsPeriod": 0.0
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/examples/FX Macro Presets/Saturator/Saturator - 020 - WsPeriod.ablpreset
+++ b/examples/FX Macro Presets/Saturator/Saturator - 020 - WsPeriod.ablpreset
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+  "kind": "audioEffectRack",
+  "name": "Custom FX Chain",
+  "parameters": {
+    "lockId": 1001,
+    "lockSeal": -100211998,
+    "Macro0": {
+      "value": 0.0,
+      "customName": "WsPeriod"
+    },
+    "Macro1": {
+      "value": 0.0,
+      "customName": "Macro 2"
+    },
+    "Macro2": {
+      "value": 0.0,
+      "customName": "Macro 3"
+    },
+    "Macro3": {
+      "value": 0.0,
+      "customName": "Macro 4"
+    },
+    "Macro4": {
+      "value": 0.0,
+      "customName": "Macro 5"
+    },
+    "Macro5": {
+      "value": 0.0,
+      "customName": "Macro 6"
+    },
+    "Macro6": {
+      "value": 0.0,
+      "customName": "Macro 7"
+    },
+    "Macro7": {
+      "value": 0.0,
+      "customName": "Macro 8"
+    }
+  },
+  "deviceData": {},
+  "chains": [
+    {
+      "name": "",
+      "color": 0,
+      "devices": [
+        {
+          "$schema": "http://tech.ableton.com/schema/song/1.5.1/devicePreset.json",
+          "kind": "saturator",
+          "name": "Default Saturator",
+          "parameters": {
+            "BaseDrive": 0.0,
+            "BassShaperThreshold": -50.0,
+            "ColorDepth": 0.0,
+            "ColorFrequency": 1000.0,
+            "ColorOn": true,
+            "ColorWidth": 0.30000001192092896,
+            "DryWet": 1.0,
+            "Enabled": true,
+            "Oversampling": false,
+            "PostClip": "off",
+            "PostDrive": 0.0,
+            "PreDcFilter": false,
+            "PreDrive": 0.0,
+            "Type": "Analog Clip",
+            "WsCurve": 0.05000000074505806,
+            "WsDamp": 0.0,
+            "WsDepth": 0.0,
+            "WsDrive": 1.0,
+            "WsLin": 0.5,
+            "WsPeriod": {
+              "value": 0.0,
+              "macroMapping": {
+                "macroIndex": 0
+              }
+            }
+          },
+          "deviceData": {}
+        }
+      ],
+      "mixer": {
+        "pan": 0.0,
+        "solo-cue": false,
+        "speakerOn": true,
+        "volume": 0.8509035110473633,
+        "sends": []
+      }
+    }
+  ]
+}

--- a/utility-scripts/generate_fx_macro_presets.py
+++ b/utility-scripts/generate_fx_macro_presets.py
@@ -1,0 +1,89 @@
+import os
+import re
+import sys
+from typing import Dict
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from core.fx_chain_handler import extract_fx_parameters, save_fx_chain_with_macros
+
+AUDIO_EFFECTS_DIR = os.path.join('examples', 'Audio Effects')
+OUTPUT_ROOT = os.path.join('examples', 'FX Macro Presets')
+
+
+def sanitize_filename(name: str) -> str:
+    """Return a safe filename component."""
+    name = re.sub(r"[\\/:]+", '-', name)
+    name = name.replace(' ', '_')
+    return name
+
+
+def find_base_preset(effect_dir: str) -> str:
+    """Return a preset path to use as the base for an effect."""
+    for f in os.listdir(effect_dir):
+        if f.lower().startswith('default') and f.endswith('.json'):
+            return os.path.join(effect_dir, f)
+    for f in os.listdir(effect_dir):
+        if f.endswith('.json'):
+            return os.path.join(effect_dir, f)
+    return ''
+
+
+def generate_presets_for_effect(effect_name: str, preset_path: str) -> int:
+    """Generate macro presets for a single effect."""
+    info = extract_fx_parameters(preset_path)
+    if not info.get('success'):
+        print(f"Failed to read {preset_path}: {info.get('message')}")
+        return 0
+    params = info.get('parameters', [])
+    paths: Dict[str, str] = info.get('parameter_paths', {})
+
+    out_dir = os.path.join(OUTPUT_ROOT, effect_name)
+    os.makedirs(out_dir, exist_ok=True)
+
+    count = 0
+    for i, param in enumerate(params, 1):
+        name = param['name']
+        path = paths.get(name)
+        if not path:
+            continue
+        macros = [{
+            'index': 0,
+            'name': name,
+            'parameters': [{
+                'name': name,
+                'path': path,
+            }]
+        }]
+        filename = f"{effect_name} - {i:03d} - {sanitize_filename(name)}.ablpreset"
+        dest = os.path.join(out_dir, filename)
+        res = save_fx_chain_with_macros(preset_path, macros, dest)
+        if res.get('success'):
+            count += 1
+        else:
+            print(f"Error saving {filename}: {res.get('message')}")
+    return count
+
+
+def main() -> None:
+    os.makedirs(OUTPUT_ROOT, exist_ok=True)
+    total = 0
+    for effect in sorted(os.listdir(AUDIO_EFFECTS_DIR)):
+        effect_path = os.path.join(AUDIO_EFFECTS_DIR, effect)
+        if not os.path.isdir(effect_path):
+            continue
+        base = find_base_preset(effect_path)
+        if not base:
+            print(f"No preset found for {effect}")
+            continue
+        print(f"Processing {effect} using {os.path.basename(base)}")
+        count = generate_presets_for_effect(effect, base)
+        print(f"  created {count} presets")
+        total += count
+    print(f"Generated {total} preset files in {OUTPUT_ROOT}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a utility script to build FX chain presets with Macro0 mappings
- document the script in the README

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a437bf40c8325859767ec78c53a1e