### PR TITLE
feat: Introduce Over(view) page

### DIFF
--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -4,6 +4,8 @@ import json
 from core.config import MSETS_DIRECTORY
 from core.pad_colors import move_color_to_ui
 
+_BPM_CACHE = {}
+
 def get_xattr_value(relative_path, attr):
     """
     Retrieve the extended attribute value for a given file or directory.
@@ -29,10 +31,16 @@ def _parse_bpm_from_song(set_path):
     """Parse BPM from Song.abl file. Returns None if not found."""
     try:
         abl_path = os.path.join(set_path, 'Song.abl')
+        modified_ns = os.stat(abl_path).st_mtime_ns
+        cached = _BPM_CACHE.get(abl_path)
+        if cached and cached[0] == modified_ns:
+            return cached[1]
         with open(abl_path, 'r') as f:
             data = json.load(f)
         tempo = data.get('tempo')
-        return round(float(tempo), 1) if tempo else None
+        bpm = round(float(tempo), 1) if tempo else None
+        _BPM_CACHE[abl_path] = (modified_ns, bpm)
+        return bpm
     except Exception:
         return None
 

--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import json
 from core.config import MSETS_DIRECTORY
 
 def get_xattr_value(relative_path, attr):
@@ -22,6 +23,18 @@ def get_xattr_value(relative_path, attr):
         return output
     except subprocess.CalledProcessError:
         return "Unknown"
+
+def _parse_bpm_from_song(set_path):
+    """Parse BPM from Song.abl file. Returns None if not found."""
+    try:
+        abl_path = os.path.join(set_path, 'Song.abl')
+        with open(abl_path, 'r') as f:
+            data = json.load(f)
+        tempo = data.get('tempo')
+        return round(float(tempo), 1) if tempo else None
+    except Exception:
+        return None
+
 
 def list_msets(return_free_ids=False):
     """
@@ -58,6 +71,13 @@ def list_msets(return_free_ids=False):
             mset_extmodified = get_xattr_value(uuid, "user.was-externally-modified")
 
             mset_id_value = int(mset_id) if mset_id.isdigit() else 9999
+
+            # Parse BPM from Song.abl
+            bpm = None
+            if mset_folders:
+                set_path = os.path.join(uuid_path, mset_folders[0])
+                bpm = _parse_bpm_from_song(set_path)
+
             msets.append({
                 "uuid": uuid,
                 "mset_name": mset_name,
@@ -65,7 +85,8 @@ def list_msets(return_free_ids=False):
                 "mset_color": mset_color if mset_color.isdigit() else "Unknown",
                 "mset_cloudstate": mset_cloudstate,
                 "mset_modifiedtime": mset_modifiedtime,
-                "mset_extmodified": mset_extmodified
+                "mset_extmodified": mset_extmodified,
+                "bpm": bpm
             })
 
             if 0 <= mset_id_value <= 31:

--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import json
 from core.config import MSETS_DIRECTORY
+from core.pad_colors import move_color_to_ui
 
 def get_xattr_value(relative_path, attr):
     """
@@ -71,6 +72,7 @@ def list_msets(return_free_ids=False):
             mset_extmodified = get_xattr_value(uuid, "user.was-externally-modified")
 
             mset_id_value = int(mset_id) if mset_id.isdigit() else 9999
+            mset_color_value = int(mset_color) if mset_color.isdigit() else None
 
             # Parse BPM from Song.abl
             bpm = None
@@ -82,7 +84,7 @@ def list_msets(return_free_ids=False):
                 "uuid": uuid,
                 "mset_name": mset_name,
                 "mset_id": mset_id_value,
-                "mset_color": mset_color if mset_color.isdigit() else "Unknown",
+                "mset_color": move_color_to_ui(mset_color_value) if mset_color_value is not None else "Unknown",
                 "mset_cloudstate": mset_cloudstate,
                 "mset_modifiedtime": mset_modifiedtime,
                 "mset_extmodified": mset_extmodified,

--- a/core/overview_handler.py
+++ b/core/overview_handler.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from core.config import MSETS_DIRECTORY
-from core.pad_colors import PAD_COLORS
+from core.pad_colors import PAD_COLORS, move_color_to_ui
 
 SETTINGS_FILE = '/data/UserData/settings/Settings.json'
 SETS_ROOT = MSETS_DIRECTORY
@@ -96,7 +96,8 @@ def get_sets_data() -> dict:
             scale = parsed.get('scale')
             camelot = _key_to_camelot(key, scale) if key and scale else None
 
-            rgb = PAD_COLORS.get(xattr_color)
+            color_id = move_color_to_ui(xattr_color)
+            rgb = PAD_COLORS.get(color_id)
             color_css = f'rgb({rgb[0]},{rgb[1]},{rgb[2]})' if rgb else None
 
             sets_data.append({
@@ -110,6 +111,7 @@ def get_sets_data() -> dict:
                 'camelot':     camelot,
                 'slot':        slot,
                 'xattr_color': xattr_color,
+                'color_id':    color_id,
                 'color_css':   color_css,
             })
     except Exception:

--- a/core/overview_handler.py
+++ b/core/overview_handler.py
@@ -1,0 +1,180 @@
+"""Overview handler: pad grid, set metadata (BPM/key/Camelot), disk and system stats.
+
+Reads the local filesystem directly — no SSH needed since this runs on Move.
+Uses os.getxattr() for xattr reads (Python stdlib on Linux, no subprocess).
+"""
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from core.config import MSETS_DIRECTORY
+from core.pad_colors import PAD_COLORS
+
+SETTINGS_FILE = '/data/UserData/settings/Settings.json'
+SETS_ROOT = MSETS_DIRECTORY
+
+
+def _read_xattr(path: str, attr_name: str) -> Optional[str]:
+    """Read a single xattr via os.getxattr() — no subprocess required."""
+    try:
+        raw = os.getxattr(path, attr_name)
+        return raw.decode('utf-8', errors='replace').strip() or None
+    except Exception:
+        return None
+
+
+_ROOT_NOTE_NAMES = ['C', 'C#', 'D', 'Eb', 'E', 'F', 'F#', 'G', 'Ab', 'A', 'Bb', 'B']
+
+def _parse_song_abl(set_path: str) -> dict:
+    """Parse Song.abl (raw JSON) for BPM, key, and scale. Returns {} on failure."""
+    try:
+        abl_path = os.path.join(set_path, 'Song.abl')
+        with open(abl_path, 'r') as f:
+            data = json.load(f)
+        tempo = data.get('tempo')
+        bpm = round(float(tempo), 1) if tempo else None
+        root = data.get('rootNote')
+        key = _ROOT_NOTE_NAMES[int(root) % 12] if root is not None else None
+        scale_raw = data.get('scale', '')
+        scale = 'minor' if 'minor' in scale_raw.lower() else 'major' if scale_raw else None
+        return {'bpm': bpm, 'key': key, 'scale': scale}
+    except Exception:
+        return {}
+
+
+def _key_to_camelot(key: str, scale: str) -> Optional[str]:
+    """Map a key + scale to a Camelot wheel code."""
+    TABLE = {
+        ('C', 'major'): '8B',  ('A', 'minor'): '8A',
+        ('G', 'major'): '9B',  ('E', 'minor'): '9A',
+        ('D', 'major'): '10B', ('B', 'minor'): '10A',
+        ('A', 'major'): '11B', ('F#', 'minor'): '11A',
+        ('E', 'major'): '12B', ('C#', 'minor'): '12A',
+        ('B', 'major'): '1B',  ('G#', 'minor'): '1A',
+        ('F#', 'major'): '2B', ('D#', 'minor'): '2A',
+        ('Db', 'major'): '3B', ('Bb', 'minor'): '3A',
+        ('Ab', 'major'): '4B', ('F', 'minor'): '4A',
+        ('Eb', 'major'): '5B', ('C', 'minor'): '5A',
+        ('Bb', 'major'): '6B', ('G', 'minor'): '6A',
+        ('F', 'major'): '7B',  ('D', 'minor'): '7A',
+    }
+    if not key or not scale:
+        return None
+    return TABLE.get((key, scale.lower()))
+
+
+def get_sets_data() -> dict:
+    """Return full set metadata: pad grid, BPM, key, Camelot, disk usage, active slot."""
+    sets_data = []
+    try:
+        sets_root = Path(SETS_ROOT)
+        for uuid_dir in sorted(sets_root.iterdir()):
+            if not uuid_dir.is_dir():
+                continue
+            children = [d for d in uuid_dir.iterdir() if d.is_dir()]
+            if not children:
+                continue
+            set_dir = children[0]
+            uuid_path = str(uuid_dir)
+
+            slot_val  = _read_xattr(uuid_path, 'user.song-index')
+            color_val = _read_xattr(uuid_path, 'user.song-color')
+            try:
+                slot = int(slot_val) if slot_val is not None else None
+            except (ValueError, TypeError):
+                slot = None
+            try:
+                xattr_color = int(color_val) if color_val is not None else None
+            except (ValueError, TypeError):
+                xattr_color = None
+
+            parsed = _parse_song_abl(str(set_dir))
+            bpm   = parsed.get('bpm')
+            key   = parsed.get('key')
+            scale = parsed.get('scale')
+            camelot = _key_to_camelot(key, scale) if key and scale else None
+
+            rgb = PAD_COLORS.get(xattr_color)
+            color_css = f'rgb({rgb[0]},{rgb[1]},{rgb[2]})' if rgb else None
+
+            sets_data.append({
+                'name':        set_dir.name,
+                'path':        str(set_dir),
+                'uuid':        uuid_dir.name,
+                'modified':    uuid_dir.stat().st_mtime,
+                'bpm':         bpm,
+                'key':         key,
+                'mode':        scale,
+                'camelot':     camelot,
+                'slot':        slot,
+                'xattr_color': xattr_color,
+                'color_css':   color_css,
+            })
+    except Exception:
+        pass
+
+    sets_data.sort(key=lambda s: s['slot'] if s['slot'] is not None else 9999)
+
+    disk = None
+    try:
+        usage = shutil.disk_usage('/data/UserData')
+        disk = {
+            'total_gb':     round(usage.total / 1024 ** 3, 1),
+            'used_gb':      round(usage.used  / 1024 ** 3, 1),
+            'free_gb':      round(usage.free  / 1024 ** 3, 1),
+            'percent_used': round(usage.used / usage.total * 100),
+        }
+    except Exception:
+        pass
+
+    current_slot = get_active_slot()
+
+    return {
+        'sets':         sets_data,
+        'disk':         disk,
+        'total_sets':   len(sets_data),
+        'current_slot': current_slot,
+    }
+
+
+def get_active_slot() -> Optional[int]:
+    """Read currentSongIndex from Settings.json."""
+    try:
+        with open(SETTINGS_FILE, 'r') as f:
+            data = json.load(f)
+        val = data.get('currentSongIndex')
+        return int(val) if val is not None else None
+    except Exception:
+        return None
+
+
+def get_system_stats() -> dict:
+    """Read CPU load averages and memory usage from /proc."""
+    stats = {}
+    try:
+        parts = open('/proc/loadavg').read().split()
+        stats['load_1']  = float(parts[0])
+        stats['load_5']  = float(parts[1])
+        stats['load_15'] = float(parts[2])
+    except Exception:
+        pass
+    try:
+        meminfo = {}
+        for line in open('/proc/meminfo'):
+            k, v = line.split(':', 1)
+            meminfo[k.strip()] = int(v.strip().split()[0])
+        total_kb = meminfo.get('MemTotal', 0)
+        avail_kb = meminfo.get('MemAvailable', meminfo.get('MemFree', 0))
+        used_kb  = total_kb - avail_kb
+        stats['mem_total_mb'] = round(total_kb / 1024)
+        stats['mem_used_mb']  = round(used_kb  / 1024)
+        stats['mem_pct']      = round(used_kb / total_kb * 100) if total_kb else 0
+    except Exception:
+        pass
+    try:
+        stats['cpu_count'] = os.cpu_count() or 1
+    except Exception:
+        pass
+    return stats

--- a/core/pad_colors.py
+++ b/core/pad_colors.py
@@ -55,6 +55,12 @@ PAD_COLOR_LABELS = {
     25: "Fuchsia",
 }
 
+def move_color_to_ui(color_id):
+    if color_id == 0:
+        return 1
+    return color_id
+
+
 def rgb_string(color_id):
     rgb = PAD_COLORS.get(color_id)
     if rgb:

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -29,8 +29,10 @@ class BaseHandler:
         name_map: Optional[Dict[int, str]] = None,
         bpm_map: Optional[Dict[int, str]] = None,
         selected_idx: Optional[int] = None,
+        active_idx: Optional[int] = None,
         input_name: str = "pad_index",
         free_only: bool = False,
+        view_only: bool = False,
     ) -> str:
         """Generate HTML for a 32-pad grid showing set occupancy with colors, names, and BPM.
 
@@ -69,6 +71,7 @@ class BaseHandler:
                     disabled = "" if has_set else "disabled"
 
                 status = "occupied" if has_set else "free"
+                active = " active" if active_idx is not None and idx == active_idx else ""
                 checked = " checked" if selected_idx is not None and idx == selected_idx else ""
                 color_id = color_map.get(idx)
                 # Generate semi-transparent background + solid border like Overview page
@@ -90,9 +93,10 @@ class BaseHandler:
 
                 cells.append(
                     f'<input type="radio" id="pad_{num}" name="{input_name}" value="{num}"{checked} {disabled}>'
-                    f'<label for="pad_{num}" class="pad-cell {status}"{style}>{inner_html}</label>'
+                    f'<label for="pad_{num}" class="pad-cell {status}{active}"{style}>{inner_html}</label>'
                 )
-        return '<div class="pad-grid">' + "".join(cells) + "</div>"
+        grid_class = "pad-grid view-only" if view_only else "pad-grid"
+        return f'<div class="{grid_class}">' + "".join(cells) + "</div>"
 
     def __init__(self):
         """

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -2,7 +2,8 @@
 import os
 import shutil
 import logging
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, Set
+from core.pad_colors import rgb_string
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +16,84 @@ class BaseHandler:
     - Form action validation
     - Response formatting
     - Cleanup of temporary files
+    - Shared pad grid generation for set selection UI
     
     Each feature handler should inherit from this class and implement
     its own handle_post method to process specific feature requests.
     """
-    
+
+    def generate_pad_grid(
+        self,
+        used_ids: Set[int],
+        color_map: Optional[Dict[int, int]] = None,
+        name_map: Optional[Dict[int, str]] = None,
+        bpm_map: Optional[Dict[int, str]] = None,
+        selected_idx: Optional[int] = None,
+        input_name: str = "pad_index",
+        free_only: bool = False,
+    ) -> str:
+        """Generate HTML for a 32-pad grid showing set occupancy with colors, names, and BPM.
+
+        This is the standard pad grid implementation shared across all handlers
+        that need pad selection (Restore, Set Inspector, MIDI Upload, etc.).
+        Displays pad number, set name, and BPM inside each pad like the Overview page.
+
+        Args:
+            used_ids: Set of pad indices (0-31) that contain sets.
+            color_map: Optional mapping of pad index to pad color ID (1-25).
+            name_map: Optional mapping of pad index to set name.
+            bpm_map: Optional mapping of pad index to BPM string.
+            selected_idx: Optional pad index to mark as pre-selected.
+            input_name: Name attribute for the radio inputs (default: "pad_index").
+            free_only: If True, only free pads are selectable (for restore/upload).
+                         If False, only occupied pads are selectable (for set inspector).
+
+        Returns:
+            HTML string containing the pad grid div with styled radio inputs.
+        """
+        color_map = color_map or {}
+        name_map = name_map or {}
+        bpm_map = bpm_map or {}
+        cells = []
+        for row in range(4):
+            for col in range(8):
+                idx = (3 - row) * 8 + col
+                num = idx + 1
+                has_set = idx in used_ids
+
+                if free_only:
+                    # For restore/upload: only free pads selectable
+                    disabled = "disabled" if has_set else ""
+                else:
+                    # For set inspector: only occupied pads selectable
+                    disabled = "" if has_set else "disabled"
+
+                status = "occupied" if has_set else "free"
+                checked = "checked" if selected_idx is not None and idx == selected_idx else ""
+                color_id = color_map.get(idx)
+                # Generate semi-transparent background + solid border like Overview page
+                if color_id:
+                    rgb = rgb_string(color_id).replace("rgb(", "").replace(")", "")
+                    style = f' style="background-color: rgba({rgb}, 0.2); border-color: rgb({rgb});"'
+                else:
+                    style = ""
+                name = name_map.get(idx, "")
+                bpm = bpm_map.get(idx, "")
+
+                # Build inner content like Overview page
+                if has_set:
+                    inner_html = f'<div class="pad-num">{num}</div><div class="pad-name">{name}</div>'
+                    if bpm:
+                        inner_html += f'<div class="pad-bpm">{bpm} BPM</div>'
+                else:
+                    inner_html = f'<div class="pad-num">{num}</div>'
+
+                cells.append(
+                    f'<input type="radio" id="pad_{num}" name="{input_name}" value="{num}"{checked} {disabled}>'
+                    f'<label for="pad_{num}" class="pad-cell {status}"{style}>{inner_html}</label>'
+                )
+        return '<div class="pad-grid">' + "".join(cells) + "</div>"
+
     def __init__(self):
         """
         Initialize the handler with a temporary uploads directory.

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import html
 import os
 import shutil
 import logging
@@ -80,8 +81,8 @@ class BaseHandler:
                     style = f' style="background-color: rgba({rgb}, 0.2); border-color: rgb({rgb});"'
                 else:
                     style = ""
-                name = name_map.get(idx, "")
-                bpm = bpm_map.get(idx, "")
+                name = html.escape(str(name_map.get(idx, "")))
+                bpm = html.escape(str(bpm_map.get(idx, "")))
 
                 # Build inner content like Overview page
                 if has_set:

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -69,7 +69,7 @@ class BaseHandler:
                     disabled = "" if has_set else "disabled"
 
                 status = "occupied" if has_set else "free"
-                checked = "checked" if selected_idx is not None and idx == selected_idx else ""
+                checked = " checked" if selected_idx is not None and idx == selected_idx else ""
                 color_id = color_map.get(idx)
                 # Generate semi-transparent background + solid border like Overview page
                 if color_id:

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -13,6 +13,38 @@ class OverviewHandler(BaseHandler):
         """Return full sets data as JSON."""
         return get_sets_data()
 
+    def generate_pad_grid_html(self, restore_mode=False, camelot=None):
+        data = get_sets_data()
+        sets = data.get("sets", [])
+        if camelot and not restore_mode:
+            sets = [set_data for set_data in sets if set_data.get("camelot") == camelot]
+        used_ids = {set_data["slot"] for set_data in sets if set_data.get("slot") is not None}
+        color_map = {
+            set_data["slot"]: set_data["color_id"]
+            for set_data in sets
+            if set_data.get("slot") is not None and set_data.get("color_id") is not None
+        }
+        name_map = {
+            set_data["slot"]: set_data["name"]
+            for set_data in sets
+            if set_data.get("slot") is not None
+        }
+        bpm_map = {
+            set_data["slot"]: str(set_data["bpm"])
+            for set_data in sets
+            if set_data.get("slot") is not None and set_data.get("bpm") is not None
+        }
+        return self.generate_pad_grid(
+            used_ids,
+            color_map,
+            name_map,
+            bpm_map,
+            active_idx=data.get("current_slot"),
+            input_name="overview_pad",
+            free_only=restore_mode,
+            view_only=not restore_mode,
+        )
+
     def handle_get_active_slot(self):
         """Return only the current active pad slot."""
         return {'current_slot': get_active_slot()}

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -53,6 +53,10 @@ class OverviewHandler(BaseHandler):
                 result = restore_abl(filepath, pad_selected, pad_color)
 
             self.cleanup_upload(filepath)
+            if result.get("success"):
+                result["message"] = result["message"].replace(
+                    f"pad {pad_selected}", f"pad {pad_selected + 1}"
+                )
             return result
 
         except Exception as e:

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from handlers.base_handler import BaseHandler
+from core.overview_handler import get_sets_data, get_active_slot, get_system_stats
+
+
+class OverviewHandler(BaseHandler):
+    def handle_get_data(self):
+        """Return full sets data as JSON."""
+        return get_sets_data()
+
+    def handle_get_active_slot(self):
+        """Return only the current active pad slot."""
+        return {'current_slot': get_active_slot()}
+
+    def handle_get_system_stats(self):
+        """Return CPU load and memory usage."""
+        return get_system_stats()

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
+import os
+import logging
 from handlers.base_handler import BaseHandler
 from core.overview_handler import get_sets_data, get_active_slot, get_system_stats
+from core.restore_handler import restore_ablbundle, restore_abl
+from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
+import json
 
 
 class OverviewHandler(BaseHandler):
@@ -15,3 +20,47 @@ class OverviewHandler(BaseHandler):
     def handle_get_system_stats(self):
         """Return CPU load and memory usage."""
         return get_system_stats()
+
+    def handle_post_restore(self, form):
+        """Handle restore POST request from Overview page."""
+        try:
+            # Validate file upload
+            success, filepath, error_response = self.handle_file_upload(form, "ablbundle")
+            if not success:
+                return {"success": False, "message": error_response.get('message', "Failed to upload file") if error_response else "Upload failed"}
+
+            # Get form values
+            pad_selected = form.getvalue("target_pad")
+            pad_color = form.getvalue("pad_color")
+
+            # Validate pad selection
+            if not pad_selected or not pad_selected.isdigit():
+                self.cleanup_upload(filepath)
+                return {"success": False, "message": "Please select a target pad from the grid."}
+
+            # Validate color
+            if not pad_color or not pad_color.isdigit():
+                self.cleanup_upload(filepath)
+                return {"success": False, "message": "Please select a pad color."}
+
+            pad_selected = int(pad_selected) - 1  # Convert to internal ID (0-31)
+            pad_color = int(pad_color)
+
+            # Execute restore
+            if filepath.lower().endswith('.ablbundle'):
+                result = restore_ablbundle(filepath, pad_selected, pad_color)
+            else:
+                result = restore_abl(filepath, pad_selected, pad_color)
+
+            self.cleanup_upload(filepath)
+            return result
+
+        except Exception as e:
+            logging.error(f"Error in handle_post_restore: {str(e)}")
+            return {"success": False, "message": f"Error restoring set: {str(e)}"}
+
+    def generate_color_options_json(self):
+        """Return pad colors and labels as JSON for client-side use."""
+        colors = [PAD_COLORS[i] for i in sorted(PAD_COLORS)]
+        names = [PAD_COLOR_LABELS[i] for i in sorted(PAD_COLOR_LABELS)]
+        return {"colors": colors, "names": names}

--- a/handlers/restore_handler_class.py
+++ b/handlers/restore_handler_class.py
@@ -3,7 +3,7 @@ import logging
 from handlers.base_handler import BaseHandler
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle, restore_abl
-from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS, rgb_string
+from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
 import json
 
 class RestoreHandler(BaseHandler):
@@ -22,7 +22,9 @@ class RestoreHandler(BaseHandler):
             msets, ids = list_msets(return_free_ids=True)
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             logging.info(f"Available Pads: {free_pads}")
 
             return {
@@ -55,7 +57,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             error_response["options"] = options
             error_response["color_options"] = self.generate_color_options()
             error_response["pad_grid"] = pad_grid
@@ -70,7 +74,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad selection provided.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
         # Early validation: color
         if not pad_color or not pad_color.isdigit():
@@ -78,7 +84,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad color provided.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
 
         pad_selected = int(pad_selected) - 1  # Convert back to internal ID
@@ -89,14 +97,18 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad selection. Must be between 1 and 32.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
         if not (1 <= pad_color <= 25):
             msets, ids = list_msets(return_free_ids=True)
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad color. Must be between 1 and 25.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
 
         success, filepath, error_response = self.handle_file_upload(form, "ablbundle")
@@ -105,7 +117,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             if error_response is None:
                 error_response = {}
             error_response["options"] = options
@@ -126,7 +140,9 @@ class RestoreHandler(BaseHandler):
                 free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
                 options = self.generate_pad_options(free_pads)
                 color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+                name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+                bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
                 return self.format_success_response(result["message"], options, pad_grid)
             else:
                 # Regenerate available pad options on error
@@ -134,14 +150,18 @@ class RestoreHandler(BaseHandler):
                 free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
                 options = self.generate_pad_options(free_pads)
                 color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+                name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+                bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
                 return self.format_error_response(result["message"], options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
         except Exception as e:
             msets, ids = list_msets(return_free_ids=True)
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response(f"Error restoring bundle: {str(e)}", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
 
     def generate_pad_options(self, free_pads):
@@ -166,24 +186,6 @@ class RestoreHandler(BaseHandler):
             "pad_grid": pad_grid,
         }
 
-    def generate_pad_grid(self, used_ids, color_map):
-        """Return HTML for a 32-pad grid showing occupied pads with colors."""
-        cells = []
-        for row in range(4):
-            for col in range(8):
-                idx = (3 - row) * 8 + col
-                num = idx + 1
-                occupied = idx in used_ids
-                status = 'occupied' if occupied else 'free'
-                disabled = 'disabled' if occupied else ''
-                color_id = color_map.get(idx)
-                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
-                label_text = "" if not occupied else ""
-                cells.append(
-                    f'<input type="radio" id="restore_pad_{num}" name="mset_index" value="{num}" {disabled}>'
-                    f'<label for="restore_pad_{num}" class="pad-cell {status}"{style}>{label_text}</label>'
-                )
-        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
 
     def generate_color_options(self, input_name="mset_color", pad_input_name="mset_index"):
         """Return HTML for the custom color dropdown with pad preview."""

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -18,35 +18,6 @@ import json
 import os
 
 class SetInspectorHandler(BaseHandler):
-    def generate_pad_grid(self, used_ids, color_map, name_map, selected_idx=None):
-        """Return HTML for a 32-pad grid showing sets with colors.
-
-        Args:
-            used_ids (set): Pad indices that contain sets.
-            color_map (dict): Mapping of pad index to pad color ID.
-            name_map (dict): Mapping of pad index to set name.
-            selected_idx (int, optional): Pad index to mark as selected.
-        """
-        cells = []
-        for row in range(4):
-            for col in range(8):
-                idx = (3 - row) * 8 + col
-                num = idx + 1
-                has_set = idx in used_ids
-                status = 'occupied' if has_set else 'free'
-                disabled = '' if has_set else 'disabled'
-                checked = ' checked' if selected_idx is not None and idx == selected_idx else ''
-                color_id = color_map.get(idx)
-                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
-                name_attr = (
-                    f" data-name=\"{name_map.get(idx, '')}\"" if idx in name_map else ""
-                )
-                cells.append(
-                    f'<input type="radio" id="inspect_pad_{num}" name="pad_index" value="{num}"{checked} {disabled}>'
-                    f'<label for="inspect_pad_{num}" class="pad-cell {status}"{style}{name_attr}></label>'
-                )
-        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
-
     def generate_clip_grid(self, clips, selected=None):
         """Return HTML for an 8x8 grid of clips including empty slots."""
         clip_map = {(c["track"], c["clip"]): c for c in clips}
@@ -83,8 +54,9 @@ class SetInspectorHandler(BaseHandler):
             if str(m["mset_color"]).isdigit()
         }
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
         selected_idx = None
-        pad_grid = self.generate_pad_grid(used, color_map, name_map)
+        pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
         return {
             "pad_grid": pad_grid,
             "message": "Select a set to inspect",
@@ -113,7 +85,8 @@ class SetInspectorHandler(BaseHandler):
             if str(m["mset_color"]).isdigit()
         }
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
-        pad_grid = self.generate_pad_grid(used, color_map, name_map)
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+        pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
 
         if action == "select_set":
             pad_val = form.getvalue("pad_index")
@@ -122,7 +95,7 @@ class SetInspectorHandler(BaseHandler):
                 idx = int(pad_val) - 1
                 entry = next((m for m in msets if m.get("mset_id") == idx), None)
                 if not entry:
-                    pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                    pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                     return self.format_error_response("No set on selected pad", pad_grid=pad_grid)
                 set_path = os.path.join(
                     MSETS_DIRECTORY,
@@ -139,15 +112,15 @@ class SetInspectorHandler(BaseHandler):
                 if entry:
                     selected_idx = int(entry.get("mset_id"))
             if not set_path:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("No set selected", pad_grid=pad_grid)
             result = list_clips(set_path)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_grid = self.generate_clip_grid(result.get("clips", []))
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {
@@ -172,7 +145,7 @@ class SetInspectorHandler(BaseHandler):
             set_path = form.getvalue("set_path")
             clip_val = form.getvalue("clip_select")
             if not set_path or not clip_val:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -183,7 +156,7 @@ class SetInspectorHandler(BaseHandler):
             track_idx, clip_idx = map(int, clip_val.split(":"))
             result = get_clip_data(set_path, track_idx, clip_idx)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_info = list_clips(set_path)
             clip_grid = self.generate_clip_grid(clip_info.get("clips", []), selected=clip_val)
@@ -201,7 +174,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {
@@ -234,7 +207,7 @@ class SetInspectorHandler(BaseHandler):
             param_val = form.getvalue("parameter_id")
             env_data = form.getvalue("envelope_data")
             if not (set_path and clip_val and param_val and env_data):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -246,11 +219,11 @@ class SetInspectorHandler(BaseHandler):
             try:
                 breakpoints = json.loads(env_data)
             except Exception:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("Invalid envelope data", pad_grid=pad_grid)
             result = save_envelope(set_path, track_idx, clip_idx, int(param_val), breakpoints)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_info = list_clips(set_path)
             clip_grid = self.generate_clip_grid(clip_info.get("clips", []), selected=clip_val)
@@ -275,7 +248,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             ro_state = is_read_only(set_path)
             return {
                 "pad_grid": pad_grid,
@@ -317,7 +290,7 @@ class SetInspectorHandler(BaseHandler):
                 and loop_start_val is not None
                 and loop_end_val is not None
             ):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -333,7 +306,7 @@ class SetInspectorHandler(BaseHandler):
                 loop_start = float(loop_start_val)
                 loop_end = float(loop_end_val)
             except Exception:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("Invalid clip data", pad_grid=pad_grid)
             from core.set_inspector_handler import save_clip
 
@@ -348,7 +321,7 @@ class SetInspectorHandler(BaseHandler):
                 loop_end,
             )
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_info = list_clips(set_path)
             clip_grid = self.generate_clip_grid(clip_info.get("clips", []), selected=clip_val)
@@ -368,7 +341,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             ro_state = is_read_only(set_path)
             return {
                 "pad_grid": pad_grid,
@@ -397,7 +370,7 @@ class SetInspectorHandler(BaseHandler):
             set_path = form.getvalue("set_path")
             ro_val = form.getvalue("make_read_only")
             if not set_path or ro_val not in ("true", "false"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -407,15 +380,15 @@ class SetInspectorHandler(BaseHandler):
                 selected_idx = int(entry.get("mset_id"))
             perm_result = set_read_only(set_path, ro_val == "true")
             if not perm_result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(perm_result.get("message"), pad_grid=pad_grid)
             result = list_clips(set_path)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_grid = self.generate_clip_grid(result.get("clips", []))
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {
@@ -440,7 +413,7 @@ class SetInspectorHandler(BaseHandler):
             set_path = form.getvalue("set_path")
             backup_name = form.getvalue("backup_file")
             if not set_path or not backup_name:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -449,15 +422,15 @@ class SetInspectorHandler(BaseHandler):
             if entry:
                 selected_idx = int(entry.get("mset_id"))
             if not restore_backup(set_path, backup_name):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("Backup not found", pad_grid=pad_grid)
             result = list_clips(set_path)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_grid = self.generate_clip_grid(result.get("clips", []))
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -10,7 +10,7 @@ from core.set_management_handler import (
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
-from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS, rgb_string
+from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
 import json
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,9 @@ class SetManagementHandler(BaseHandler):
         pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + pad_options
         pad_color_options = self.generate_color_options()
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+        name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
         return {
             'pad_options': pad_options,
             'pad_color_options': pad_color_options,
@@ -48,7 +50,9 @@ class SetManagementHandler(BaseHandler):
         pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in free_pads)
         pad_color_options = self.generate_color_options()
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+        name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
 
         if action == 'upload_midi':
             # Generate set from uploaded MIDI file
@@ -186,32 +190,16 @@ class SetManagementHandler(BaseHandler):
             updated_pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in updated_free_pads)
             updated_pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + updated_pad_options
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets_updated if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(updated_ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets_updated}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets_updated if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(updated_ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
             return self.format_success_response(restore_result['message'], pad_options=updated_pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid)
         else:
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
             return self.format_error_response(restore_result.get('message'), pad_options=pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid)
-
-    def generate_pad_grid(self, used_ids, color_map):
-        """Return HTML for a 32-pad grid showing occupied pads with colors."""
-        cells = []
-        # Pad numbering starts with 1 on the bottom-left
-        for row in range(4):
-            for col in range(8):
-                idx = (3 - row) * 8 + col
-                num = idx + 1
-                occupied = idx in used_ids
-                status = 'occupied' if occupied else 'free'
-                disabled = 'disabled' if occupied else ''
-                color_id = color_map.get(idx)
-                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
-                label_text = "" if not occupied else ""
-                cells.append(
-                    f'<input type="radio" id="pad_{num}" name="pad_index" value="{num}" {disabled}>'
-                    f'<label for="pad_{num}" class="pad-cell {status}"{style}>{label_text}</label>'
-                )
-        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
 
     def generate_color_options(self, input_name="pad_color", pad_input_name="pad_index"):
         """Return HTML for the custom color dropdown with pad preview."""

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -285,9 +285,10 @@ def overview_api_system():
 @app.route("/overview/api/restore", methods=["POST"])
 def overview_api_restore():
     """Handle set restore from Overview page."""
-    from flask import request
-    # Use the same form wrapper as other handlers
-    form = FieldStorageWrapper(request.form, request.files)
+    form_data = request.form.to_dict()
+    if "ablbundle" in request.files:
+        form_data["ablbundle"] = FileField(request.files["ablbundle"])
+    form = SimpleForm(form_data)
     result = overview_handler.handle_post_restore(form)
     return jsonify(result)
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -261,13 +261,24 @@ def warm_up_modules():
 @app.route("/overview")
 def overview():
     """Render the Move Over (view) overview page."""
-    return render_template("overview.html", active_tab="overview")
+    return render_template(
+        "overview.html",
+        active_tab="overview",
+        pad_grid=overview_handler.generate_pad_grid_html(),
+    )
 
 
 @app.route("/overview/api/data")
 def overview_api_data():
     """Return full sets data as JSON."""
     return jsonify(get_sets_data())
+
+
+@app.route("/overview/api/grid")
+def overview_api_grid():
+    restore_mode = request.args.get("restore_mode") == "1"
+    camelot = request.args.get("camelot")
+    return jsonify({"pad_grid": overview_handler.generate_pad_grid_html(restore_mode, camelot)})
 
 
 @app.route("/overview/api/active-slot")

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -282,6 +282,22 @@ def overview_api_system():
     return jsonify(get_system_stats())
 
 
+@app.route("/overview/api/restore", methods=["POST"])
+def overview_api_restore():
+    """Handle set restore from Overview page."""
+    from flask import request
+    # Use the same form wrapper as other handlers
+    form = FieldStorageWrapper(request.form, request.files)
+    result = overview_handler.handle_post_restore(form)
+    return jsonify(result)
+
+
+@app.route("/overview/api/colors")
+def overview_api_colors():
+    """Return pad colors for color picker."""
+    return jsonify(overview_handler.generate_color_options_json())
+
+
 @app.route("/")
 def index():
     return redirect("/overview")
@@ -454,38 +470,8 @@ def lfo_route():
 
 @app.route("/restore", methods=["GET", "POST"])
 def restore():
-    message = None
-    success = False
-    message_type = None
-    options_html = ""
-    color_options = ""
-    pad_grid = ""
-    if request.method == "POST":
-        form_data = request.form.to_dict()
-        if "ablbundle" in request.files:
-            form_data["ablbundle"] = FileField(request.files["ablbundle"])
-        form = SimpleForm(form_data)
-        result = restore_handler.handle_post(form)
-        message = result.get("message")
-        message_type = result.get("message_type")
-        success = message_type != "error"
-        options_html = result.get("options", options_html)
-        color_options = result.get("color_options", color_options)
-        pad_grid = result.get("pad_grid", pad_grid)
-    context = restore_handler.handle_get()
-    options_html = context.get("options", options_html)
-    color_options = context.get("color_options", color_options)
-    pad_grid = context.get("pad_grid", pad_grid)
-    return render_template(
-        "restore.html",
-        message=message,
-        success=success,
-        message_type=message_type,
-        options_html=options_html,
-        color_options=color_options,
-        pad_grid=pad_grid,
-        active_tab="restore",
-    )
+    """Restore page now redirects to Overview where restore functionality is integrated."""
+    return redirect("/overview")
 
 
 @app.route("/slice", methods=["GET", "POST"])

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -47,6 +47,8 @@ from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
+from handlers.overview_handler_class import OverviewHandler
+from core.overview_handler import get_sets_data, get_active_slot, get_system_stats
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -137,6 +139,7 @@ adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
 set_inspector_handler = SetInspectorHandler()
+overview_handler = OverviewHandler()
 
 
 @app.before_request
@@ -255,9 +258,33 @@ def warm_up_modules():
     logger.info("Module warm-up finished in %.3fs", time.perf_counter() - overall_start)
 
 
+@app.route("/overview")
+def overview():
+    """Render the Move Over (view) overview page."""
+    return render_template("overview.html", active_tab="overview")
+
+
+@app.route("/overview/api/data")
+def overview_api_data():
+    """Return full sets data as JSON."""
+    return jsonify(get_sets_data())
+
+
+@app.route("/overview/api/active-slot")
+def overview_api_active_slot():
+    """Return only the current active pad slot."""
+    return jsonify({"current_slot": get_active_slot()})
+
+
+@app.route("/overview/api/system")
+def overview_api_system():
+    """Return CPU load and memory stats."""
+    return jsonify(get_system_stats())
+
+
 @app.route("/")
 def index():
-    return redirect("/restore")
+    return redirect("/overview")
 
 
 @app.route("/browse-dir")

--- a/static/style.css
+++ b/static/style.css
@@ -47,6 +47,41 @@
     font-style: italic;
 }
 
+/* Global Dark Mode Theme Variables */
+#app-wrap {
+    /* Light mode (default) */
+    --bg-primary: #ffffff;
+    --bg-secondary: #f5f5f5;
+    --bg-tertiary: #f0f0f0;
+    --border-color: #dddddd;
+    --text-primary: #262626;
+    --text-secondary: #555555;
+    --text-dim: #888888;
+    --accent-color: #ff764d;
+    --link-color: #0000ff;
+    --tab-bg: #e0e0e0;
+    --tab-active-bg: #ffffff;
+    --input-bg: #ffffff;
+    --input-border: #cccccc;
+}
+
+#app-wrap.dark {
+    /* Dark mode - matches Overview page dark theme */
+    --bg-primary: #0a0a0a;
+    --bg-secondary: #111111;
+    --bg-tertiary: #151515;
+    --border-color: #2a2a2a;
+    --text-primary: #e0e0e0;
+    --text-secondary: #888888;
+    --text-dim: #555555;
+    --accent-color: #4dd9d9;
+    --link-color: #4dd9d9;
+    --tab-bg: #1e1e1e;
+    --tab-active-bg: #0a0a0a;
+    --input-bg: #111111;
+    --input-border: #333333;
+}
+
 /* Base styles */
 body {
     font-family: 'Ableton Sans', Arial, sans-serif;
@@ -57,6 +92,17 @@ body {
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+#app-wrap {
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    min-height: 100vh;
+    padding: 1rem;
+}
+
+#app-wrap.dark body {
+    background-color: #0a0a0a;
 }
 
 .text-lg {
@@ -171,6 +217,39 @@ h3 {
     box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 }
 
+/* Dark mode overrides for common elements */
+#app-wrap.dark h1,
+#app-wrap.dark h2,
+#app-wrap.dark h3,
+#app-wrap.dark h4 {
+    color: var(--text-primary);
+}
+
+#app-wrap.dark .tab a {
+    color: var(--text-secondary);
+}
+
+#app-wrap.dark .tab a:hover {
+    color: var(--text-primary);
+}
+
+#app-wrap.dark .tab a.active {
+    color: var(--accent-color);
+}
+
+#app-wrap.dark .tabcontent {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+#app-wrap.dark a {
+    color: var(--link-color);
+}
+
+#app-wrap.dark #footer a {
+    color: var(--link-color);
+}
+
 /* Form elements */
 input[type="text"],
 input[type="number"],
@@ -226,6 +305,28 @@ input[type="submit"] {
 
 .drum-grid button {
     margin-left: 0.5rem;
+}
+
+/* Dark mode for form elements */
+#app-wrap.dark input[type="text"],
+#app-wrap.dark input[type="number"],
+#app-wrap.dark input[type="file"],
+#app-wrap.dark select {
+    background-color: var(--input-bg);
+    border-color: var(--input-border);
+    color: var(--text-primary);
+}
+
+#app-wrap.dark label,
+#app-wrap.dark .slice-even-group label,
+#app-wrap.dark .slice-transient-group label {
+    color: var(--text-secondary);
+}
+
+#app-wrap.dark button,
+#app-wrap.dark input[type="submit"] {
+    background-color: var(--accent-color);
+    color: #000;
 }
 
 button:hover, 
@@ -339,6 +440,35 @@ body.page-melodic-sampler .waveform-container {
 .current-preset {
     font-weight: 500;
     margin-bottom: 1rem;
+}
+
+/* Dark mode for messages and UI elements */
+#app-wrap.dark .success {
+    color: #4dd9d9;
+    background-color: rgba(77, 217, 217, 0.1);
+}
+
+#app-wrap.dark .error {
+    color: #ff6b6b;
+    background-color: rgba(255, 107, 107, 0.1);
+}
+
+#app-wrap.dark .info {
+    color: #4dd9d9;
+    background-color: rgba(77, 217, 217, 0.1);
+}
+
+#app-wrap.dark .file-browser {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+}
+
+#app-wrap.dark .chord-preview {
+    background-color: var(--bg-secondary);
+}
+
+#app-wrap.dark .file-tree .file-entry button {
+    color: var(--link-color);
 }
 
 /* Chord grid styling */
@@ -526,6 +656,27 @@ nav.breadcrumbs form {
     box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
     animation: pad-pulse 2s ease-in-out infinite;
     opacity: 1 !important;
+}
+
+/* Dark mode pad grid overrides */
+#app-wrap.dark .pad-grid {
+    --pg-bg: #0a0a0a;
+    --pg-bg2: #111111;
+    --pg-border: #2a2a2a;
+    --pg-text: #e0e0e0;
+    --pg-text-dim: #555555;
+    --pg-text-mid: #888888;
+    --pg-pad-empty: #151515;
+    --pg-pad-occupied-bg: var(--pg-bg2);
+}
+
+#app-wrap.dark .pad-cell.free:hover {
+    border-color: #4dd9d9;
+}
+
+#app-wrap.dark .pad-cell.active {
+    border-color: #ff764d !important;
+    box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
 }
 
 @keyframes pad-pulse {

--- a/static/style.css
+++ b/static/style.css
@@ -460,33 +460,103 @@ nav.breadcrumbs form {
     margin-bottom: 1rem;
 }
 
-/* Pad grid for set management */
+/* Pad grid for set management - matches Overview page styling */
 .pad-grid {
     display: grid;
     grid-template-columns: repeat(8, 1fr);
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-    max-width: 600px;
+    gap: 0.35rem;
+    margin-bottom: 1.5rem;
+    max-width: 1100px;
+    /* CSS variables for theming (mirrors Overview page) */
+    --pg-bg: #ffffff;
+    --pg-bg2: #f5f5f5;
+    --pg-border: #dddddd;
+    --pg-text: #262626;
+    --pg-text-dim: #888888;
+    --pg-text-mid: #555555;
+    --pg-pad-empty: #f0f0f0;
+    --pg-pad-occupied-bg: var(--pg-bg2);
 }
 
 .pad-cell {
-    box-shadow: inset 0 0 0 2px transparent;
+    background: var(--pg-pad-empty);
+    color: var(--pg-text);
     border-radius: 4px;
-    padding: 0.5rem;
+    padding: 0.35rem 0.25rem;
     text-align: center;
-    font-weight: 600;
+    font-size: 0.8rem;
+    font-weight: 500;
     box-sizing: border-box;
-    aspect-ratio: 4 / 3; 
+    aspect-ratio: 4/3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid transparent;
+    overflow: hidden;
 }
 
 .pad-cell.free {
     cursor: pointer;
-    background: #f0f0f0;
+}
+
+.pad-cell.free:hover {
+    border-color: #0000ff;
 }
 
 .pad-cell.occupied {
-    cursor: default;
-    background: #ffeef0;
+    cursor: pointer;
+    /* Semi-transparent background to match Overview page (alpha 0.2) */
+    background: var(--pg-pad-occupied-bg);
+}
+
+/* Disabled pads (non-selectable) - reduced opacity like Overview */
+.pad-grid input[type="radio"]:disabled + label {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Occupied pads that are disabled (on restore/midi pages) */
+.pad-grid input[type="radio"]:disabled + label.occupied {
+    opacity: 0.6;
+}
+
+.pad-cell.active {
+    border-color: #ff764d !important;
+    box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
+    animation: pad-pulse 2s ease-in-out infinite;
+    opacity: 1 !important;
+}
+
+@keyframes pad-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(255, 118, 77, 0.3); }
+    50% { box-shadow: 0 0 0 5px rgba(255, 118, 77, 0.5); }
+}
+
+.pad-cell .pad-num {
+    color: var(--pg-text-dim);
+    font-size: 0.7rem;
+    line-height: 1;
+}
+
+.pad-cell .pad-name {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    width: 100%;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    line-clamp: 4;
+}
+
+.pad-cell .pad-bpm {
+    color: var(--pg-text-mid);
+    font-size: 0.7rem;
+}
+
+.pad-cell.free .pad-num {
+    color: #aaa;
 }
 
 .pad-grid input[type="radio"] {
@@ -494,8 +564,8 @@ nav.breadcrumbs form {
 }
 
 .pad-grid input[type="radio"]:checked + label {
-    box-shadow: inset 0 0 0 2px #333;
-    background: #d0e8ff;
+    border-color: #ff764d;
+    box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
 }
 
 .pad-grid label {

--- a/static/style.css
+++ b/static/style.css
@@ -714,6 +714,11 @@ nav.breadcrumbs form {
     display: none;
 }
 
+.pad-grid.view-only label {
+    cursor: default;
+    pointer-events: none;
+}
+
 .pad-grid input[type="radio"]:checked + label {
     border-color: #ff764d;
     box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -9,6 +9,7 @@
 <body class="page-{{ active_tab }}">
     <h1 id="header">Move - Extended</h1>
     <nav class="tab">
+        <a href="{{ host_prefix }}/overview" class="{% if active_tab == 'overview' %}active{% endif %}">Overview</a>
         <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
         <a href="{{ host_prefix }}/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice</a>
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -14,7 +14,6 @@
     </div>
     <nav class="tab">
         <a href="{{ host_prefix }}/overview" class="{% if active_tab == 'overview' %}active{% endif %}">Overview</a>
-        <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
         <a href="{{ host_prefix }}/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice</a>
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
         <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -7,7 +7,11 @@
     <link rel="stylesheet" href="{{ host_prefix }}/static/style.css">
 </head>
 <body class="page-{{ active_tab }}">
-    <h1 id="header">Move - Extended</h1>
+    <div id="app-wrap">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+        <h1 id="header">Move - Extended</h1>
+        <button id="theme-toggle" onclick="toggleTheme()" style="font-size:0.8rem;padding:0.3rem 0.8rem;margin:0;">🌙 Dark</button>
+    </div>
     <nav class="tab">
         <a href="{{ host_prefix }}/overview" class="{% if active_tab == 'overview' %}active{% endif %}">Overview</a>
         <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
@@ -33,6 +37,7 @@
         <a href="http://github.com/charlesvestal/extending-move/">GitHub</a> |
         <a href="https://discord.gg/GHWaZCC9bQ">Discord</a>
     </footer>
+    </div>
     <script>
     // Shared pad grid styling - matches Overview page behavior
     (function() {
@@ -65,6 +70,48 @@
             }
         });
     })();
+    </script>
+    <script>
+    // Global theme toggle
+    function toggleTheme() {
+        const wrap = document.getElementById('app-wrap');
+        const btn = document.getElementById('theme-toggle');
+        const isDark = wrap.classList.toggle('dark');
+        btn.textContent = isDark ? '☀️ Light' : '🌙 Dark';
+        localStorage.setItem('move-theme', isDark ? 'dark' : 'light');
+        // Update pad grid opacity for dark mode
+        updatePadGridForTheme(isDark);
+    }
+    
+    function updatePadGridForTheme(isDark) {
+        document.querySelectorAll('.pad-grid .pad-cell').forEach(cell => {
+            const bg = cell.style.backgroundColor;
+            if (bg && bg.includes('rgba')) {
+                // In dark mode, use 0.08 opacity, in light mode use 0.2
+                const newAlpha = isDark ? '0.08' : '0.2';
+                cell.style.backgroundColor = bg.replace(/rgba\((\d+),\s*(\d+),\s*(\d+),\s*[\d.]+\)/, `rgba($1, $2, $3, ${newAlpha})`);
+            }
+        });
+    }
+    
+    (function() {
+        // Restore theme preference on page load
+        if (localStorage.getItem('move-theme') === 'dark') {
+            document.getElementById('app-wrap').classList.add('dark');
+            document.getElementById('theme-toggle').textContent = '☀️ Light';
+        }
+    })();
+    
+    // Initialize pad grid opacity after DOM is ready
+    document.addEventListener('DOMContentLoaded', function() {
+        const isDark = document.getElementById('app-wrap').classList.contains('dark');
+        if (isDark && typeof updatePadGridForTheme === 'function') {
+            // Small delay to ensure pad grid is rendered
+            setTimeout(function() {
+                updatePadGridForTheme(true);
+            }, 0);
+        }
+    });
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -33,6 +33,39 @@
         <a href="http://github.com/charlesvestal/extending-move/">GitHub</a> |
         <a href="https://discord.gg/GHWaZCC9bQ">Discord</a>
     </footer>
+    <script>
+    // Shared pad grid styling - matches Overview page behavior
+    (function() {
+        function updatePadOpacity() {
+            // Reset all pad backgrounds to 0.2 opacity
+            document.querySelectorAll('.pad-grid .pad-cell').forEach(cell => {
+                const bg = cell.style.backgroundColor;
+                if (bg && bg.includes('rgba')) {
+                    cell.style.backgroundColor = bg.replace(/rgba\((\d+),\s*(\d+),\s*(\d+),\s*[\d.]+\)/, 'rgba($1, $2, $3, 0.2)');
+                }
+            });
+            // Increase opacity to 0.4 for selected pad
+            const checked = document.querySelector('.pad-grid input[type="radio"]:checked');
+            if (checked) {
+                const label = document.querySelector('label[for="' + checked.id + '"]');
+                if (label) {
+                    const bg = label.style.backgroundColor;
+                    if (bg && bg.includes('rgba')) {
+                        label.style.backgroundColor = bg.replace(/rgba\((\d+),\s*(\d+),\s*(\d+),\s*[\d.]+\)/, 'rgba($1, $2, $3, 0.4)');
+                    }
+                    label.classList.add('active');
+                }
+            }
+        }
+        document.addEventListener('DOMContentLoaded', function() {
+            const padGrid = document.querySelector('.pad-grid');
+            if (padGrid) {
+                updatePadOpacity();
+                padGrid.addEventListener('change', updatePadOpacity);
+            }
+        });
+    })();
+    </script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -2,10 +2,7 @@
 
 {% block content %}
 <div id="overview-wrap">
-<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
-    <h2 style="margin-bottom:0;">Move Over (view)</h2>
-    <button id="theme-toggle" onclick="toggleTheme()" style="font-size:0.8rem;padding:0.3rem 0.8rem;margin:0;">🌙 Dark</button>
-</div>
+<h2 style="margin-bottom:0;">Move Over (view)</h2>
 <div class="overview-stats">
     <div class="overview-stat-box">
         <div class="overview-stat-label">STORAGE: <span id="disk-text">—</span></div>
@@ -63,7 +60,9 @@
         --ov-pad-empty:  #f0f0f0;
         --ov-bar-track:  #e0e0e0;
     }
-    #overview-wrap.dark {
+    /* Overview uses global dark mode - override variables for dark theme */
+    #app-wrap.dark #overview-wrap {
+        font-family: monospace;
         --ov-bg:         #0a0a0a;
         --ov-bg2:        #111111;
         --ov-border:     #2a2a2a;
@@ -72,33 +71,22 @@
         --ov-text-mid:   #888888;
         --ov-pad-empty:  #151515;
         --ov-bar-track:  #1e1e1e;
-        --ov-accent:     #4dd9d9;
-        font-family: monospace;
-        background: #0a0a0a;
-        padding: 1rem;
-        border-radius: 4px;
-        margin: -2rem;
     }
-    #overview-wrap.dark h2 {
-        color: #4dd9d9;
-        font-family: monospace;
-    }
-    #overview-wrap.dark .overview-filter-btn.active {
+    #app-wrap.dark #overview-wrap .overview-filter-btn.active {
         background: rgba(77,217,217,0.15);
         border-color: #4dd9d9;
         color: #4dd9d9;
     }
-    #overview-wrap.dark .overview-filter-btn {
+    #app-wrap.dark #overview-wrap .overview-filter-btn {
         border-color: #333;
         color: #aaa;
         font-family: monospace;
     }
-    #overview-wrap.dark .overview-table th,
-    #overview-wrap.dark .overview-table td {
-        color: var(--ov-text);
+    #app-wrap.dark #overview-wrap .overview-table th,
+    #app-wrap.dark #overview-wrap .overview-table td {
         font-family: monospace;
     }
-    #overview-wrap.dark .camelot-badge {
+    #app-wrap.dark #overview-wrap .camelot-badge {
         font-family: monospace;
     }
     .overview-stats {
@@ -326,7 +314,7 @@
                 cell.className = 'overview-pad-cell';
                 const s = bySlot[i];
                 if (s) {
-                    const isDark = document.getElementById('overview-wrap').classList.contains('dark');
+                    const isDark = document.getElementById('app-wrap').classList.contains('dark');
                     const isActive = s.slot == activeSlot;
                     if (s.color_css) cell.style.borderColor = s.color_css;
                     const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
@@ -401,20 +389,7 @@
         } catch (e) {}
     }
 
-    function toggleTheme() {
-        const wrap = document.getElementById('overview-wrap');
-        const btn = document.getElementById('theme-toggle');
-        const isDark = wrap.classList.toggle('dark');
-        btn.textContent = isDark ? '☀️ Light' : '🌙 Dark';
-        localStorage.setItem('overview-theme', isDark ? 'dark' : 'light');
-    }
-
-    (function() {
-        if (localStorage.getItem('overview-theme') === 'dark') {
-            document.getElementById('overview-wrap').classList.add('dark');
-            document.getElementById('theme-toggle').textContent = '☀️ Light';
-        }
-    })();
+    // Overview page now uses global dark mode from base.html
 
     loadData();
     pollSystemStats();

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Move Over (view)</h2>
-
+<div id="overview-wrap">
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+    <h2 style="margin-bottom:0;">Move Over (view)</h2>
+    <button id="theme-toggle" onclick="toggleTheme()" style="font-size:0.8rem;padding:0.3rem 0.8rem;margin:0;">🌙 Dark</button>
+</div>
 <div class="overview-stats">
     <div class="overview-stat-box">
         <div class="overview-stat-label">STORAGE: <span id="disk-text">—</span></div>
@@ -23,7 +26,7 @@
 
     <div style="margin:1rem 0;">
         <label style="display:inline;font-weight:400;margin-right:0.5rem;">Filter by Camelot key:</label>
-        <button class="overview-filter-btn active" onclick="filterByCamelot(null, this)">All</button>
+        <button class="overview-filter-btn active" onclick="filterByCamelot(null, this)">All Keys</button>
         <span id="camelot-filter-btns"></span>
     </div>
 
@@ -45,26 +48,76 @@
         Sets refresh every 30s &nbsp;·&nbsp; Active pad updates every 2s
     </div>
 </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
 <style>
+    #overview-wrap {
+        --ov-bg:         #ffffff;
+        --ov-bg2:        #f5f5f5;
+        --ov-border:     #dddddd;
+        --ov-text:       #262626;
+        --ov-text-dim:   #888888;
+        --ov-text-mid:   #555555;
+        --ov-pad-empty:  #f0f0f0;
+        --ov-bar-track:  #e0e0e0;
+    }
+    #overview-wrap.dark {
+        --ov-bg:         #0a0a0a;
+        --ov-bg2:        #111111;
+        --ov-border:     #2a2a2a;
+        --ov-text:       #e0e0e0;
+        --ov-text-dim:   #555555;
+        --ov-text-mid:   #888888;
+        --ov-pad-empty:  #151515;
+        --ov-bar-track:  #1e1e1e;
+        --ov-accent:     #4dd9d9;
+        font-family: monospace;
+        background: #0a0a0a;
+        padding: 1rem;
+        border-radius: 4px;
+        margin: -2rem;
+    }
+    #overview-wrap.dark h2 {
+        color: #4dd9d9;
+        font-family: monospace;
+    }
+    #overview-wrap.dark .overview-filter-btn.active {
+        background: rgba(77,217,217,0.15);
+        border-color: #4dd9d9;
+        color: #4dd9d9;
+    }
+    #overview-wrap.dark .overview-filter-btn {
+        border-color: #333;
+        color: #aaa;
+        font-family: monospace;
+    }
+    #overview-wrap.dark .overview-table th,
+    #overview-wrap.dark .overview-table td {
+        color: var(--ov-text);
+        font-family: monospace;
+    }
+    #overview-wrap.dark .camelot-badge {
+        font-family: monospace;
+    }
     .overview-stats {
+        color: var(--ov-text);
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 0.75rem;
         margin-bottom: 1.5rem;
     }
     .overview-stat-box {
-        background: #f5f5f5;
-        border: 1px solid #ddd;
+        background: var(--ov-bg2);
+        border: 1px solid var(--ov-border);
         border-radius: 4px;
         padding: 0.75rem 1rem;
         font-size: 0.875rem;
     }
     .overview-stat-label { margin-bottom: 0.4rem; }
     .overview-bar-track {
-        background: #e0e0e0;
+        background: var(--ov-bar-track);
         border-radius: 2px;
         height: 12px;
         overflow: hidden;
@@ -80,46 +133,50 @@
     .overview-pad-grid {
         display: grid;
         grid-template-columns: repeat(8, 1fr);
-        gap: 0.4rem;
+        gap: 0.35rem;
         margin-bottom: 1.5rem;
-        max-width: 640px;
+        max-width: 1100px;
     }
     .overview-pad-cell {
+        background: var(--ov-pad-empty);
+        color: var(--ov-text);
         border-radius: 4px;
-        padding: 0.4rem 0.25rem;
+        padding: 0.35rem 0.25rem;
         text-align: center;
-        font-size: 0.7rem;
+        font-size: 0.8rem;
         font-weight: 500;
         aspect-ratio: 4/3;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        background: #f0f0f0;
         border: 2px solid transparent;
         box-sizing: border-box;
         overflow: hidden;
     }
     .overview-pad-cell.active {
-        border-color: #ff764d;
-        box-shadow: 0 0 0 2px rgba(255,118,77,0.3);
+        border-color: #ff764d !important;
+        box-shadow: 0 0 0 3px rgba(255,118,77,0.5);
         animation: overview-pulse 2s ease-in-out infinite;
     }
     .overview-pad-cell .pad-num {
-        font-size: 0.6rem;
-        color: #888;
+        color: var(--ov-text-dim);
+        font-size: 0.7rem;
         line-height: 1;
     }
     .overview-pad-cell .pad-name {
-        font-size: 0.65rem;
-        word-break: break-word;
+        font-size: 0.75rem;
         line-height: 1.2;
-        max-height: 2.4em;
+        width: 100%;
         overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 4;
+        -webkit-box-orient: vertical;
+        line-clamp: 4;
     }
     .overview-pad-cell .pad-bpm {
-        font-size: 0.6rem;
-        color: #555;
+        color: var(--ov-text-mid);
+        font-size: 0.7rem;
     }
     @keyframes overview-pulse {
         0%, 100% { box-shadow: 0 0 0 2px rgba(255,118,77,0.3); }
@@ -150,27 +207,31 @@
         font-size: 0.875rem;
     }
     .overview-table th {
+        color: var(--ov-text-dim);
+        border-bottom-color: var(--ov-border);
         text-align: left;
         padding: 0.4rem 0.6rem;
-        border-bottom: 2px solid #ddd;
+        border-bottom: 2px solid var(--ov-border);
         font-weight: 500;
-        color: #444;
     }
     .overview-table td {
+        border-bottom-color: var(--ov-border);
         padding: 0.35rem 0.6rem;
-        border-bottom: 1px solid #eee;
+        border-bottom: 1px solid var(--ov-border);
     }
     .overview-table tr.active-row td {
-        background: #fff5f0;
+        background: var(--ov-bg2);
         font-weight: 500;
     }
     .camelot-badge {
+        background: var(--ov-bg2);
+        border-color: var(--ov-border);
+        color: var(--ov-text);
         display: inline-block;
         padding: 0.1rem 0.4rem;
         border-radius: 3px;
         font-size: 0.75rem;
-        background: #f0f0f0;
-        border: 1px solid #ccc;
+        border: 1px solid var(--ov-border);
     }
     .color-dot {
         display: inline-block;
@@ -257,23 +318,35 @@
         grid.innerHTML = '';
         const bySlot = {};
         sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
-        for (let i = 0; i < 32; i++) {
-            const cell = document.createElement('div');
-            cell.className = 'overview-pad-cell';
-            const s = bySlot[i];
-            if (s) {
-                if (s.color_css) cell.style.background = s.color_css + '33';
-                if (s.color_css) cell.style.borderColor = s.color_css;
-                if (s.slot == activeSlot) cell.classList.add('active');
-                cell.innerHTML = `
-                    <div class="pad-num">${i + 1}</div>
-                    <div class="pad-name">${s.name}</div>
-                    ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
-                `;
-            } else {
-                cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+        // Build rows bottom-to-top to match physical Move hardware layout
+        for (let row = 3; row >= 0; row--) {
+            for (let col = 0; col < 8; col++) {
+                const i = row * 8 + col;
+                const cell = document.createElement('div');
+                cell.className = 'overview-pad-cell';
+                const s = bySlot[i];
+                if (s) {
+                    const isDark = document.getElementById('overview-wrap').classList.contains('dark');
+                    const isActive = s.slot == activeSlot;
+                    if (s.color_css) cell.style.borderColor = s.color_css;
+                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
+                    if (isActive) {
+                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
+                    } else if (s.color_css) {
+                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
+                    }
+                    if (isActive) cell.classList.add('active');
+                    cell.title = s.name;
+                    cell.innerHTML = `
+                        <div class="pad-num">${i + 1}</div>
+                        <div class="pad-name">${s.name}</div>
+                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
+                    `;
+                } else {
+                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+                }
+                grid.appendChild(cell);
             }
-            grid.appendChild(cell);
         }
     }
 
@@ -327,6 +400,21 @@
             }
         } catch (e) {}
     }
+
+    function toggleTheme() {
+        const wrap = document.getElementById('overview-wrap');
+        const btn = document.getElementById('theme-toggle');
+        const isDark = wrap.classList.toggle('dark');
+        btn.textContent = isDark ? '☀️ Light' : '🌙 Dark';
+        localStorage.setItem('overview-theme', isDark ? 'dark' : 'light');
+    }
+
+    (function() {
+        if (localStorage.getItem('overview-theme') === 'dark') {
+            document.getElementById('overview-wrap').classList.add('dark');
+            document.getElementById('theme-toggle').textContent = '☀️ Light';
+        }
+    })();
 
     loadData();
     pollSystemStats();

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -415,16 +415,43 @@
         sorted.forEach(s => {
             const tr = document.createElement('tr');
             if (s.slot == activeSlot) tr.className = 'active-row';
-            const dot = s.color_css ? `<span class="color-dot" style="background:${s.color_css}"></span>` : '';
-            const playing = s.slot == activeSlot ? '<span class="now-playing-badge">NOW PLAYING</span>' : '';
-            tr.innerHTML = `
-                <td>${s.slot != null ? s.slot + 1 : '—'}</td>
-                <td>${dot}${s.name}${playing}</td>
-                <td>${s.bpm ?? '—'}</td>
-                <td>${s.key ?? '—'}</td>
-                <td>${s.mode ?? '—'}</td>
-                <td>${s.camelot ? `<span class="camelot-badge">${s.camelot}</span>` : '—'}</td>
-            `;
+
+            const padCell = document.createElement('td');
+            padCell.textContent = s.slot != null ? s.slot + 1 : '—';
+            tr.appendChild(padCell);
+
+            const nameCell = document.createElement('td');
+            if (s.color_css) {
+                const dot = document.createElement('span');
+                dot.className = 'color-dot';
+                dot.style.background = s.color_css;
+                nameCell.appendChild(dot);
+            }
+            nameCell.append(document.createTextNode(s.name ?? '—'));
+            if (s.slot == activeSlot) {
+                const playing = document.createElement('span');
+                playing.className = 'now-playing-badge';
+                playing.textContent = 'NOW PLAYING';
+                nameCell.appendChild(playing);
+            }
+            tr.appendChild(nameCell);
+
+            [s.bpm, s.key, s.mode].forEach(value => {
+                const cell = document.createElement('td');
+                cell.textContent = value ?? '—';
+                tr.appendChild(cell);
+            });
+
+            const camelotCell = document.createElement('td');
+            if (s.camelot) {
+                const badge = document.createElement('span');
+                badge.className = 'camelot-badge';
+                badge.textContent = s.camelot;
+                camelotCell.appendChild(badge);
+            } else {
+                camelotCell.textContent = '—';
+            }
+            tr.appendChild(camelotCell);
             tbody.appendChild(tr);
         });
     }

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -19,6 +19,41 @@
 <div id="overview-error" style="color:#d73a49;margin:1rem 0;"></div>
 
 <div id="overview-content" style="display:none;">
+    <!-- Restore Mode Toggle -->
+    <div style="margin-bottom:1rem;">
+        <button id="restore-mode-btn" class="overview-filter-btn" onclick="toggleRestoreMode()">+ Restore Set</button>
+    </div>
+
+    <!-- Restore Form (shown when in restore mode) -->
+    <div id="restore-form-container" style="display:none;margin-bottom:1.5rem;padding:1rem;background:var(--ov-bg2);border:1px solid var(--ov-border);border-radius:4px;">
+        <div id="restore-message" style="margin-bottom:1rem;"></div>
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-end;">
+            <div>
+                <label for="ablbundle" style="font-size:0.8rem;">Set file (.ablbundle/.abl):</label>
+                <input type="file" id="ablbundle" name="ablbundle" accept=".ablbundle,.abl" style="margin-bottom:0;">
+            </div>
+            <div>
+                <label style="font-size:0.8rem;">Pad Color:</label>
+                <div class="color-dropdown" id="color-dropdown">
+                    <div class="dropdown-toggle" onclick="toggleColorDropdown()">
+                        <span class="color-preview" id="selected-color-preview"></span>
+                        <span id="selected-color-name">Select...</span>
+                        <span class="dropdown-arrow">▼</span>
+                    </div>
+                    <div class="dropdown-menu" id="color-dropdown-menu" style="display:none;"></div>
+                </div>
+                <input type="hidden" id="pad_color" name="pad_color" value="">
+            </div>
+            <div id="target-pad-display" style="font-size:0.9rem;color:var(--ov-text-mid);">
+                Click a <strong>free pad</strong> below
+            </div>
+            <input type="hidden" id="target_pad" name="target_pad" value="">
+            <button id="restore-btn" onclick="submitRestore()" disabled style="margin:0;">Upload & Restore</button>
+            <button type="button" onclick="toggleRestoreMode()" style="margin:0;background:transparent;color:var(--ov-text);">Cancel</button>
+        </div>
+    </div>
+
+    <!-- Main Pad Grid (shared between view and restore modes) -->
     <div class="overview-pad-grid" id="pad-grid"></div>
 
     <div style="margin:1rem 0;">
@@ -240,6 +275,99 @@
         margin-left: 0.4rem;
         vertical-align: middle;
     }
+    /* Color dropdown for restore */
+    .color-dropdown {
+        position: relative;
+        display: inline-block;
+        min-width: 200px;
+    }
+    .dropdown-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem;
+        border: 1px solid var(--ov-border);
+        border-radius: 4px;
+        cursor: pointer;
+        background: var(--ov-bg);
+    }
+    .dropdown-toggle:hover {
+        border-color: #999;
+    }
+    .color-preview {
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        border-radius: 3px;
+        border: 1px solid rgba(0,0,0,0.2);
+    }
+    .dropdown-arrow {
+        margin-left: auto;
+        font-size: 0.7rem;
+    }
+    .dropdown-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: var(--ov-bg);
+        border: 1px solid var(--ov-border);
+        border-radius: 4px;
+        margin-top: 2px;
+        max-height: 300px;
+        overflow-y: auto;
+        z-index: 100;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .dropdown-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem;
+        cursor: pointer;
+    }
+    .dropdown-item:hover {
+        background: var(--ov-bg2);
+    }
+    /* Restore mode - main grid free pads are selectable */
+    #pad-grid.restore-mode .overview-pad-cell.free {
+        cursor: pointer;
+        border: 2px dashed #ccc;
+    }
+    #pad-grid.restore-mode .overview-pad-cell.free:hover {
+        border-color: #0000ff;
+        border-style: solid;
+    }
+    #pad-grid.restore-mode .overview-pad-cell.free.selected {
+        border-color: #0000ff !important;
+        border-style: solid !important;
+        background: rgba(0,0,255,0.15) !important;
+    }
+    #pad-grid.restore-mode .overview-pad-cell.occupied {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free {
+        border-color: #444;
+    }
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free:hover,
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+        border-color: #4dd9d9 !important;
+    }
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+        background: rgba(77,217,217,0.2) !important;
+    }
+    /* Restore form button styling */
+    #restore-mode-btn.active {
+        background: #0000ff;
+        border-color: #0000ff;
+        color: white;
+    }
+    #app-wrap.dark #restore-mode-btn.active {
+        background: #4dd9d9;
+        border-color: #4dd9d9;
+        color: #000;
+    }
 </style>
 
 <script>
@@ -301,6 +429,10 @@
         renderTable(sets, activeSlot);
     }
 
+    // Restore mode state
+    let restoreMode = false;
+    let selectedTargetPad = null;
+
     function renderPadGrid(sets, activeSlot) {
         const grid = document.getElementById('pad-grid');
         grid.innerHTML = '';
@@ -311,9 +443,10 @@
             for (let col = 0; col < 8; col++) {
                 const i = row * 8 + col;
                 const cell = document.createElement('div');
-                cell.className = 'overview-pad-cell';
                 const s = bySlot[i];
                 if (s) {
+                    // Occupied pad
+                    cell.className = 'overview-pad-cell occupied';
                     const isDark = document.getElementById('app-wrap').classList.contains('dark');
                     const isActive = s.slot == activeSlot;
                     if (s.color_css) cell.style.borderColor = s.color_css;
@@ -331,6 +464,13 @@
                         ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
                     `;
                 } else {
+                    // Free pad
+                    cell.className = 'overview-pad-cell free';
+                    cell.dataset.padNum = i + 1;
+                    // Add click handler for restore mode
+                    if (restoreMode) {
+                        cell.onclick = () => selectTargetPad(i + 1, cell);
+                    }
                     cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
                 }
                 grid.appendChild(cell);
@@ -391,10 +531,220 @@
 
     // Overview page now uses global dark mode from base.html
 
+    // ==================== RESTORE FUNCTIONALITY ====================
+    let padColors = [];
+    let padColorNames = [];
+
+    async function loadPadColors() {
+        try {
+            const res = await fetch('/overview/api/colors');
+            const data = await res.json();
+            padColors = data.colors;
+            padColorNames = data.names;
+            buildColorDropdown();
+            // Select first color by default
+            if (padColors.length > 0) {
+                selectColor(0);
+            }
+        } catch (e) {
+            console.error('Failed to load pad colors:', e);
+        }
+    }
+
+    function buildColorDropdown() {
+        const menu = document.getElementById('color-dropdown-menu');
+        menu.innerHTML = '';
+        padColors.forEach((color, idx) => {
+            const item = document.createElement('div');
+            item.className = 'dropdown-item';
+            item.onclick = () => selectColor(idx);
+            item.innerHTML = `
+                <span class="color-preview" style="background:rgb(${color[0]},${color[1]},${color[2]})"></span>
+                <span>${padColorNames[idx]}</span>
+            `;
+            menu.appendChild(item);
+        });
+    }
+
+    function toggleColorDropdown() {
+        const menu = document.getElementById('color-dropdown-menu');
+        menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+    }
+
+    function selectColor(idx) {
+        const color = padColors[idx];
+        document.getElementById('selected-color-preview').style.background = `rgb(${color[0]},${color[1]},${color[2]})`;
+        document.getElementById('selected-color-name').textContent = padColorNames[idx];
+        document.getElementById('pad_color').value = idx + 1; // 1-indexed color ID
+        document.getElementById('color-dropdown-menu').style.display = 'none';
+        updateRestoreButton();
+    }
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function(e) {
+        const dropdown = document.getElementById('color-dropdown');
+        if (!dropdown.contains(e.target)) {
+            document.getElementById('color-dropdown-menu').style.display = 'none';
+        }
+    });
+
+    function renderRestoreGrid(sets) {
+        restoreAllSets = sets;
+        const grid = document.getElementById('restore-pad-grid');
+        grid.innerHTML = '';
+        const bySlot = {};
+        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
+
+        // Build rows bottom-to-top to match physical Move hardware layout
+        for (let row = 3; row >= 0; row--) {
+            for (let col = 0; col < 8; col++) {
+                const i = row * 8 + col;
+                const cell = document.createElement('div');
+                const s = bySlot[i];
+                const isDark = document.getElementById('app-wrap').classList.contains('dark');
+
+                if (s) {
+                    // Occupied pad
+                    cell.className = 'overview-pad-cell occupied';
+                    const isActive = s.slot == activeSlot;
+                    if (s.color_css) cell.style.borderColor = s.color_css;
+                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
+                    if (isActive) {
+                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
+                    } else if (s.color_css) {
+                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
+                    }
+                    if (isActive) cell.classList.add('active');
+                    cell.title = s.name;
+                    cell.innerHTML = `
+                        <div class="pad-num">${i + 1}</div>
+                        <div class="pad-name">${s.name}</div>
+                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
+                    `;
+                } else {
+                    // Free pad - selectable in restore mode
+                    cell.className = 'overview-pad-cell free';
+                    cell.dataset.padNum = i + 1;
+                    // Add click handler only in restore mode
+                    if (restoreMode) {
+                        cell.onclick = () => selectTargetPad(i + 1, cell);
+                    }
+                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+                }
+                grid.appendChild(cell);
+            }
+        }
+    }
+
+    function toggleRestoreMode() {
+        restoreMode = !restoreMode;
+        const btn = document.getElementById('restore-mode-btn');
+        const form = document.getElementById('restore-form-container');
+        const grid = document.getElementById('pad-grid');
+
+        if (restoreMode) {
+            btn.textContent = '✕ Cancel Restore';
+            btn.classList.add('active');
+            form.style.display = 'block';
+            grid.classList.add('restore-mode');
+        } else {
+            btn.textContent = '+ Restore Set';
+            btn.classList.remove('active');
+            form.style.display = 'none';
+            grid.classList.remove('restore-mode');
+            // Clear selection
+            selectedTargetPad = null;
+            document.getElementById('target_pad').value = '';
+            document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
+            document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+                c.classList.remove('selected');
+            });
+        }
+        // Re-render grid to add/remove click handlers
+        const filtered = activeCamelot ? allSets.filter(s => s.camelot === activeCamelot) : allSets;
+        render(filtered, currentSlot);
+    }
+
+    function selectTargetPad(padNum, cellElement) {
+        // Deselect previous
+        document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+            c.classList.remove('selected');
+        });
+
+        // Select new
+        selectedTargetPad = padNum;
+        cellElement.classList.add('selected');
+        document.getElementById('target_pad').value = padNum;
+        document.getElementById('target-pad-display').textContent = `Pad ${padNum}`;
+        updateRestoreButton();
+    }
+
+    function updateRestoreButton() {
+        const hasFile = document.getElementById('ablbundle').files.length > 0;
+        const hasColor = document.getElementById('pad_color').value !== '';
+        const hasPad = selectedTargetPad !== null;
+        document.getElementById('restore-btn').disabled = !(hasFile && hasColor && hasPad);
+    }
+
+    async function submitRestore() {
+        const btn = document.getElementById('restore-btn');
+        const msg = document.getElementById('restore-message');
+        btn.disabled = true;
+        btn.textContent = 'Restoring...';
+
+        const formData = new FormData();
+        formData.append('ablbundle', document.getElementById('ablbundle').files[0]);
+        formData.append('pad_color', document.getElementById('pad_color').value);
+        formData.append('target_pad', document.getElementById('target_pad').value);
+
+        try {
+            const res = await fetch('/overview/api/restore', {
+                method: 'POST',
+                body: formData
+            });
+            const result = await res.json();
+
+            if (result.success) {
+                msg.innerHTML = `<p class="success">${result.message}</p>`;
+                // Reset form
+                document.getElementById('ablbundle').value = '';
+                selectedTargetPad = null;
+                document.getElementById('target_pad').value = '';
+                document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
+                document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+                    c.classList.remove('selected');
+                });
+                selectColor(0); // Reset to first color
+                // Exit restore mode after short delay
+                setTimeout(() => {
+                    toggleRestoreMode();
+                    msg.innerHTML = '';
+                }, 2000);
+                // Reload data to show new set
+                await loadData();
+            } else {
+                msg.innerHTML = `<p class="error">${result.message}</p>`;
+            }
+        } catch (e) {
+            msg.innerHTML = `<p class="error">Error: ${e.message}</p>`;
+        } finally {
+            btn.disabled = false;
+            btn.textContent = 'Upload & Restore';
+        }
+    }
+
+    // Event listeners
+    document.getElementById('ablbundle').addEventListener('change', updateRestoreButton);
+
+    // Initialize
+    loadPadColors();
+
+    // ==================== END RESTORE FUNCTIONALITY ====================
+
     loadData();
     pollSystemStats();
     setInterval(loadData, 30000);
-    setInterval(pollActiveSlot, 2000);
-    setInterval(pollSystemStats, 5000);
+    setInterval(pollActiveSlot, 2002);
+    setInterval(pollSystemStats, 5005);
 </script>
 {% endblock %}

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -1,0 +1,337 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Move Over (view)</h2>
+
+<div class="overview-stats">
+    <div class="overview-stat-box">
+        <div class="overview-stat-label">STORAGE: <span id="disk-text">—</span></div>
+        <div class="overview-bar-track"><div class="overview-bar-fill" id="disk-fill" style="width:0%"></div></div>
+    </div>
+    <div class="overview-stat-box">
+        <div class="overview-stat-label">MEMORY: <span id="mem-text">—</span></div>
+        <div class="overview-bar-track"><div class="overview-bar-fill overview-bar-mem" id="mem-fill" style="width:0%"></div></div>
+        <div class="overview-stat-label" style="margin-top:6px;">LOAD: <span id="load-text">—</span></div>
+    </div>
+</div>
+
+<div id="overview-loading" style="color:#888;margin:1rem 0;">Loading sets…</div>
+<div id="overview-error" style="color:#d73a49;margin:1rem 0;"></div>
+
+<div id="overview-content" style="display:none;">
+    <div class="overview-pad-grid" id="pad-grid"></div>
+
+    <div style="margin:1rem 0;">
+        <label style="display:inline;font-weight:400;margin-right:0.5rem;">Filter by Camelot key:</label>
+        <button class="overview-filter-btn active" onclick="filterByCamelot(null, this)">All</button>
+        <span id="camelot-filter-btns"></span>
+    </div>
+
+    <table class="overview-table" id="sets-table">
+        <thead>
+            <tr>
+                <th>Pad</th>
+                <th>Name</th>
+                <th>BPM</th>
+                <th>Key</th>
+                <th>Mode</th>
+                <th>Camelot</th>
+            </tr>
+        </thead>
+        <tbody id="sets-tbody"></tbody>
+    </table>
+
+    <div style="color:#888;font-size:0.75rem;margin-top:0.75rem;">
+        Sets refresh every 30s &nbsp;·&nbsp; Active pad updates every 2s
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<style>
+    .overview-stats {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+    }
+    .overview-stat-box {
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+    }
+    .overview-stat-label { margin-bottom: 0.4rem; }
+    .overview-bar-track {
+        background: #e0e0e0;
+        border-radius: 2px;
+        height: 12px;
+        overflow: hidden;
+    }
+    .overview-bar-fill {
+        height: 100%;
+        background: #0000ff;
+        border-radius: 2px;
+        transition: width 0.4s;
+    }
+    .overview-bar-mem { background: #8b5cf6; }
+
+    .overview-pad-grid {
+        display: grid;
+        grid-template-columns: repeat(8, 1fr);
+        gap: 0.4rem;
+        margin-bottom: 1.5rem;
+        max-width: 640px;
+    }
+    .overview-pad-cell {
+        border-radius: 4px;
+        padding: 0.4rem 0.25rem;
+        text-align: center;
+        font-size: 0.7rem;
+        font-weight: 500;
+        aspect-ratio: 4/3;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: #f0f0f0;
+        border: 2px solid transparent;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+    .overview-pad-cell.active {
+        border-color: #ff764d;
+        box-shadow: 0 0 0 2px rgba(255,118,77,0.3);
+        animation: overview-pulse 2s ease-in-out infinite;
+    }
+    .overview-pad-cell .pad-num {
+        font-size: 0.6rem;
+        color: #888;
+        line-height: 1;
+    }
+    .overview-pad-cell .pad-name {
+        font-size: 0.65rem;
+        word-break: break-word;
+        line-height: 1.2;
+        max-height: 2.4em;
+        overflow: hidden;
+    }
+    .overview-pad-cell .pad-bpm {
+        font-size: 0.6rem;
+        color: #555;
+    }
+    @keyframes overview-pulse {
+        0%, 100% { box-shadow: 0 0 0 2px rgba(255,118,77,0.3); }
+        50%       { box-shadow: 0 0 0 5px rgba(255,118,77,0.5); }
+    }
+
+    .overview-filter-btn {
+        background: transparent;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        padding: 0.2rem 0.6rem;
+        font-size: 0.8rem;
+        color: #444;
+        cursor: pointer;
+        margin-right: 0.25rem;
+        margin-bottom: 0.25rem;
+        font-family: 'Ableton Sans', Arial, sans-serif;
+    }
+    .overview-filter-btn.active {
+        background: #0000ff;
+        border-color: #0000ff;
+        color: white;
+    }
+
+    .overview-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.875rem;
+    }
+    .overview-table th {
+        text-align: left;
+        padding: 0.4rem 0.6rem;
+        border-bottom: 2px solid #ddd;
+        font-weight: 500;
+        color: #444;
+    }
+    .overview-table td {
+        padding: 0.35rem 0.6rem;
+        border-bottom: 1px solid #eee;
+    }
+    .overview-table tr.active-row td {
+        background: #fff5f0;
+        font-weight: 500;
+    }
+    .camelot-badge {
+        display: inline-block;
+        padding: 0.1rem 0.4rem;
+        border-radius: 3px;
+        font-size: 0.75rem;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+    }
+    .color-dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        margin-right: 0.3rem;
+        vertical-align: middle;
+        border: 1px solid rgba(0,0,0,0.15);
+    }
+    .now-playing-badge {
+        display: inline-block;
+        background: #ff764d;
+        color: white;
+        font-size: 0.65rem;
+        padding: 0.1rem 0.35rem;
+        border-radius: 2px;
+        margin-left: 0.4rem;
+        vertical-align: middle;
+    }
+</style>
+
+<script>
+    let allSets = [];
+    let currentSlot = null;
+    let activeCamelot = null;
+
+    async function loadData() {
+        try {
+            const res = await fetch('/overview/api/data');
+            const d = await res.json();
+            if (d.error) {
+                document.getElementById('overview-error').textContent = 'Error: ' + d.error;
+                return;
+            }
+            allSets = d.sets || [];
+            currentSlot = d.current_slot;
+            document.getElementById('overview-loading').style.display = 'none';
+            document.getElementById('overview-content').style.display = '';
+
+            if (d.disk) {
+                document.getElementById('disk-text').textContent =
+                    `${d.disk.used_gb} GB / ${d.disk.total_gb} GB — ${d.disk.percent_used}%`;
+                const df = document.getElementById('disk-fill');
+                df.style.width = d.disk.percent_used + '%';
+                df.style.background = d.disk.percent_used > 80 ? '#d73a49' : '#0000ff';
+            }
+
+            buildCamelotFilters(allSets);
+            render(allSets, currentSlot);
+        } catch (e) {
+            document.getElementById('overview-error').textContent = 'Failed to load data.';
+        }
+    }
+
+    function buildCamelotFilters(sets) {
+        const codes = [...new Set(sets.map(s => s.camelot).filter(Boolean))].sort();
+        const container = document.getElementById('camelot-filter-btns');
+        container.innerHTML = '';
+        codes.forEach(code => {
+            const btn = document.createElement('button');
+            btn.className = 'overview-filter-btn';
+            btn.textContent = code;
+            btn.onclick = () => filterByCamelot(code, btn);
+            container.appendChild(btn);
+        });
+    }
+
+    function filterByCamelot(code, btn) {
+        activeCamelot = code;
+        document.querySelectorAll('.overview-filter-btn').forEach(b => b.classList.remove('active'));
+        if (btn) btn.classList.add('active');
+        const filtered = code ? allSets.filter(s => s.camelot === code) : allSets;
+        render(filtered, currentSlot);
+    }
+
+    function render(sets, activeSlot) {
+        renderPadGrid(sets, activeSlot);
+        renderTable(sets, activeSlot);
+    }
+
+    function renderPadGrid(sets, activeSlot) {
+        const grid = document.getElementById('pad-grid');
+        grid.innerHTML = '';
+        const bySlot = {};
+        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
+        for (let i = 0; i < 32; i++) {
+            const cell = document.createElement('div');
+            cell.className = 'overview-pad-cell';
+            const s = bySlot[i];
+            if (s) {
+                if (s.color_css) cell.style.background = s.color_css + '33';
+                if (s.color_css) cell.style.borderColor = s.color_css;
+                if (s.slot == activeSlot) cell.classList.add('active');
+                cell.innerHTML = `
+                    <div class="pad-num">${i + 1}</div>
+                    <div class="pad-name">${s.name}</div>
+                    ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
+                `;
+            } else {
+                cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+            }
+            grid.appendChild(cell);
+        }
+    }
+
+    function renderTable(sets, activeSlot) {
+        const tbody = document.getElementById('sets-tbody');
+        tbody.innerHTML = '';
+        const sorted = [...sets].sort((a, b) => (a.slot ?? 999) - (b.slot ?? 999));
+        sorted.forEach(s => {
+            const tr = document.createElement('tr');
+            if (s.slot == activeSlot) tr.className = 'active-row';
+            const dot = s.color_css ? `<span class="color-dot" style="background:${s.color_css}"></span>` : '';
+            const playing = s.slot == activeSlot ? '<span class="now-playing-badge">NOW PLAYING</span>' : '';
+            tr.innerHTML = `
+                <td>${s.slot != null ? s.slot + 1 : '—'}</td>
+                <td>${dot}${s.name}${playing}</td>
+                <td>${s.bpm ?? '—'}</td>
+                <td>${s.key ?? '—'}</td>
+                <td>${s.mode ?? '—'}</td>
+                <td>${s.camelot ? `<span class="camelot-badge">${s.camelot}</span>` : '—'}</td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    async function pollActiveSlot() {
+        try {
+            const res = await fetch('/overview/api/active-slot');
+            const d = await res.json();
+            if (d.current_slot != null && d.current_slot !== currentSlot) {
+                currentSlot = d.current_slot;
+                const filtered = activeCamelot ? allSets.filter(s => s.camelot === activeCamelot) : allSets;
+                render(filtered, currentSlot);
+            }
+        } catch (e) {}
+    }
+
+    async function pollSystemStats() {
+        try {
+            const res = await fetch('/overview/api/system');
+            const d = await res.json();
+            if (d.mem_pct != null) {
+                document.getElementById('mem-text').textContent =
+                    `${d.mem_used_mb} MB / ${d.mem_total_mb} MB — ${d.mem_pct}%`;
+                const mf = document.getElementById('mem-fill');
+                mf.style.width = d.mem_pct + '%';
+                mf.style.background = d.mem_pct > 80 ? '#d73a49' : '#8b5cf6';
+            }
+            if (d.load_1 != null) {
+                document.getElementById('load-text').textContent =
+                    `${d.load_1.toFixed(2)} / ${d.load_5.toFixed(2)} / ${d.load_15.toFixed(2)} (1m/5m/15m)`;
+            }
+        } catch (e) {}
+    }
+
+    loadData();
+    pollSystemStats();
+    setInterval(loadData, 30000);
+    setInterval(pollActiveSlot, 2000);
+    setInterval(pollSystemStats, 5000);
+</script>
+{% endblock %}

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -54,7 +54,7 @@
     </div>
 
     <!-- Main Pad Grid (shared between view and restore modes) -->
-    <div class="overview-pad-grid" id="pad-grid"></div>
+    <div id="pad-grid">{{ pad_grid|safe }}</div>
 
     <div style="margin:1rem 0;">
         <label style="display:inline;font-weight:400;margin-right:0.5rem;">Filter by Camelot key:</label>
@@ -152,59 +152,6 @@
         transition: width 0.4s;
     }
     .overview-bar-mem { background: #8b5cf6; }
-
-    .overview-pad-grid {
-        display: grid;
-        grid-template-columns: repeat(8, 1fr);
-        gap: 0.35rem;
-        margin-bottom: 1.5rem;
-        max-width: 1100px;
-    }
-    .overview-pad-cell {
-        background: var(--ov-pad-empty);
-        color: var(--ov-text);
-        border-radius: 4px;
-        padding: 0.35rem 0.25rem;
-        text-align: center;
-        font-size: 0.8rem;
-        font-weight: 500;
-        aspect-ratio: 4/3;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        border: 2px solid transparent;
-        box-sizing: border-box;
-        overflow: hidden;
-    }
-    .overview-pad-cell.active {
-        border-color: #ff764d !important;
-        box-shadow: 0 0 0 3px rgba(255,118,77,0.5);
-        animation: overview-pulse 2s ease-in-out infinite;
-    }
-    .overview-pad-cell .pad-num {
-        color: var(--ov-text-dim);
-        font-size: 0.7rem;
-        line-height: 1;
-    }
-    .overview-pad-cell .pad-name {
-        font-size: 0.75rem;
-        line-height: 1.2;
-        width: 100%;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 4;
-        -webkit-box-orient: vertical;
-        line-clamp: 4;
-    }
-    .overview-pad-cell .pad-bpm {
-        color: var(--ov-text-mid);
-        font-size: 0.7rem;
-    }
-    @keyframes overview-pulse {
-        0%, 100% { box-shadow: 0 0 0 2px rgba(255,118,77,0.3); }
-        50%       { box-shadow: 0 0 0 5px rgba(255,118,77,0.5); }
-    }
 
     .overview-filter-btn {
         background: transparent;
@@ -330,31 +277,31 @@
         background: var(--ov-bg2);
     }
     /* Restore mode - main grid free pads are selectable */
-    #pad-grid.restore-mode .overview-pad-cell.free {
+    #pad-grid.restore-mode .pad-cell.free {
         cursor: pointer;
         border: 2px dashed #ccc;
     }
-    #pad-grid.restore-mode .overview-pad-cell.free:hover {
+    #pad-grid.restore-mode .pad-cell.free:hover {
         border-color: #0000ff;
         border-style: solid;
     }
-    #pad-grid.restore-mode .overview-pad-cell.free.selected {
+    #pad-grid.restore-mode .pad-cell.free.selected {
         border-color: #0000ff !important;
         border-style: solid !important;
         background: rgba(0,0,255,0.15) !important;
     }
-    #pad-grid.restore-mode .overview-pad-cell.occupied {
+    #pad-grid.restore-mode .pad-cell.occupied {
         opacity: 0.4;
         cursor: not-allowed;
     }
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free {
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free {
         border-color: #444;
     }
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free:hover,
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free:hover,
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free.selected {
         border-color: #4dd9d9 !important;
     }
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free.selected {
         background: rgba(77,217,217,0.2) !important;
     }
     /* Restore form button styling */
@@ -425,7 +372,7 @@
     }
 
     function render(sets, activeSlot) {
-        renderPadGrid(sets, activeSlot);
+        refreshPadGrid();
         renderTable(sets, activeSlot);
     }
 
@@ -433,47 +380,30 @@
     let restoreMode = false;
     let selectedTargetPad = null;
 
-    function renderPadGrid(sets, activeSlot) {
+    async function refreshPadGrid() {
+        const params = new URLSearchParams();
+        if (restoreMode) {
+            params.set('restore_mode', '1');
+        } else if (activeCamelot) {
+            params.set('camelot', activeCamelot);
+        }
+        const res = await fetch(`/overview/api/grid?${params}`);
+        const data = await res.json();
         const grid = document.getElementById('pad-grid');
-        grid.innerHTML = '';
-        const bySlot = {};
-        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
-        // Build rows bottom-to-top to match physical Move hardware layout
-        for (let row = 3; row >= 0; row--) {
-            for (let col = 0; col < 8; col++) {
-                const i = row * 8 + col;
-                const cell = document.createElement('div');
-                const s = bySlot[i];
-                if (s) {
-                    // Occupied pad
-                    cell.className = 'overview-pad-cell occupied';
-                    const isDark = document.getElementById('app-wrap').classList.contains('dark');
-                    const isActive = s.slot == activeSlot;
-                    if (s.color_css) cell.style.borderColor = s.color_css;
-                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
-                    if (isActive) {
-                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
-                    } else if (s.color_css) {
-                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
-                    }
-                    if (isActive) cell.classList.add('active');
-                    cell.title = s.name;
-                    cell.innerHTML = `
-                        <div class="pad-num">${i + 1}</div>
-                        <div class="pad-name">${s.name}</div>
-                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
-                    `;
-                } else {
-                    // Free pad
-                    cell.className = 'overview-pad-cell free';
-                    cell.dataset.padNum = i + 1;
-                    // Add click handler for restore mode
-                    if (restoreMode) {
-                        cell.onclick = () => selectTargetPad(i + 1, cell);
-                    }
-                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
-                }
-                grid.appendChild(cell);
+        grid.innerHTML = data.pad_grid;
+        grid.classList.toggle('restore-mode', restoreMode);
+
+        if (!restoreMode) return;
+
+        grid.querySelectorAll('input[name="overview_pad"]:not(:disabled)').forEach(input => {
+            input.addEventListener('change', () => selectTargetPad(Number(input.value)));
+        });
+
+        if (selectedTargetPad !== null) {
+            const input = document.getElementById(`pad_${selectedTargetPad}`);
+            if (input) {
+                input.checked = true;
+                input.nextElementSibling.classList.add('selected');
             }
         }
     }
@@ -588,92 +518,36 @@
         }
     });
 
-    function renderRestoreGrid(sets) {
-        restoreAllSets = sets;
-        const grid = document.getElementById('restore-pad-grid');
-        grid.innerHTML = '';
-        const bySlot = {};
-        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
-
-        // Build rows bottom-to-top to match physical Move hardware layout
-        for (let row = 3; row >= 0; row--) {
-            for (let col = 0; col < 8; col++) {
-                const i = row * 8 + col;
-                const cell = document.createElement('div');
-                const s = bySlot[i];
-                const isDark = document.getElementById('app-wrap').classList.contains('dark');
-
-                if (s) {
-                    // Occupied pad
-                    cell.className = 'overview-pad-cell occupied';
-                    const isActive = s.slot == activeSlot;
-                    if (s.color_css) cell.style.borderColor = s.color_css;
-                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
-                    if (isActive) {
-                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
-                    } else if (s.color_css) {
-                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
-                    }
-                    if (isActive) cell.classList.add('active');
-                    cell.title = s.name;
-                    cell.innerHTML = `
-                        <div class="pad-num">${i + 1}</div>
-                        <div class="pad-name">${s.name}</div>
-                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
-                    `;
-                } else {
-                    // Free pad - selectable in restore mode
-                    cell.className = 'overview-pad-cell free';
-                    cell.dataset.padNum = i + 1;
-                    // Add click handler only in restore mode
-                    if (restoreMode) {
-                        cell.onclick = () => selectTargetPad(i + 1, cell);
-                    }
-                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
-                }
-                grid.appendChild(cell);
-            }
-        }
-    }
-
-    function toggleRestoreMode() {
+    async function toggleRestoreMode() {
         restoreMode = !restoreMode;
         const btn = document.getElementById('restore-mode-btn');
         const form = document.getElementById('restore-form-container');
-        const grid = document.getElementById('pad-grid');
 
         if (restoreMode) {
             btn.textContent = '✕ Cancel Restore';
             btn.classList.add('active');
             form.style.display = 'block';
-            grid.classList.add('restore-mode');
         } else {
             btn.textContent = '+ Restore Set';
             btn.classList.remove('active');
             form.style.display = 'none';
-            grid.classList.remove('restore-mode');
-            // Clear selection
             selectedTargetPad = null;
             document.getElementById('target_pad').value = '';
             document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
-            document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
-                c.classList.remove('selected');
-            });
         }
-        // Re-render grid to add/remove click handlers
-        const filtered = activeCamelot ? allSets.filter(s => s.camelot === activeCamelot) : allSets;
-        render(filtered, currentSlot);
+
+        await refreshPadGrid();
     }
 
-    function selectTargetPad(padNum, cellElement) {
-        // Deselect previous
-        document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
-            c.classList.remove('selected');
+    function selectTargetPad(padNum) {
+        document.querySelectorAll('#pad-grid .pad-cell.free').forEach(cell => {
+            cell.classList.remove('selected');
         });
 
-        // Select new
         selectedTargetPad = padNum;
-        cellElement.classList.add('selected');
+        const input = document.getElementById(`pad_${padNum}`);
+        input.checked = true;
+        input.nextElementSibling.classList.add('selected');
         document.getElementById('target_pad').value = padNum;
         document.getElementById('target-pad-display').textContent = `Pad ${padNum}`;
         updateRestoreButton();
@@ -711,7 +585,7 @@
                 selectedTargetPad = null;
                 document.getElementById('target_pad').value = '';
                 document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
-                document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+                document.querySelectorAll('#pad-grid .pad-cell.free').forEach(c => {
                     c.classList.remove('selected');
                 });
                 selectColor(0); // Reset to first color

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -101,26 +101,16 @@ def test_lfo_get(client, monkeypatch):
     assert b'id="amount"' in resp.data
     assert b'id="attack"' in resp.data
 
-def test_restore_get(client, monkeypatch):
-    def fake_get():
-        return {'options': '<option value="1">1</option>', 'pad_grid': '<div class="pad-grid"></div>', 'message': ''}
-    monkeypatch.setattr(move_webserver.restore_handler, 'handle_get', fake_get)
+def test_restore_get(client):
     resp = client.get('/restore')
-    assert resp.status_code == 200
-    assert b'class="pad-grid"' in resp.data
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/overview')
 
-def test_restore_post(client, monkeypatch):
-    def fake_handle_post(form):
-        return {'message': 'restored', 'message_type': 'success', 'pad_grid': '<div class="pad-grid"></div>', 'options': ''}
-    monkeypatch.setattr(move_webserver.restore_handler, 'handle_post', fake_handle_post)
-    data = {
-        'action': 'restore_ablbundle',
-        'mset_index': '1',
-        'mset_color': '1'
-    }
-    resp = client.post('/restore', data=data, content_type='multipart/form-data')
-    assert resp.status_code == 200
-    assert b'restored' in resp.data
+
+def test_restore_post(client):
+    resp = client.post('/restore')
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/overview')
 
 
 def test_overview_restore_post(client, monkeypatch):
@@ -486,7 +476,7 @@ def test_refresh_get(client, monkeypatch):
 def test_index_redirect(client):
     resp = client.get('/')
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/restore')
+    assert resp.headers['Location'].endswith('/overview')
 
 
 def test_browse_dir(client, tmp_path):

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -122,6 +122,34 @@ def test_restore_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'restored' in resp.data
 
+
+def test_overview_restore_post(client, monkeypatch):
+    def fake_handle_post_restore(form):
+        assert form.getvalue('target_pad') == '8'
+        assert form.getvalue('pad_color') == '4'
+        assert form['ablbundle'].filename == 'test.ablbundle'
+        assert form['ablbundle'].file.read() == b'bundle-data'
+        return {'success': True, 'message': 'restored'}
+
+    monkeypatch.setattr(
+        move_webserver.overview_handler,
+        'handle_post_restore',
+        fake_handle_post_restore,
+    )
+    resp = client.post(
+        '/overview/api/restore',
+        data={
+            'target_pad': '8',
+            'pad_color': '4',
+            'ablbundle': (io.BytesIO(b'bundle-data'), 'test.ablbundle'),
+        },
+        content_type='multipart/form-data',
+    )
+
+    assert resp.status_code == 200
+    assert resp.json == {'success': True, 'message': 'restored'}
+
+
 def test_slice_post(client, monkeypatch):
     def fake_handle_post(form):
         return {'message': 'sliced', 'message_type': 'success'}

--- a/tests/test_list_msets_handler.py
+++ b/tests/test_list_msets_handler.py
@@ -1,9 +1,37 @@
+import os
 import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from core import list_msets_handler as lmh
+
+
+def test_parse_bpm_cache_invalidates_when_song_changes(tmp_path, monkeypatch):
+    song_path = tmp_path / "SetA" / "Song.abl"
+    song_path.parent.mkdir()
+    song_path.write_text('{"tempo": 120}')
+    lmh._BPM_CACHE.clear()
+    calls = 0
+    original_load = lmh.json.load
+
+    def tracking_load(file):
+        nonlocal calls
+        calls += 1
+        return original_load(file)
+
+    monkeypatch.setattr(lmh.json, "load", tracking_load)
+
+    assert lmh._parse_bpm_from_song(str(song_path.parent)) == 120.0
+    assert lmh._parse_bpm_from_song(str(song_path.parent)) == 120.0
+    assert calls == 1
+
+    song_path.write_text('{"tempo": 140}')
+    stat = song_path.stat()
+    os.utime(song_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1))
+
+    assert lmh._parse_bpm_from_song(str(song_path.parent)) == 140.0
+    assert calls == 2
 
 
 def test_list_msets_no_directory(tmp_path, monkeypatch):

--- a/tests/test_overview_handler.py
+++ b/tests/test_overview_handler.py
@@ -35,6 +35,32 @@ def test_generate_pad_grid_html_uses_shared_grid(monkeypatch):
     assert '120.0 BPM' in html
 
 
+def test_generate_pad_grid_html_escapes_set_names(monkeypatch):
+    malicious_name = '<img src=x onerror="alert(1)">'
+    monkeypatch.setattr(
+        overview_module,
+        "get_sets_data",
+        lambda: {
+            "sets": [
+                {
+                    "slot": 5,
+                    "xattr_color": 1,
+                    "color_id": 1,
+                    "name": malicious_name,
+                    "bpm": 120.0,
+                    "camelot": "8B",
+                }
+            ],
+            "current_slot": None,
+        },
+    )
+
+    html = OverviewHandler().generate_pad_grid_html()
+
+    assert malicious_name not in html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
+
+
 def test_generate_pad_grid_html_restore_mode_selects_only_free_pads(monkeypatch):
     monkeypatch.setattr(
         overview_module,

--- a/tests/test_overview_handler.py
+++ b/tests/test_overview_handler.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers.overview_handler_class import OverviewHandler
+import handlers.overview_handler_class as overview_module
+
+
+def test_generate_pad_grid_html_uses_shared_grid(monkeypatch):
+    monkeypatch.setattr(
+        overview_module,
+        "get_sets_data",
+        lambda: {
+            "sets": [
+                {
+                    "slot": 5,
+                    "xattr_color": 3,
+                    "color_id": 4,
+                    "name": "Test Set",
+                    "bpm": 120.0,
+                    "camelot": "8B",
+                }
+            ],
+            "current_slot": 5,
+        },
+    )
+
+    html = OverviewHandler().generate_pad_grid_html()
+
+    assert 'class="pad-grid view-only"' in html
+    assert 'id="pad_6" name="overview_pad" value="6"' in html
+    assert 'class="pad-cell occupied active"' in html
+    assert 'Test Set' in html
+    assert '120.0 BPM' in html
+
+
+def test_generate_pad_grid_html_restore_mode_selects_only_free_pads(monkeypatch):
+    monkeypatch.setattr(
+        overview_module,
+        "get_sets_data",
+        lambda: {
+            "sets": [
+                {
+                    "slot": 5,
+                    "xattr_color": 3,
+                    "color_id": 4,
+                    "name": "Test Set",
+                    "bpm": 120.0,
+                    "camelot": "8B",
+                }
+            ],
+            "current_slot": 5,
+        },
+    )
+
+    html = OverviewHandler().generate_pad_grid_html(restore_mode=True)
+
+    assert 'class="pad-grid"' in html
+    assert 'id="pad_6" name="overview_pad" value="6" disabled' in html
+    assert 'id="pad_7" name="overview_pad" value="7" ' in html

--- a/tests/test_pad_colors.py
+++ b/tests/test_pad_colors.py
@@ -3,9 +3,16 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from core.pad_colors import rgb_string
+from core.pad_colors import move_color_to_ui, rgb_string
 
 
 def test_rgb_string_valid_and_invalid():
     assert rgb_string(1) == "rgb(255, 25, 23)"
     assert rgb_string(999) == ""
+
+
+def test_move_zero_color_aliases_the_first_palette_color():
+    assert move_color_to_ui(0) == 1
+    assert move_color_to_ui(1) == 1
+    assert move_color_to_ui(24) == 24
+    assert move_color_to_ui(None) is None

--- a/tests/test_restore_handler_utils.py
+++ b/tests/test_restore_handler_utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from handlers.restore_handler_class import RestoreHandler
+from handlers.overview_handler_class import OverviewHandler
+import handlers.overview_handler_class as overview_module
 
 
 def test_generate_pad_options_empty():
@@ -21,10 +23,10 @@ def test_generate_pad_options_some():
 
 def test_generate_pad_grid():
     h = RestoreHandler()
-    html = h.generate_pad_grid({0, 31}, {0: 1})
+    html = h.generate_pad_grid({0, 31}, {0: 1}, input_name="mset_index", free_only=True)
     assert html.count('class="pad-cell occupied"') == 2
-    assert 'restore_pad_1" name="mset_index" value="1" disabled' in html
-    assert 'background-color: rgb(' in html
+    assert 'id="pad_1" name="mset_index" value="1" disabled' in html
+    assert 'background-color: rgba(' in html
 
 def test_generate_color_options_custom():
     h = RestoreHandler()
@@ -33,3 +35,33 @@ def test_generate_color_options_custom():
     assert 'name="clr"' in html
     assert 'padName = "pad"' in html
     assert 'color-dropdown' in html
+
+
+def test_overview_restore_message_uses_ui_pad_number(monkeypatch, tmp_path):
+    class Form(dict):
+        def getvalue(self, name, default=None):
+            return self.get(name, default)
+
+    upload_path = tmp_path / "test.abl"
+    upload_path.write_text("{}")
+    handler = OverviewHandler()
+    monkeypatch.setattr(
+        handler,
+        "handle_file_upload",
+        lambda form, field_name: (True, str(upload_path), None),
+    )
+    monkeypatch.setattr(
+        overview_module,
+        "restore_abl",
+        lambda filepath, pad, color: {
+            "success": True,
+            "message": f"Successfully restored test to pad {pad}",
+        },
+    )
+
+    result = handler.handle_post_restore(
+        Form({"target_pad": "6", "pad_color": "1"})
+    )
+
+    assert result["success"]
+    assert result["message"] == "Successfully restored test to pad 6"

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -39,7 +39,7 @@ def test_generate_pad_grid():
     assert html.count('class="pad-cell occupied"') == 2
     assert html.count('name="pad_index"') == 32
     # Selected pad should have "checked" attribute
-    assert 'inspect_pad_32" name="pad_index" value="32" checked' in html
+    assert 'id="pad_32" name="pad_index" value="32" checked' in html
 
 
 def test_generate_clip_grid():


### PR DESCRIPTION
**Add "Move Over (view)" — pad grid overview tab**

Adds a new Overview tab as the first tab in the nav, providing a "second screen" view of all sets on the device.

Features:

* 32-pad grid (bottom-to-top, matching hardware layout) with set name, BPM, and pad color
* Active pad highlighted with color fill + pulsing border, polling every 2s via Settings.json
* Storage, memory, and CPU load bars
* Sets table with BPM, key, mode, and Camelot wheel code
* Camelot key filter buttons
* Dark/light theme toggle with localStorage persistence

Implementation notes:

* New core/overview_handler.py — all logic, uses os.getxattr() instead of subprocess/getfattr
* New handlers/overview_handler_class.py — thin wrapper
* New templates_jinja/overview.html — self-contained styles + vanilla JS
* Three new routes under /overview/ — no impact on existing routes
* No new dependencies