### PR TITLE
Update FX macro exclusion list

### DIFF
--- a/handlers/fx_chain_editor_handler_class.py
+++ b/handlers/fx_chain_editor_handler_class.py
@@ -17,18 +17,25 @@ if not os.path.exists(USER_LIBRARY_DIR) and os.path.exists("examples/Audio Effec
     USER_LIBRARY_DIR = "examples/Audio Effects"
 
 # Parameters that cannot be assigned to macro knobs but should remain editable.
-# Each line notes the device where the parameter originates.
+# Keys are device folder names and values are sets of parameters that belong to
+# that device. This avoids excluding parameters with common names on other
+# effects.
 EXCLUDED_MACRO_PARAMS = {
-    "DelayLine_CompatibilityMode",  # Delay
-    "DryWetMode",  # Delay
-    "EcoProcessing",  # Delay / Redux
-    "Enabled",  # Dynamics
-    "Oversampling",  # Saturator
-    "HiQuality",  # Auto Filter
-    "HostVisualisationRate",  # Auto Filter
-    "InternalSideChainGain",  # Auto Filter
-    "SideChainListen",  # Auto Filter
-    "SideChainMono",  # Auto Filter
+    "Delay": {
+        "DelayLine_CompatibilityMode",
+        "DryWetMode",
+        "EcoProcessing",
+    },
+    "Redux": {"EcoProcessing"},
+    "Dynamics": {"Enabled"},
+    "Saturator": {"Oversampling"},
+    "Auto Filter": {
+        "HiQuality",
+        "HostVisualisationRate",
+        "InternalSideChainGain",
+        "SideChainListen",
+        "SideChainMono",
+    },
 }
 
 
@@ -117,13 +124,15 @@ class FxChainEditorHandler(BaseHandler):
                 macro_knobs_html = ""
                 macros_json = "[]"
             params_html = self.generate_params_html(param_info["parameters"], mapped_info)
+            device_folder = os.path.basename(os.path.dirname(preset_path))
+            excluded = EXCLUDED_MACRO_PARAMS.get(device_folder, set())
             params_for_macros = [
-                p for p in param_info["parameters"] if p["name"] not in EXCLUDED_MACRO_PARAMS
+                p for p in param_info["parameters"] if p["name"] not in excluded
             ]
             paths_for_macros = {
                 k: v
                 for k, v in param_info.get("parameter_paths", {}).items()
-                if k not in EXCLUDED_MACRO_PARAMS
+                if k not in excluded
             }
             available_params_json = json.dumps([p["name"] for p in params_for_macros])
             param_paths_json = json.dumps(paths_for_macros)

--- a/tests/test_fx_macro_exclude.py
+++ b/tests/test_fx_macro_exclude.py
@@ -10,7 +10,7 @@ class SimpleForm(dict):
         return self.get(name, default)
 
 
-def create_fx_preset(path):
+def create_fx_preset(path: Path) -> None:
     preset = {
         "kind": "delay",
         "parameters": {
@@ -27,11 +27,12 @@ def create_fx_preset(path):
             "SideChainMono": False,
         },
     }
-    Path(path).write_text(json.dumps(preset))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(preset))
 
 
 def test_excluded_macro_params(monkeypatch, tmp_path):
-    p = tmp_path / "effect.json"
+    p = tmp_path / "Delay" / "effect.json"
     create_fx_preset(p)
 
     monkeypatch.setattr(fceh, "refresh_library", lambda: (True, "ok"))
@@ -42,10 +43,10 @@ def test_excluded_macro_params(monkeypatch, tmp_path):
     result = handler.handle_post(form)
 
     params = json.loads(result["available_params_json"])
-    for name in fceh.EXCLUDED_MACRO_PARAMS:
+    for name in fceh.EXCLUDED_MACRO_PARAMS["Delay"]:
         assert name not in params
 
     info = extract_fx_parameters(str(p))
     names = [param["name"] for param in info["parameters"]]
-    for name in fceh.EXCLUDED_MACRO_PARAMS:
+    for name in fceh.EXCLUDED_MACRO_PARAMS["Delay"]:
         assert name in names


### PR DESCRIPTION
## Summary
- ignore unsupported FX parameters when extracting macros
- add regression test for FX macro parameter exclusion

## Testing
- `pip install -r requirements.txt`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a4ca04ba08325af4ee3d5e6618e95