### PR TITLE
Extend server startup wait

### DIFF
--- a/utility-scripts/restart-webserver.sh
+++ b/utility-scripts/restart-webserver.sh
@@ -90,10 +90,9 @@ fi
 
 # Wait for the server to respond on configured port (allow time for warm-up)
 # The webserver performs an extensive warm-up that can take close to a minute
-# on first start. The original timeout of 30 seconds was not sufficient,
-# causing false negatives. Increase the wait time to 90 seconds to accommodate
-# the warm-up process.
-for i in {1..90}; do
+# on first start. To avoid false negatives, increase the wait time to three
+# minutes (180 seconds) to accommodate slower devices.
+for i in {1..180}; do
     if command -v curl >/dev/null 2>&1; then
         if curl -sf http://localhost:${PORT}/ > /dev/null; then
             PORT_READY=true


### PR DESCRIPTION
## Summary
- increase webserver startup wait time to three minutes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da2b208188325ae95f5f7ef652a77