### PR TITLE
Updated Version Check Logic

### DIFF
--- a/utility-scripts/install-on-move.sh
+++ b/utility-scripts/install-on-move.sh
@@ -58,7 +58,16 @@ REMOTE_HOST="move.local"
 
 # Version check: ensure Move version is within tested range
 HIGHEST_TESTED_VERSION="1.5.1"
-INSTALLED_VERSION=$(ssh "${REMOTE_USER}@${REMOTE_HOST}" "/opt/move/Move -v" | awk '{print $3}')
+# Grab version no matter the result
+INSTALLED_VERSION=$( 
+    ssh "${REMOTE_USER}@${REMOTE_HOST}" "/opt/move/Move -v" \
+    | sed -nE 's/.*Version:.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' || true 
+)
+# Check to see if we got a version that's not empty
+if [[ -z "$INSTALLED_VERSION" ]]; then 
+    echo "Error: Could not determine Move version." >&2 
+    exit 1 
+fi
 # Determine if installed version exceeds highest tested
 LATEST_VERSION=$(printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V | tail -n1)
 if [ "$LATEST_VERSION" != "$HIGHEST_TESTED_VERSION" ]; then

--- a/utility-scripts/restart-webserver.sh
+++ b/utility-scripts/restart-webserver.sh
@@ -120,3 +120,4 @@ fi
 
 echo "Webserver started successfully with PID: $NEW_PID"
 EOF
+exit 0

--- a/utility-scripts/update-on-move.sh
+++ b/utility-scripts/update-on-move.sh
@@ -40,13 +40,25 @@ REMOTE_DIR="/data/UserData/extending-move"
 
 # --- Version check: ensure Move version is within tested range ---
 HIGHEST_TESTED_VERSION="1.5.1"
-INSTALLED_VERSION=$(ssh -T "${REMOTE_USER}@${REMOTE_HOST}" "/opt/move/Move -v" | awk '{print $3}')
-if ! printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V | head -n1 | grep -qx "$HIGHEST_TESTED_VERSION"; then
-  read -p "Warning: Installed Move ($INSTALLED_VERSION) > tested ($HIGHEST_TESTED_VERSION). Continue? [y/N] " confirm
-  if [[ ! $confirm =~ ^[Yy]$ ]]; then
-    echo "Aborting."
-    exit 1
-  fi
+# Grab version no matter the result
+INSTALLED_VERSION=$( 
+    ssh "${REMOTE_USER}@${REMOTE_HOST}" "/opt/move/Move -v" \
+    | sed -nE 's/.*Version:.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' || true 
+)
+# Check to see if we got a version that's not empty
+if [[ -z "$INSTALLED_VERSION" ]]; then 
+    echo "Error: Could not determine Move version." >&2 
+    exit 1 
+fi
+
+LATEST_VERSION=$(printf "%s\n%s\n" "$HIGHEST_TESTED_VERSION" "$INSTALLED_VERSION" | sort -V | tail -n1)
+
+if [ "$LATEST_VERSION" != "$HIGHEST_TESTED_VERSION" ]; then
+    read -p "Warning: Installed Move version ($INSTALLED_VERSION) is newer than highest tested ($HIGHEST_TESTED_VERSION). Continue? [y/N] " confirm
+    if [[ ! $confirm =~ ^[Yy]$ ]]; then
+        echo "Aborting installation."
+        exit 1
+    fi
 fi
 
 # --- Ensure remote directory exists ---


### PR DESCRIPTION
Hello,

These commits change some of the install scripts logic to work with the latest version of move.

Primarily there are two changes:

1. Changed the version check logic to utilize regular expression to grab the version number of move. This was updated in the install script as well as the update script.
2. Added exit 0 at the end of restart-webserver.sh. This resolved an issue I encountered with pipefail being set.

These changes were tested locally on my mac and was able to run through the scripts successfully.

Please let me know if there is any feedback.

Thanks!