### PR TITLE
DRAFT: Multi MIDI File Import

### DIFF
--- a/core/filter_visualizer.py
+++ b/core/filter_visualizer.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from scipy import signal
 
@@ -98,7 +100,7 @@ def compute_filter_response(
 
 def compute_chain_response(
     filter1: dict,
-    filter2: dict | None = None,
+    filter2: Optional[dict] = None,
     routing: str = "Serial",
     sr: int = 44100,
     n: int = 512,

--- a/core/lfo_handler.py
+++ b/core/lfo_handler.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Defaults for the LFO visualizer."""
 
-from typing import Dict
+from typing import Dict, Union
 
 
-def get_lfo_defaults() -> Dict[str, float | str]:
+def get_lfo_defaults() -> Dict[str, Union[float, str]]:
     """Return default values for the LFO visualizer."""
     return {
         "shape": "sine",

--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -4,6 +4,8 @@ import json
 from core.config import MSETS_DIRECTORY
 from core.pad_colors import move_color_to_ui
 
+_BPM_CACHE = {}
+
 def get_xattr_value(relative_path, attr):
     """
     Retrieve the extended attribute value for a given file or directory.
@@ -29,10 +31,16 @@ def _parse_bpm_from_song(set_path):
     """Parse BPM from Song.abl file. Returns None if not found."""
     try:
         abl_path = os.path.join(set_path, 'Song.abl')
+        modified_ns = os.stat(abl_path).st_mtime_ns
+        cached = _BPM_CACHE.get(abl_path)
+        if cached and cached[0] == modified_ns:
+            return cached[1]
         with open(abl_path, 'r') as f:
             data = json.load(f)
         tempo = data.get('tempo')
-        return round(float(tempo), 1) if tempo else None
+        bpm = round(float(tempo), 1) if tempo else None
+        _BPM_CACHE[abl_path] = (modified_ns, bpm)
+        return bpm
     except Exception:
         return None
 

--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import json
 from core.config import MSETS_DIRECTORY
 
 def get_xattr_value(relative_path, attr):
@@ -22,6 +23,18 @@ def get_xattr_value(relative_path, attr):
         return output
     except subprocess.CalledProcessError:
         return "Unknown"
+
+def _parse_bpm_from_song(set_path):
+    """Parse BPM from Song.abl file. Returns None if not found."""
+    try:
+        abl_path = os.path.join(set_path, 'Song.abl')
+        with open(abl_path, 'r') as f:
+            data = json.load(f)
+        tempo = data.get('tempo')
+        return round(float(tempo), 1) if tempo else None
+    except Exception:
+        return None
+
 
 def list_msets(return_free_ids=False):
     """
@@ -58,6 +71,13 @@ def list_msets(return_free_ids=False):
             mset_extmodified = get_xattr_value(uuid, "user.was-externally-modified")
 
             mset_id_value = int(mset_id) if mset_id.isdigit() else 9999
+
+            # Parse BPM from Song.abl
+            bpm = None
+            if mset_folders:
+                set_path = os.path.join(uuid_path, mset_folders[0])
+                bpm = _parse_bpm_from_song(set_path)
+
             msets.append({
                 "uuid": uuid,
                 "mset_name": mset_name,
@@ -65,7 +85,8 @@ def list_msets(return_free_ids=False):
                 "mset_color": mset_color if mset_color.isdigit() else "Unknown",
                 "mset_cloudstate": mset_cloudstate,
                 "mset_modifiedtime": mset_modifiedtime,
-                "mset_extmodified": mset_extmodified
+                "mset_extmodified": mset_extmodified,
+                "bpm": bpm
             })
 
             if 0 <= mset_id_value <= 31:

--- a/core/list_msets_handler.py
+++ b/core/list_msets_handler.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import json
 from core.config import MSETS_DIRECTORY
+from core.pad_colors import move_color_to_ui
 
 def get_xattr_value(relative_path, attr):
     """
@@ -71,6 +72,7 @@ def list_msets(return_free_ids=False):
             mset_extmodified = get_xattr_value(uuid, "user.was-externally-modified")
 
             mset_id_value = int(mset_id) if mset_id.isdigit() else 9999
+            mset_color_value = int(mset_color) if mset_color.isdigit() else None
 
             # Parse BPM from Song.abl
             bpm = None
@@ -82,7 +84,7 @@ def list_msets(return_free_ids=False):
                 "uuid": uuid,
                 "mset_name": mset_name,
                 "mset_id": mset_id_value,
-                "mset_color": mset_color if mset_color.isdigit() else "Unknown",
+                "mset_color": move_color_to_ui(mset_color_value) if mset_color_value is not None else "Unknown",
                 "mset_cloudstate": mset_cloudstate,
                 "mset_modifiedtime": mset_modifiedtime,
                 "mset_extmodified": mset_extmodified,

--- a/core/overview_handler.py
+++ b/core/overview_handler.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from core.config import MSETS_DIRECTORY
-from core.pad_colors import PAD_COLORS
+from core.pad_colors import PAD_COLORS, move_color_to_ui
 
 SETTINGS_FILE = '/data/UserData/settings/Settings.json'
 SETS_ROOT = MSETS_DIRECTORY
@@ -96,7 +96,8 @@ def get_sets_data() -> dict:
             scale = parsed.get('scale')
             camelot = _key_to_camelot(key, scale) if key and scale else None
 
-            rgb = PAD_COLORS.get(xattr_color)
+            color_id = move_color_to_ui(xattr_color)
+            rgb = PAD_COLORS.get(color_id)
             color_css = f'rgb({rgb[0]},{rgb[1]},{rgb[2]})' if rgb else None
 
             sets_data.append({
@@ -110,6 +111,7 @@ def get_sets_data() -> dict:
                 'camelot':     camelot,
                 'slot':        slot,
                 'xattr_color': xattr_color,
+                'color_id':    color_id,
                 'color_css':   color_css,
             })
     except Exception:

--- a/core/overview_handler.py
+++ b/core/overview_handler.py
@@ -1,0 +1,180 @@
+"""Overview handler: pad grid, set metadata (BPM/key/Camelot), disk and system stats.
+
+Reads the local filesystem directly — no SSH needed since this runs on Move.
+Uses os.getxattr() for xattr reads (Python stdlib on Linux, no subprocess).
+"""
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from core.config import MSETS_DIRECTORY
+from core.pad_colors import PAD_COLORS
+
+SETTINGS_FILE = '/data/UserData/settings/Settings.json'
+SETS_ROOT = MSETS_DIRECTORY
+
+
+def _read_xattr(path: str, attr_name: str) -> Optional[str]:
+    """Read a single xattr via os.getxattr() — no subprocess required."""
+    try:
+        raw = os.getxattr(path, attr_name)
+        return raw.decode('utf-8', errors='replace').strip() or None
+    except Exception:
+        return None
+
+
+_ROOT_NOTE_NAMES = ['C', 'C#', 'D', 'Eb', 'E', 'F', 'F#', 'G', 'Ab', 'A', 'Bb', 'B']
+
+def _parse_song_abl(set_path: str) -> dict:
+    """Parse Song.abl (raw JSON) for BPM, key, and scale. Returns {} on failure."""
+    try:
+        abl_path = os.path.join(set_path, 'Song.abl')
+        with open(abl_path, 'r') as f:
+            data = json.load(f)
+        tempo = data.get('tempo')
+        bpm = round(float(tempo), 1) if tempo else None
+        root = data.get('rootNote')
+        key = _ROOT_NOTE_NAMES[int(root) % 12] if root is not None else None
+        scale_raw = data.get('scale', '')
+        scale = 'minor' if 'minor' in scale_raw.lower() else 'major' if scale_raw else None
+        return {'bpm': bpm, 'key': key, 'scale': scale}
+    except Exception:
+        return {}
+
+
+def _key_to_camelot(key: str, scale: str) -> Optional[str]:
+    """Map a key + scale to a Camelot wheel code."""
+    TABLE = {
+        ('C', 'major'): '8B',  ('A', 'minor'): '8A',
+        ('G', 'major'): '9B',  ('E', 'minor'): '9A',
+        ('D', 'major'): '10B', ('B', 'minor'): '10A',
+        ('A', 'major'): '11B', ('F#', 'minor'): '11A',
+        ('E', 'major'): '12B', ('C#', 'minor'): '12A',
+        ('B', 'major'): '1B',  ('G#', 'minor'): '1A',
+        ('F#', 'major'): '2B', ('D#', 'minor'): '2A',
+        ('Db', 'major'): '3B', ('Bb', 'minor'): '3A',
+        ('Ab', 'major'): '4B', ('F', 'minor'): '4A',
+        ('Eb', 'major'): '5B', ('C', 'minor'): '5A',
+        ('Bb', 'major'): '6B', ('G', 'minor'): '6A',
+        ('F', 'major'): '7B',  ('D', 'minor'): '7A',
+    }
+    if not key or not scale:
+        return None
+    return TABLE.get((key, scale.lower()))
+
+
+def get_sets_data() -> dict:
+    """Return full set metadata: pad grid, BPM, key, Camelot, disk usage, active slot."""
+    sets_data = []
+    try:
+        sets_root = Path(SETS_ROOT)
+        for uuid_dir in sorted(sets_root.iterdir()):
+            if not uuid_dir.is_dir():
+                continue
+            children = [d for d in uuid_dir.iterdir() if d.is_dir()]
+            if not children:
+                continue
+            set_dir = children[0]
+            uuid_path = str(uuid_dir)
+
+            slot_val  = _read_xattr(uuid_path, 'user.song-index')
+            color_val = _read_xattr(uuid_path, 'user.song-color')
+            try:
+                slot = int(slot_val) if slot_val is not None else None
+            except (ValueError, TypeError):
+                slot = None
+            try:
+                xattr_color = int(color_val) if color_val is not None else None
+            except (ValueError, TypeError):
+                xattr_color = None
+
+            parsed = _parse_song_abl(str(set_dir))
+            bpm   = parsed.get('bpm')
+            key   = parsed.get('key')
+            scale = parsed.get('scale')
+            camelot = _key_to_camelot(key, scale) if key and scale else None
+
+            rgb = PAD_COLORS.get(xattr_color)
+            color_css = f'rgb({rgb[0]},{rgb[1]},{rgb[2]})' if rgb else None
+
+            sets_data.append({
+                'name':        set_dir.name,
+                'path':        str(set_dir),
+                'uuid':        uuid_dir.name,
+                'modified':    uuid_dir.stat().st_mtime,
+                'bpm':         bpm,
+                'key':         key,
+                'mode':        scale,
+                'camelot':     camelot,
+                'slot':        slot,
+                'xattr_color': xattr_color,
+                'color_css':   color_css,
+            })
+    except Exception:
+        pass
+
+    sets_data.sort(key=lambda s: s['slot'] if s['slot'] is not None else 9999)
+
+    disk = None
+    try:
+        usage = shutil.disk_usage('/data/UserData')
+        disk = {
+            'total_gb':     round(usage.total / 1024 ** 3, 1),
+            'used_gb':      round(usage.used  / 1024 ** 3, 1),
+            'free_gb':      round(usage.free  / 1024 ** 3, 1),
+            'percent_used': round(usage.used / usage.total * 100),
+        }
+    except Exception:
+        pass
+
+    current_slot = get_active_slot()
+
+    return {
+        'sets':         sets_data,
+        'disk':         disk,
+        'total_sets':   len(sets_data),
+        'current_slot': current_slot,
+    }
+
+
+def get_active_slot() -> Optional[int]:
+    """Read currentSongIndex from Settings.json."""
+    try:
+        with open(SETTINGS_FILE, 'r') as f:
+            data = json.load(f)
+        val = data.get('currentSongIndex')
+        return int(val) if val is not None else None
+    except Exception:
+        return None
+
+
+def get_system_stats() -> dict:
+    """Read CPU load averages and memory usage from /proc."""
+    stats = {}
+    try:
+        parts = open('/proc/loadavg').read().split()
+        stats['load_1']  = float(parts[0])
+        stats['load_5']  = float(parts[1])
+        stats['load_15'] = float(parts[2])
+    except Exception:
+        pass
+    try:
+        meminfo = {}
+        for line in open('/proc/meminfo'):
+            k, v = line.split(':', 1)
+            meminfo[k.strip()] = int(v.strip().split()[0])
+        total_kb = meminfo.get('MemTotal', 0)
+        avail_kb = meminfo.get('MemAvailable', meminfo.get('MemFree', 0))
+        used_kb  = total_kb - avail_kb
+        stats['mem_total_mb'] = round(total_kb / 1024)
+        stats['mem_used_mb']  = round(used_kb  / 1024)
+        stats['mem_pct']      = round(used_kb / total_kb * 100) if total_kb else 0
+    except Exception:
+        pass
+    try:
+        stats['cpu_count'] = os.cpu_count() or 1
+    except Exception:
+        pass
+    return stats

--- a/core/pad_colors.py
+++ b/core/pad_colors.py
@@ -55,6 +55,12 @@ PAD_COLOR_LABELS = {
     25: "Fuchsia",
 }
 
+def move_color_to_ui(color_id):
+    if color_id == 0:
+        return 1
+    return color_id
+
+
 def rgb_string(color_id):
     rgb = PAD_COLORS.get(color_id)
     if rgb:

--- a/core/set_inspector_handler.py
+++ b/core/set_inspector_handler.py
@@ -127,6 +127,8 @@ def get_clip_data(set_path: str, track: int, clip: int) -> Dict[str, Any]:
             song = json.load(f)
         track_obj = song["tracks"][track]
         clip_obj = track_obj["clipSlots"][clip]["clip"]
+        if clip_obj is None:
+            return {"success": False, "message": f"Clip {clip + 1} on Track {track + 1} is empty"}
         notes = clip_obj.get("notes", [])
         envelopes = clip_obj.get("envelopes", [])
         region_info = clip_obj.get("region", {})

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -634,11 +634,14 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                     'message': f"Track {target_track} has no empty clip slots available"
                 }
             
-            # Create new clip in the empty slot
+            # Create new clip in the empty slot with all required fields
             new_clip = {
-                'notes': notes,
-                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
-                'enabled': True
+                'isPlaying': False,
+                'name': '',
+                'isEnabled': True,
+                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length, 'isEnabled': True}},
+                'grooveId': 1,
+                'notes': notes
             }
             # Apply clip color if provided
             if clip_color:

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -629,10 +629,20 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                     'enabled': True
                 }
             else:
+                # Merge new notes with existing clip
                 clip = clip_slot['clip']
-                clip['notes'] = notes
-                clip['region']['end'] = clip_length
-                clip['region']['loop']['end'] = clip_length
+                existing_notes = clip.get('notes', [])
+                # Offset new notes to start after existing notes
+                if existing_notes:
+                    last_note_end = max(n.get('position', 0) + n.get('duration', 0) for n in existing_notes)
+                    for note in notes:
+                        note['position'] = note.get('position', 0) + last_note_end
+                # Append new notes to existing
+                clip['notes'] = existing_notes + notes
+                # Update clip length to accommodate all notes
+                total_end = max(n.get('position', 0) + n.get('duration', 0) for n in clip['notes'])
+                clip['region']['end'] = total_end
+                clip['region']['loop']['end'] = total_end
             track['name'] = f"Track {target_track}"
         else:
             return {

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -638,11 +638,16 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                     'message': f"Track {target_track} has no empty clip slots available"
                 }
             
-            # Create new clip in the empty slot
+            # Create new clip in the empty slot with all required fields
             new_clip = {
+                'isPlaying': False,
+                'name': '',
+                'isEnabled': True,
+                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length, 'isEnabled': True}},
+                'grooveId': 1,
                 'notes': notes,
-                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
-                'enabled': True
+                'stepEditorScrollPosition': 0.0,
+                'envelopes': []
             }
             # Apply clip color if provided
             if clip_color:

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -627,20 +627,37 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         clip_length = max(4.0, math.ceil(max_end_time / 4.0) * 4.0)
         
         # Load existing set or create new
+        template_clip = None
         if existing_set_path and os.path.exists(existing_set_path):
             # Load existing set
             with open(existing_set_path, 'r') as f:
                 song = json.load(f)
             mode = "updated"
+            # Find an existing clip to use as template for new clips
+            for t in song.get('tracks', []):
+                for slot in t.get('clipSlots', []):
+                    if slot.get('clip') is not None:
+                        template_clip = copy.deepcopy(slot['clip'])
+                        break
+                if template_clip:
+                    break
         else:
             # Create new set from template
             template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', 'midi_template.abl')
             song = load_set_template(template_path)
-            # Clear any existing clips from template
+            # Store a copy of the template's clip structure before clearing
+            template_clip = copy.deepcopy(song['tracks'][0]['clipSlots'][0]['clip'])
+            # Clear all clips from template
             for track in song.get('tracks', []):
                 for slot in track.get('clipSlots', []):
                     slot['clip'] = None
             mode = "created"
+        
+        # Fallback: load template clip if we didn't find one
+        if template_clip is None:
+            template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', 'midi_template.abl')
+            tmpl = load_set_template(template_path)
+            template_clip = copy.deepcopy(tmpl['tracks'][0]['clipSlots'][0]['clip'])
         
         # Validate track index
         track_idx = target_track - 1  # Convert 1-4 to 0-3
@@ -666,18 +683,16 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                     'message': f"Track {target_track} has no empty clip slots available"
                 }
             
-            # Create new clip in the empty slot with all required fields
-            new_clip = {
-                'isPlaying': True,
-                'name': '',
-                'color': clip_color if clip_color else 1,
-                'isEnabled': True,
-                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length, 'isEnabled': True}},
-                'grooveId': 1,
-                'notes': notes,
-                'stepEditorScrollPosition': 0.0,
-                'envelopes': []
-            }
+            # Create new clip from template structure with our notes
+            new_clip = copy.deepcopy(template_clip)
+            new_clip['isPlaying'] = True
+            new_clip['name'] = ''
+            new_clip['color'] = clip_color if clip_color else 1
+            new_clip['isEnabled'] = True
+            new_clip['region'] = {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length, 'isEnabled': True}}
+            new_clip['notes'] = notes
+            new_clip['stepEditorScrollPosition'] = 0.0
+            new_clip['envelopes'] = []
             track['clipSlots'][empty_slot_idx]['clip'] = new_clip
             track['name'] = f"Track {target_track}"
         else:

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -634,14 +634,11 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                     'message': f"Track {target_track} has no empty clip slots available"
                 }
             
-            # Create new clip in the empty slot with all required fields
+            # Create new clip in the empty slot
             new_clip = {
-                'isPlaying': False,
-                'name': '',
-                'isEnabled': True,
-                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length, 'isEnabled': True}},
-                'grooveId': 1,
-                'notes': notes
+                'notes': notes,
+                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
+                'enabled': True
             }
             # Apply clip color if provided
             if clip_color:

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -608,6 +608,10 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
             # Create new set from template
             template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', 'midi_template.abl')
             song = load_set_template(template_path)
+            # Clear any existing clips from template
+            for track in song.get('tracks', []):
+                for slot in track.get('clipSlots', []):
+                    slot['clip'] = None
             mode = "created"
         
         # Validate track index

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -655,8 +655,9 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                 'message': f"Track {target_track} has no clip slots available"
             }
         
-        # Update tempo
-        song['tempo'] = tempo
+        # Only update tempo when creating new set, preserve existing set's tempo
+        if mode == "created":
+            song['tempo'] = tempo
         
         # Save - use same path if updating existing set
         if existing_set_path and mode == "updated":

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -496,7 +496,7 @@ def generate_multichannel_midi_set(set_name: str, midi_file_path: str, tempo: fl
 
 
 def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int, 
-                         existing_set_path: str = None, tempo: float = None) -> Dict[str, Any]:
+                         existing_set_path: str = None, tempo: float = None, clip_color: int = None) -> Dict[str, Any]:
     """
     Assign a single-track MIDI file to a specific track slot (1-4) in a set.
     Can create a new set or append to an existing set.
@@ -507,6 +507,7 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         target_track: Track number 1-4 to place the MIDI on
         existing_set_path: If provided, load this set and add to it. If None, create new set.
         tempo: Tempo in BPM (if None, will try to detect from MIDI or use 120)
+        clip_color: Color ID for new clip (1-9) when adding to existing set
         
     Returns:
         Result dictionary with success status and message
@@ -634,11 +635,15 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                 }
             
             # Create new clip in the empty slot
-            track['clipSlots'][empty_slot_idx]['clip'] = {
+            new_clip = {
                 'notes': notes,
                 'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
                 'enabled': True
             }
+            # Apply clip color if provided
+            if clip_color:
+                new_clip['color'] = clip_color
+            track['clipSlots'][empty_slot_idx]['clip'] = new_clip
             track['name'] = f"Track {target_track}"
         else:
             return {

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -1,6 +1,7 @@
 import os
 import json
 import copy
+import math
 import mido
 from typing import Dict, List, Any, Optional
 
@@ -190,7 +191,7 @@ def generate_midi_set_from_file(set_name: str, midi_file_path: str, tempo: float
         
         # Calculate clip length (round up to nearest bar)
         max_end_time = max(note['startTime'] + note['duration'] for note in notes)
-        clip_length = max(4.0, ((int(max_end_time) // 4) + 1) * 4.0)
+        clip_length = max(4.0, math.ceil(max_end_time / 4.0) * 4.0)
         
         # Load the template
         template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', 'midi_template.abl')
@@ -307,9 +308,9 @@ def generate_drum_set_from_file(set_name: str, midi_file_path: str, tempo: float
                 'offVelocity': n['offVelocity']
             })
 
-        # Determine clip length as nearest bar (4 beats)
+        # Determine clip length (round up to nearest bar)
         max_end = max(n['startTime'] + n['duration'] for n in mapped_notes)
-        clip_length = max(4.0, ((int(max_end) // 4) + 1) * 4.0)
+        clip_length = max(4.0, math.ceil(max_end / 4.0) * 4.0)
 
         # Load the 808 template
         template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', '808.abl')
@@ -445,7 +446,7 @@ def generate_multichannel_midi_set(set_name: str, midi_file_path: str, tempo: fl
                 channel_max = max(note['startTime'] + note['duration'] for note in notes)
                 max_end_time = max(max_end_time, channel_max)
         
-        clip_length = max(4.0, ((int(max_end_time) // 4) + 1) * 4.0)
+        clip_length = max(4.0, math.ceil(max_end_time / 4.0) * 4.0)
         
         # Get channels sorted
         channels = sorted(channel_notes.keys())
@@ -596,7 +597,7 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         
         # Calculate clip length
         max_end_time = max(note['startTime'] + note['duration'] for note in notes)
-        clip_length = max(4.0, ((int(max_end_time) // 4) + 1) * 4.0)
+        clip_length = max(4.0, math.ceil(max_end_time / 4.0) * 4.0)
         
         # Load existing set or create new
         if existing_set_path and os.path.exists(existing_set_path):
@@ -640,8 +641,9 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
             
             # Create new clip in the empty slot with all required fields
             new_clip = {
-                'isPlaying': False,
+                'isPlaying': True,
                 'name': '',
+                'color': clip_color if clip_color else 1,
                 'isEnabled': True,
                 'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length, 'isEnabled': True}},
                 'grooveId': 1,
@@ -649,9 +651,6 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                 'stepEditorScrollPosition': 0.0,
                 'envelopes': []
             }
-            # Apply clip color if provided
-            if clip_color:
-                new_clip['color'] = clip_color
             track['clipSlots'][empty_slot_idx]['clip'] = new_clip
             track['name'] = f"Track {target_track}"
         else:

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -335,3 +335,161 @@ def generate_drum_set_from_file(set_name: str, midi_file_path: str, tempo: float
 
     except Exception as e:
         return {'success': False, 'message': f"Failed to process drum MIDI file: {str(e)}"}
+
+
+def generate_multichannel_midi_set(set_name: str, midi_file_path: str, tempo: float = None) -> Dict[str, Any]:
+    """
+    Generate an Ableton Live set from a multi-channel MIDI file.
+    Each MIDI channel (up to 4) becomes a separate track with its own clip.
+    
+    Args:
+        set_name: Name for the new set
+        midi_file_path: Path to the uploaded MIDI file
+        tempo: Tempo in BPM (if None, will try to detect from MIDI or use 120)
+        
+    Returns:
+        Result dictionary with success status and message
+    """
+    try:
+        # Load the MIDI file
+        mid = mido.MidiFile(midi_file_path)
+        
+        # Try to detect tempo from MIDI file
+        detected_tempo = 120.0
+        for track in mid.tracks:
+            for msg in track:
+                if msg.type == 'set_tempo':
+                    detected_tempo = 60000000 / msg.tempo
+                    break
+            if detected_tempo != 120.0:
+                break
+        
+        if tempo is None:
+            tempo = detected_tempo
+        
+        # Extract notes grouped by channel
+        ticks_per_beat = mid.ticks_per_beat
+        channel_notes = {}  # channel -> list of notes
+        
+        for track in mid.tracks:
+            current_time = 0
+            active_notes = {}  # (channel, note) -> start_time
+            
+            for msg in track:
+                current_time += msg.time
+                
+                if msg.type == 'note_on' and msg.velocity > 0:
+                    key = (msg.channel, msg.note)
+                    active_notes[key] = {
+                        'start_time': current_time / ticks_per_beat,
+                        'velocity': msg.velocity
+                    }
+                elif msg.type == 'note_off' or (msg.type == 'note_on' and msg.velocity == 0):
+                    key = (msg.channel, msg.note)
+                    if key in active_notes:
+                        start_beat = active_notes[key]['start_time']
+                        duration = (current_time / ticks_per_beat) - start_beat
+                        
+                        if duration > 0:
+                            channel = msg.channel
+                            if channel not in channel_notes:
+                                channel_notes[channel] = []
+                            
+                            channel_notes[channel].append({
+                                'noteNumber': msg.note,
+                                'startTime': start_beat,
+                                'duration': duration,
+                                'velocity': float(active_notes[key]['velocity']),
+                                'offVelocity': 0.0
+                            })
+                        
+                        del active_notes[key]
+            
+            # Handle any remaining active notes at end of track
+            final_time = current_time / ticks_per_beat
+            for (channel, note_num), data in active_notes.items():
+                duration = final_time - data['start_time']
+                if duration > 0:
+                    if channel not in channel_notes:
+                        channel_notes[channel] = []
+                    
+                    channel_notes[channel].append({
+                        'noteNumber': note_num,
+                        'startTime': data['start_time'],
+                        'duration': duration,
+                        'velocity': float(data['velocity']),
+                        'offVelocity': 0.0
+                    })
+        
+        # Filter out channels with no notes
+        channel_notes = {ch: notes for ch, notes in channel_notes.items() if notes}
+        
+        if not channel_notes:
+            return {'success': False, 'message': "No note data found in MIDI file"}
+        
+        # Check channel limit
+        if len(channel_notes) > 4:
+            return {
+                'success': False,
+                'message': f"MIDI file contains {len(channel_notes)} channels with notes. Maximum supported is 4 channels."
+            }
+        
+        # Load the template
+        template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', 'midi_template.abl')
+        song = load_set_template(template_path)
+        
+        # Calculate clip length based on all notes
+        max_end_time = 0
+        for notes in channel_notes.values():
+            if notes:
+                channel_max = max(note['startTime'] + note['duration'] for note in notes)
+                max_end_time = max(max_end_time, channel_max)
+        
+        clip_length = max(4.0, ((int(max_end_time) // 4) + 1) * 4.0)
+        
+        # Get channels sorted
+        channels = sorted(channel_notes.keys())
+        
+        # Assign notes to tracks (up to 4)
+        for i, channel in enumerate(channels[:4]):
+            notes = channel_notes[channel]
+            notes.sort(key=lambda x: x['startTime'])
+            
+            # Use the i-th track's first clip slot
+            if i < len(song['tracks']):
+                track = song['tracks'][i]
+                if track['clipSlots']:
+                    clip = track['clipSlots'][0]['clip']
+                    clip['notes'] = notes
+                    clip['region']['end'] = clip_length
+                    clip['region']['loop']['end'] = clip_length
+                    # Name the track based on channel
+                    track['name'] = f"Ch {channel + 1}"
+        
+        # Update tempo
+        song['tempo'] = tempo
+        
+        # Save the modified set
+        output_dir = "/data/UserData/UserLibrary/Sets"
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, set_name)
+        if not output_path.endswith('.abl'):
+            output_path += '.abl'
+        
+        with open(output_path, 'w') as f:
+            json.dump(song, f, indent=2)
+        
+        # Build success message
+        channel_summary = ", ".join([f"Ch {ch+1}: {len(notes)} notes" for ch, notes in channel_notes.items()])
+        
+        return {
+            'success': True,
+            'message': f"Multi-channel set '{set_name}' generated successfully ({len(channel_notes)} channels - {channel_summary})",
+            'path': output_path
+        }
+        
+    except Exception as e:
+        return {
+            'success': False,
+            'message': f"Failed to process multi-channel MIDI file: {str(e)}"
+        }

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -3,10 +3,13 @@ import json
 import copy
 import math
 import re
+import logging
 import mido
 from typing import Dict, List, Any, Optional
 
 from core.utils import load_set_template
+
+logger = logging.getLogger(__name__)
 
 
 def sanitize_set_name(set_name: str) -> Optional[str]:
@@ -723,6 +726,11 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         
         with open(output_path, 'w') as f:
             json.dump(song, f, indent=2)
+        
+        # Debug: verify clips were written
+        clip_count = sum(1 for t in song.get('tracks', []) for s in t.get('clipSlots', []) if s.get('clip') is not None)
+        logger.info("assign_midi_to_track: saved %s, mode=%s, track=%d, slot=%d, notes=%d, total_clips=%d, path=%s",
+                     set_name, mode, target_track, empty_slot_idx, len(notes), clip_count, output_path)
         
         return {
             'success': True,

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -3,13 +3,10 @@ import json
 import copy
 import math
 import re
-import logging
 import mido
 from typing import Dict, List, Any, Optional
 
 from core.utils import load_set_template
-
-logger = logging.getLogger(__name__)
 
 
 def sanitize_set_name(set_name: str) -> Optional[str]:
@@ -726,11 +723,6 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         
         with open(output_path, 'w') as f:
             json.dump(song, f, indent=2)
-        
-        # Debug: verify clips were written
-        clip_count = sum(1 for t in song.get('tracks', []) for s in t.get('clipSlots', []) if s.get('clip') is not None)
-        logger.info("assign_midi_to_track: saved %s, mode=%s, track=%d, slot=%d, notes=%d, total_clips=%d, path=%s",
-                     set_name, mode, target_track, empty_slot_idx, len(notes), clip_count, output_path)
         
         return {
             'success': True,

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -617,32 +617,28 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
                 'message': f"Track {target_track} does not exist in set (max {len(song['tracks'])} tracks)"
             }
         
-        # Assign notes to target track
+        # Assign notes to target track - find first empty clip slot
         track = song['tracks'][track_idx]
         if track['clipSlots'] and len(track['clipSlots']) > 0:
-            clip_slot = track['clipSlots'][0]
-            if clip_slot.get('clip') is None:
-                # Create clip structure if missing
-                clip_slot['clip'] = {
-                    'notes': notes,
-                    'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
-                    'enabled': True
+            # Find first empty clip slot
+            empty_slot_idx = None
+            for idx, slot in enumerate(track['clipSlots']):
+                if slot.get('clip') is None:
+                    empty_slot_idx = idx
+                    break
+            
+            if empty_slot_idx is None:
+                return {
+                    'success': False,
+                    'message': f"Track {target_track} has no empty clip slots available"
                 }
-            else:
-                # Merge new notes with existing clip
-                clip = clip_slot['clip']
-                existing_notes = clip.get('notes', [])
-                # Offset new notes to start after existing notes
-                if existing_notes:
-                    last_note_end = max(n.get('position', 0) + n.get('duration', 0) for n in existing_notes)
-                    for note in notes:
-                        note['position'] = note.get('position', 0) + last_note_end
-                # Append new notes to existing
-                clip['notes'] = existing_notes + notes
-                # Update clip length to accommodate all notes
-                total_end = max(n.get('position', 0) + n.get('duration', 0) for n in clip['notes'])
-                clip['region']['end'] = total_end
-                clip['region']['loop']['end'] = total_end
+            
+            # Create new clip in the empty slot
+            track['clipSlots'][empty_slot_idx]['clip'] = {
+                'notes': notes,
+                'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
+                'enabled': True
+            }
             track['name'] = f"Track {target_track}"
         else:
             return {

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -643,12 +643,21 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         # Update tempo
         song['tempo'] = tempo
         
-        # Save
-        output_dir = "/data/UserData/UserLibrary/Sets"
-        os.makedirs(output_dir, exist_ok=True)
-        output_path = os.path.join(output_dir, set_name)
-        if not output_path.endswith('.abl'):
-            output_path += '.abl'
+        # Save - use same path if updating existing set
+        if existing_set_path and mode == "updated":
+            output_path = existing_set_path
+        else:
+            # Create new set
+            output_dir = "/data/UserData/UserLibrary/Sets"
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(output_dir, set_name)
+            if not output_path.endswith('.abl'):
+                output_path += '.abl'
+        
+        # Ensure directory exists
+        output_dir = os.path.dirname(output_path)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         
         with open(output_path, 'w') as f:
             json.dump(song, f, indent=2)

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -493,3 +493,174 @@ def generate_multichannel_midi_set(set_name: str, midi_file_path: str, tempo: fl
             'success': False,
             'message': f"Failed to process multi-channel MIDI file: {str(e)}"
         }
+
+
+def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int, 
+                         existing_set_path: str = None, tempo: float = None) -> Dict[str, Any]:
+    """
+    Assign a single-track MIDI file to a specific track slot (1-4) in a set.
+    Can create a new set or append to an existing set.
+    
+    Args:
+        set_name: Name for the new set (or name of existing set)
+        midi_file_path: Path to the uploaded MIDI file
+        target_track: Track number 1-4 to place the MIDI on
+        existing_set_path: If provided, load this set and add to it. If None, create new set.
+        tempo: Tempo in BPM (if None, will try to detect from MIDI or use 120)
+        
+    Returns:
+        Result dictionary with success status and message
+    """
+    try:
+        # Validate track number
+        if target_track < 1 or target_track > 4:
+            return {
+                'success': False,
+                'message': f"Invalid track number {target_track}. Must be 1-4."
+            }
+        
+        # Load and parse the MIDI file
+        mid = mido.MidiFile(midi_file_path)
+        
+        # Detect tempo
+        detected_tempo = 120.0
+        for track in mid.tracks:
+            for msg in track:
+                if msg.type == 'set_tempo':
+                    detected_tempo = 60000000 / msg.tempo
+                    break
+            if detected_tempo != 120.0:
+                break
+        
+        if tempo is None:
+            tempo = detected_tempo
+        
+        # Extract notes from first track with note data
+        ticks_per_beat = mid.ticks_per_beat
+        notes = []
+        current_time = 0
+        active_notes = {}
+        
+        note_track = None
+        for track in mid.tracks:
+            has_notes = any(msg.type in ['note_on', 'note_off'] for msg in track)
+            if has_notes:
+                note_track = track
+                break
+        
+        if note_track is None:
+            return {'success': False, 'message': "No note data found in MIDI file"}
+        
+        for msg in note_track:
+            current_time += msg.time
+            
+            if msg.type == 'note_on' and msg.velocity > 0:
+                active_notes[msg.note] = {
+                    'start_time': current_time / ticks_per_beat,
+                    'velocity': msg.velocity
+                }
+            elif msg.type == 'note_off' or (msg.type == 'note_on' and msg.velocity == 0):
+                if msg.note in active_notes:
+                    start_beat = active_notes[msg.note]['start_time']
+                    duration = (current_time / ticks_per_beat) - start_beat
+                    
+                    if duration > 0:
+                        notes.append({
+                            'noteNumber': msg.note,
+                            'startTime': start_beat,
+                            'duration': duration,
+                            'velocity': float(active_notes[msg.note]['velocity']),
+                            'offVelocity': 0.0
+                        })
+                    
+                    del active_notes[msg.note]
+        
+        # Handle remaining active notes
+        final_time = current_time / ticks_per_beat
+        for note_num, data in active_notes.items():
+            duration = final_time - data['start_time']
+            if duration > 0:
+                notes.append({
+                    'noteNumber': note_num,
+                    'startTime': data['start_time'],
+                    'duration': duration,
+                    'velocity': float(data['velocity']),
+                    'offVelocity': 0.0
+                })
+        
+        if not notes:
+            return {'success': False, 'message': "No valid notes found in MIDI file"}
+        
+        notes.sort(key=lambda x: x['startTime'])
+        
+        # Calculate clip length
+        max_end_time = max(note['startTime'] + note['duration'] for note in notes)
+        clip_length = max(4.0, ((int(max_end_time) // 4) + 1) * 4.0)
+        
+        # Load existing set or create new
+        if existing_set_path and os.path.exists(existing_set_path):
+            # Load existing set
+            with open(existing_set_path, 'r') as f:
+                song = json.load(f)
+            mode = "updated"
+        else:
+            # Create new set from template
+            template_path = os.path.join(os.path.dirname(__file__), '..', 'examples', 'Sets', 'midi_template.abl')
+            song = load_set_template(template_path)
+            mode = "created"
+        
+        # Validate track index
+        track_idx = target_track - 1  # Convert 1-4 to 0-3
+        if track_idx >= len(song['tracks']):
+            return {
+                'success': False,
+                'message': f"Track {target_track} does not exist in set (max {len(song['tracks'])} tracks)"
+            }
+        
+        # Assign notes to target track
+        track = song['tracks'][track_idx]
+        if track['clipSlots'] and len(track['clipSlots']) > 0:
+            clip_slot = track['clipSlots'][0]
+            if clip_slot.get('clip') is None:
+                # Create clip structure if missing
+                clip_slot['clip'] = {
+                    'notes': notes,
+                    'region': {'start': 0.0, 'end': clip_length, 'loop': {'start': 0.0, 'end': clip_length}},
+                    'enabled': True
+                }
+            else:
+                clip = clip_slot['clip']
+                clip['notes'] = notes
+                clip['region']['end'] = clip_length
+                clip['region']['loop']['end'] = clip_length
+            track['name'] = f"Track {target_track}"
+        else:
+            return {
+                'success': False,
+                'message': f"Track {target_track} has no clip slots available"
+            }
+        
+        # Update tempo
+        song['tempo'] = tempo
+        
+        # Save
+        output_dir = "/data/UserData/UserLibrary/Sets"
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, set_name)
+        if not output_path.endswith('.abl'):
+            output_path += '.abl'
+        
+        with open(output_path, 'w') as f:
+            json.dump(song, f, indent=2)
+        
+        return {
+            'success': True,
+            'message': f"Set '{set_name}' {mode} - Track {target_track} now has {len(notes)} notes",
+            'path': output_path
+        }
+        
+    except Exception as e:
+        return {
+            'success': False,
+            'message': f"Failed to assign MIDI to track: {str(e)}"
+        }

--- a/core/set_management_handler.py
+++ b/core/set_management_handler.py
@@ -2,10 +2,25 @@ import os
 import json
 import copy
 import math
+import re
 import mido
 from typing import Dict, List, Any, Optional
 
 from core.utils import load_set_template
+
+
+def sanitize_set_name(set_name: str) -> Optional[str]:
+    """Sanitize set_name to prevent path traversal.
+    Returns a safe name or None if the name is invalid."""
+    if not set_name or not isinstance(set_name, str):
+        return None
+    # Reject any path separators or traversal attempts
+    if '/' in set_name or '\\' in set_name or '..' in set_name:
+        return None
+    # Allow alphanumeric, spaces, hyphens, underscores
+    if not re.match(r'^[\w\s\-]+$', set_name):
+        return None
+    return set_name
 
 def create_set(set_name):
     """
@@ -100,6 +115,10 @@ def generate_midi_set_from_file(set_name: str, midi_file_path: str, tempo: float
         Result dictionary with success status and message
     """
     try:
+        safe_name = sanitize_set_name(set_name)
+        if not safe_name:
+            return {'success': False, 'message': 'Invalid set name: use only letters, numbers, spaces, hyphens, and underscores'}
+        
         # Load the MIDI file
         mid = mido.MidiFile(midi_file_path)
         
@@ -236,6 +255,10 @@ def generate_drum_set_from_file(set_name: str, midi_file_path: str, tempo: float
     mapping incoming notes to 16 pads starting at MIDI note 36.
     """
     try:
+        safe_name = sanitize_set_name(set_name)
+        if not safe_name:
+            return {'success': False, 'message': 'Invalid set name: use only letters, numbers, spaces, hyphens, and underscores'}
+        
         # Load the MIDI file
         mid = mido.MidiFile(midi_file_path)
 
@@ -514,6 +537,10 @@ def assign_midi_to_track(set_name: str, midi_file_path: str, target_track: int,
         Result dictionary with success status and message
     """
     try:
+        safe_name = sanitize_set_name(set_name)
+        if not safe_name:
+            return {'success': False, 'message': 'Invalid set name: use only letters, numbers, spaces, hyphens, and underscores'}
+        
         # Validate track number
         if target_track < 1 or target_track > 4:
             return {

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -29,8 +29,10 @@ class BaseHandler:
         name_map: Optional[Dict[int, str]] = None,
         bpm_map: Optional[Dict[int, str]] = None,
         selected_idx: Optional[int] = None,
+        active_idx: Optional[int] = None,
         input_name: str = "pad_index",
         free_only: bool = False,
+        view_only: bool = False,
     ) -> str:
         """Generate HTML for a 32-pad grid showing set occupancy with colors, names, and BPM.
 
@@ -69,6 +71,7 @@ class BaseHandler:
                     disabled = "" if has_set else "disabled"
 
                 status = "occupied" if has_set else "free"
+                active = " active" if active_idx is not None and idx == active_idx else ""
                 checked = " checked" if selected_idx is not None and idx == selected_idx else ""
                 color_id = color_map.get(idx)
                 # Generate semi-transparent background + solid border like Overview page
@@ -90,9 +93,10 @@ class BaseHandler:
 
                 cells.append(
                     f'<input type="radio" id="pad_{num}" name="{input_name}" value="{num}"{checked} {disabled}>'
-                    f'<label for="pad_{num}" class="pad-cell {status}"{style}>{inner_html}</label>'
+                    f'<label for="pad_{num}" class="pad-cell {status}{active}"{style}>{inner_html}</label>'
                 )
-        return '<div class="pad-grid">' + "".join(cells) + "</div>"
+        grid_class = "pad-grid view-only" if view_only else "pad-grid"
+        return f'<div class="{grid_class}">' + "".join(cells) + "</div>"
 
     def __init__(self):
         """

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -2,7 +2,8 @@
 import os
 import shutil
 import logging
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, Set
+from core.pad_colors import rgb_string
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +16,84 @@ class BaseHandler:
     - Form action validation
     - Response formatting
     - Cleanup of temporary files
+    - Shared pad grid generation for set selection UI
     
     Each feature handler should inherit from this class and implement
     its own handle_post method to process specific feature requests.
     """
-    
+
+    def generate_pad_grid(
+        self,
+        used_ids: Set[int],
+        color_map: Optional[Dict[int, int]] = None,
+        name_map: Optional[Dict[int, str]] = None,
+        bpm_map: Optional[Dict[int, str]] = None,
+        selected_idx: Optional[int] = None,
+        input_name: str = "pad_index",
+        free_only: bool = False,
+    ) -> str:
+        """Generate HTML for a 32-pad grid showing set occupancy with colors, names, and BPM.
+
+        This is the standard pad grid implementation shared across all handlers
+        that need pad selection (Restore, Set Inspector, MIDI Upload, etc.).
+        Displays pad number, set name, and BPM inside each pad like the Overview page.
+
+        Args:
+            used_ids: Set of pad indices (0-31) that contain sets.
+            color_map: Optional mapping of pad index to pad color ID (1-25).
+            name_map: Optional mapping of pad index to set name.
+            bpm_map: Optional mapping of pad index to BPM string.
+            selected_idx: Optional pad index to mark as pre-selected.
+            input_name: Name attribute for the radio inputs (default: "pad_index").
+            free_only: If True, only free pads are selectable (for restore/upload).
+                         If False, only occupied pads are selectable (for set inspector).
+
+        Returns:
+            HTML string containing the pad grid div with styled radio inputs.
+        """
+        color_map = color_map or {}
+        name_map = name_map or {}
+        bpm_map = bpm_map or {}
+        cells = []
+        for row in range(4):
+            for col in range(8):
+                idx = (3 - row) * 8 + col
+                num = idx + 1
+                has_set = idx in used_ids
+
+                if free_only:
+                    # For restore/upload: only free pads selectable
+                    disabled = "disabled" if has_set else ""
+                else:
+                    # For set inspector: only occupied pads selectable
+                    disabled = "" if has_set else "disabled"
+
+                status = "occupied" if has_set else "free"
+                checked = "checked" if selected_idx is not None and idx == selected_idx else ""
+                color_id = color_map.get(idx)
+                # Generate semi-transparent background + solid border like Overview page
+                if color_id:
+                    rgb = rgb_string(color_id).replace("rgb(", "").replace(")", "")
+                    style = f' style="background-color: rgba({rgb}, 0.2); border-color: rgb({rgb});"'
+                else:
+                    style = ""
+                name = name_map.get(idx, "")
+                bpm = bpm_map.get(idx, "")
+
+                # Build inner content like Overview page
+                if has_set:
+                    inner_html = f'<div class="pad-num">{num}</div><div class="pad-name">{name}</div>'
+                    if bpm:
+                        inner_html += f'<div class="pad-bpm">{bpm} BPM</div>'
+                else:
+                    inner_html = f'<div class="pad-num">{num}</div>'
+
+                cells.append(
+                    f'<input type="radio" id="pad_{num}" name="{input_name}" value="{num}"{checked} {disabled}>'
+                    f'<label for="pad_{num}" class="pad-cell {status}"{style}>{inner_html}</label>'
+                )
+        return '<div class="pad-grid">' + "".join(cells) + "</div>"
+
     def __init__(self):
         """
         Initialize the handler with a temporary uploads directory.

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -164,6 +164,43 @@ class BaseHandler:
         except Exception as e:
             return False, None, {"message": f"Error saving uploaded file: {str(e)}", "message_type": "error"}
 
+    def save_uploaded_file(self, file_item) -> Tuple[bool, Optional[str], Optional[Dict[str, str]]]:
+        """
+        Save a single uploaded file item to a temporary directory.
+        
+        Args:
+            file_item: The file item from the form (has .filename and .file attributes)
+        
+        Returns:
+            tuple: (success, filepath, error_response)
+            - success: True if upload succeeded, False otherwise
+            - filepath: Path to saved file if successful, None otherwise
+            - error_response: Error response dict if failed, None if successful
+        
+        The caller is responsible for cleaning up the uploaded file
+        by calling cleanup_upload() when the file is no longer needed.
+        """
+        if not hasattr(file_item, "filename") or not file_item.filename:
+            return False, None, {"message": "Bad Request: Invalid file item", "message_type": "error"}
+
+        try:
+            filename = os.path.basename(file_item.filename)
+            filepath = os.path.join(self.upload_dir, filename)
+            
+            # Ensure upload directory exists
+            os.makedirs(self.upload_dir, exist_ok=True)
+            
+            # Save the file
+            with open(filepath, "wb") as f:
+                shutil.copyfileobj(file_item.file, f)
+            
+            if not os.path.exists(filepath):
+                return False, None, {"message": "File upload failed: File not saved", "message_type": "error"}
+            
+            return True, filepath, None
+        except Exception as e:
+            return False, None, {"message": f"Error saving uploaded file: {str(e)}", "message_type": "error"}
+
     def format_success_response(self, message: str, **kwargs) -> Dict[str, Any]:
         """
         Format a success response with optional additional data.

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -3,6 +3,7 @@ import html
 import os
 import shutil
 import logging
+import tempfile
 from typing import Dict, Any, Optional, Tuple, Set
 from core.pad_colors import rgb_string
 
@@ -153,10 +154,12 @@ class BaseHandler:
 
         try:
             filename = os.path.basename(file_field.filename)
-            filepath = os.path.join(self.upload_dir, filename)
-            
-            # Ensure upload directory exists
-            os.makedirs(self.upload_dir, exist_ok=True)
+            # Use a unique temp name to avoid collisions between concurrent uploads
+            fd, filepath = tempfile.mkstemp(
+                suffix=os.path.splitext(filename)[1],
+                dir=self.upload_dir,
+            )
+            os.close(fd)
             
             # Save the file
             with open(filepath, "wb") as f:
@@ -190,10 +193,13 @@ class BaseHandler:
 
         try:
             filename = os.path.basename(file_item.filename)
-            filepath = os.path.join(self.upload_dir, filename)
-            
-            # Ensure upload directory exists
-            os.makedirs(self.upload_dir, exist_ok=True)
+            # Use a unique temp name to avoid collisions between concurrent uploads
+            # with the same basename (e.g. two files named clip.mid)
+            fd, filepath = tempfile.mkstemp(
+                suffix=os.path.splitext(filename)[1],
+                dir=self.upload_dir,
+            )
+            os.close(fd)
             
             # Save the file
             with open(filepath, "wb") as f:

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import html
 import os
 import shutil
 import logging
@@ -80,8 +81,8 @@ class BaseHandler:
                     style = f' style="background-color: rgba({rgb}, 0.2); border-color: rgb({rgb});"'
                 else:
                     style = ""
-                name = name_map.get(idx, "")
-                bpm = bpm_map.get(idx, "")
+                name = html.escape(str(name_map.get(idx, "")))
+                bpm = html.escape(str(bpm_map.get(idx, "")))
 
                 # Build inner content like Overview page
                 if has_set:

--- a/handlers/base_handler.py
+++ b/handlers/base_handler.py
@@ -69,7 +69,7 @@ class BaseHandler:
                     disabled = "" if has_set else "disabled"
 
                 status = "occupied" if has_set else "free"
-                checked = "checked" if selected_idx is not None and idx == selected_idx else ""
+                checked = " checked" if selected_idx is not None and idx == selected_idx else ""
                 color_id = color_map.get(idx)
                 # Generate semi-transparent background + solid border like Overview page
                 if color_id:

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -13,6 +13,38 @@ class OverviewHandler(BaseHandler):
         """Return full sets data as JSON."""
         return get_sets_data()
 
+    def generate_pad_grid_html(self, restore_mode=False, camelot=None):
+        data = get_sets_data()
+        sets = data.get("sets", [])
+        if camelot and not restore_mode:
+            sets = [set_data for set_data in sets if set_data.get("camelot") == camelot]
+        used_ids = {set_data["slot"] for set_data in sets if set_data.get("slot") is not None}
+        color_map = {
+            set_data["slot"]: set_data["color_id"]
+            for set_data in sets
+            if set_data.get("slot") is not None and set_data.get("color_id") is not None
+        }
+        name_map = {
+            set_data["slot"]: set_data["name"]
+            for set_data in sets
+            if set_data.get("slot") is not None
+        }
+        bpm_map = {
+            set_data["slot"]: str(set_data["bpm"])
+            for set_data in sets
+            if set_data.get("slot") is not None and set_data.get("bpm") is not None
+        }
+        return self.generate_pad_grid(
+            used_ids,
+            color_map,
+            name_map,
+            bpm_map,
+            active_idx=data.get("current_slot"),
+            input_name="overview_pad",
+            free_only=restore_mode,
+            view_only=not restore_mode,
+        )
+
     def handle_get_active_slot(self):
         """Return only the current active pad slot."""
         return {'current_slot': get_active_slot()}

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -53,6 +53,10 @@ class OverviewHandler(BaseHandler):
                 result = restore_abl(filepath, pad_selected, pad_color)
 
             self.cleanup_upload(filepath)
+            if result.get("success"):
+                result["message"] = result["message"].replace(
+                    f"pad {pad_selected}", f"pad {pad_selected + 1}"
+                )
             return result
 
         except Exception as e:

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from handlers.base_handler import BaseHandler
+from core.overview_handler import get_sets_data, get_active_slot, get_system_stats
+
+
+class OverviewHandler(BaseHandler):
+    def handle_get_data(self):
+        """Return full sets data as JSON."""
+        return get_sets_data()
+
+    def handle_get_active_slot(self):
+        """Return only the current active pad slot."""
+        return {'current_slot': get_active_slot()}
+
+    def handle_get_system_stats(self):
+        """Return CPU load and memory usage."""
+        return get_system_stats()

--- a/handlers/overview_handler_class.py
+++ b/handlers/overview_handler_class.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
+import os
+import logging
 from handlers.base_handler import BaseHandler
 from core.overview_handler import get_sets_data, get_active_slot, get_system_stats
+from core.restore_handler import restore_ablbundle, restore_abl
+from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
+import json
 
 
 class OverviewHandler(BaseHandler):
@@ -15,3 +20,47 @@ class OverviewHandler(BaseHandler):
     def handle_get_system_stats(self):
         """Return CPU load and memory usage."""
         return get_system_stats()
+
+    def handle_post_restore(self, form):
+        """Handle restore POST request from Overview page."""
+        try:
+            # Validate file upload
+            success, filepath, error_response = self.handle_file_upload(form, "ablbundle")
+            if not success:
+                return {"success": False, "message": error_response.get('message', "Failed to upload file") if error_response else "Upload failed"}
+
+            # Get form values
+            pad_selected = form.getvalue("target_pad")
+            pad_color = form.getvalue("pad_color")
+
+            # Validate pad selection
+            if not pad_selected or not pad_selected.isdigit():
+                self.cleanup_upload(filepath)
+                return {"success": False, "message": "Please select a target pad from the grid."}
+
+            # Validate color
+            if not pad_color or not pad_color.isdigit():
+                self.cleanup_upload(filepath)
+                return {"success": False, "message": "Please select a pad color."}
+
+            pad_selected = int(pad_selected) - 1  # Convert to internal ID (0-31)
+            pad_color = int(pad_color)
+
+            # Execute restore
+            if filepath.lower().endswith('.ablbundle'):
+                result = restore_ablbundle(filepath, pad_selected, pad_color)
+            else:
+                result = restore_abl(filepath, pad_selected, pad_color)
+
+            self.cleanup_upload(filepath)
+            return result
+
+        except Exception as e:
+            logging.error(f"Error in handle_post_restore: {str(e)}")
+            return {"success": False, "message": f"Error restoring set: {str(e)}"}
+
+    def generate_color_options_json(self):
+        """Return pad colors and labels as JSON for client-side use."""
+        colors = [PAD_COLORS[i] for i in sorted(PAD_COLORS)]
+        names = [PAD_COLOR_LABELS[i] for i in sorted(PAD_COLOR_LABELS)]
+        return {"colors": colors, "names": names}

--- a/handlers/restore_handler_class.py
+++ b/handlers/restore_handler_class.py
@@ -3,7 +3,7 @@ import logging
 from handlers.base_handler import BaseHandler
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle, restore_abl
-from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS, rgb_string
+from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
 import json
 
 class RestoreHandler(BaseHandler):
@@ -22,7 +22,9 @@ class RestoreHandler(BaseHandler):
             msets, ids = list_msets(return_free_ids=True)
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             logging.info(f"Available Pads: {free_pads}")
 
             return {
@@ -55,7 +57,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             error_response["options"] = options
             error_response["color_options"] = self.generate_color_options()
             error_response["pad_grid"] = pad_grid
@@ -70,7 +74,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad selection provided.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
         # Early validation: color
         if not pad_color or not pad_color.isdigit():
@@ -78,7 +84,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad color provided.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
 
         pad_selected = int(pad_selected) - 1  # Convert back to internal ID
@@ -89,14 +97,18 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad selection. Must be between 1 and 32.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
         if not (1 <= pad_color <= 25):
             msets, ids = list_msets(return_free_ids=True)
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response("Invalid pad color. Must be between 1 and 25.", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
 
         success, filepath, error_response = self.handle_file_upload(form, "ablbundle")
@@ -105,7 +117,9 @@ class RestoreHandler(BaseHandler):
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             if error_response is None:
                 error_response = {}
             error_response["options"] = options
@@ -126,7 +140,9 @@ class RestoreHandler(BaseHandler):
                 free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
                 options = self.generate_pad_options(free_pads)
                 color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+                name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+                bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
                 return self.format_success_response(result["message"], options, pad_grid)
             else:
                 # Regenerate available pad options on error
@@ -134,14 +150,18 @@ class RestoreHandler(BaseHandler):
                 free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
                 options = self.generate_pad_options(free_pads)
                 color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+                name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+                bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+                pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
                 return self.format_error_response(result["message"], options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
         except Exception as e:
             msets, ids = list_msets(return_free_ids=True)
             free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
             options = self.generate_pad_options(free_pads)
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, input_name="mset_index", free_only=True)
             return self.format_error_response(f"Error restoring bundle: {str(e)}", options=options, pad_grid=pad_grid, color_options=self.generate_color_options())
 
     def generate_pad_options(self, free_pads):
@@ -166,24 +186,6 @@ class RestoreHandler(BaseHandler):
             "pad_grid": pad_grid,
         }
 
-    def generate_pad_grid(self, used_ids, color_map):
-        """Return HTML for a 32-pad grid showing occupied pads with colors."""
-        cells = []
-        for row in range(4):
-            for col in range(8):
-                idx = (3 - row) * 8 + col
-                num = idx + 1
-                occupied = idx in used_ids
-                status = 'occupied' if occupied else 'free'
-                disabled = 'disabled' if occupied else ''
-                color_id = color_map.get(idx)
-                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
-                label_text = "" if not occupied else ""
-                cells.append(
-                    f'<input type="radio" id="restore_pad_{num}" name="mset_index" value="{num}" {disabled}>'
-                    f'<label for="restore_pad_{num}" class="pad-cell {status}"{style}>{label_text}</label>'
-                )
-        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
 
     def generate_color_options(self, input_name="mset_color", pad_input_name="mset_index"):
         """Return HTML for the custom color dropdown with pad preview."""

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -37,7 +37,13 @@ class SetInspectorHandler(BaseHandler):
                 status = 'occupied' if entry else 'free'
                 disabled = '' if entry else 'disabled'
                 color_id = entry.get("color") if entry else None
-                style = f' style="background-color: {rgb_string(int(color_id))}"' if color_id else ''
+                # Use clip color or default gray for clips without color
+                if color_id:
+                    style = f' style="background-color: {rgb_string(int(color_id))}"'
+                elif entry:
+                    style = ' style="background-color: rgb(200, 200, 200)"'  # Default gray for clips
+                else:
+                    style = ''
                 name_attr = f' data-name="{entry.get("name", "")}"' if entry else ''
                 cells.append(
                     f'<input type="radio" id="clip_{track}_{clip}" name="clip_select" value="{value}"{checked} {disabled}>'

--- a/handlers/set_inspector_handler_class.py
+++ b/handlers/set_inspector_handler_class.py
@@ -18,35 +18,6 @@ import json
 import os
 
 class SetInspectorHandler(BaseHandler):
-    def generate_pad_grid(self, used_ids, color_map, name_map, selected_idx=None):
-        """Return HTML for a 32-pad grid showing sets with colors.
-
-        Args:
-            used_ids (set): Pad indices that contain sets.
-            color_map (dict): Mapping of pad index to pad color ID.
-            name_map (dict): Mapping of pad index to set name.
-            selected_idx (int, optional): Pad index to mark as selected.
-        """
-        cells = []
-        for row in range(4):
-            for col in range(8):
-                idx = (3 - row) * 8 + col
-                num = idx + 1
-                has_set = idx in used_ids
-                status = 'occupied' if has_set else 'free'
-                disabled = '' if has_set else 'disabled'
-                checked = ' checked' if selected_idx is not None and idx == selected_idx else ''
-                color_id = color_map.get(idx)
-                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
-                name_attr = (
-                    f" data-name=\"{name_map.get(idx, '')}\"" if idx in name_map else ""
-                )
-                cells.append(
-                    f'<input type="radio" id="inspect_pad_{num}" name="pad_index" value="{num}"{checked} {disabled}>'
-                    f'<label for="inspect_pad_{num}" class="pad-cell {status}"{style}{name_attr}></label>'
-                )
-        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
-
     def generate_clip_grid(self, clips, selected=None):
         """Return HTML for an 8x8 grid of clips including empty slots."""
         clip_map = {(c["track"], c["clip"]): c for c in clips}
@@ -83,8 +54,9 @@ class SetInspectorHandler(BaseHandler):
             if str(m["mset_color"]).isdigit()
         }
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
         selected_idx = None
-        pad_grid = self.generate_pad_grid(used, color_map, name_map)
+        pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
         return {
             "pad_grid": pad_grid,
             "message": "Select a set to inspect",
@@ -113,7 +85,8 @@ class SetInspectorHandler(BaseHandler):
             if str(m["mset_color"]).isdigit()
         }
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
-        pad_grid = self.generate_pad_grid(used, color_map, name_map)
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+        pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
 
         if action == "select_set":
             pad_val = form.getvalue("pad_index")
@@ -122,7 +95,7 @@ class SetInspectorHandler(BaseHandler):
                 idx = int(pad_val) - 1
                 entry = next((m for m in msets if m.get("mset_id") == idx), None)
                 if not entry:
-                    pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                    pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                     return self.format_error_response("No set on selected pad", pad_grid=pad_grid)
                 set_path = os.path.join(
                     MSETS_DIRECTORY,
@@ -139,15 +112,15 @@ class SetInspectorHandler(BaseHandler):
                 if entry:
                     selected_idx = int(entry.get("mset_id"))
             if not set_path:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("No set selected", pad_grid=pad_grid)
             result = list_clips(set_path)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_grid = self.generate_clip_grid(result.get("clips", []))
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {
@@ -172,7 +145,7 @@ class SetInspectorHandler(BaseHandler):
             set_path = form.getvalue("set_path")
             clip_val = form.getvalue("clip_select")
             if not set_path or not clip_val:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -183,7 +156,7 @@ class SetInspectorHandler(BaseHandler):
             track_idx, clip_idx = map(int, clip_val.split(":"))
             result = get_clip_data(set_path, track_idx, clip_idx)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_info = list_clips(set_path)
             clip_grid = self.generate_clip_grid(clip_info.get("clips", []), selected=clip_val)
@@ -201,7 +174,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {
@@ -234,7 +207,7 @@ class SetInspectorHandler(BaseHandler):
             param_val = form.getvalue("parameter_id")
             env_data = form.getvalue("envelope_data")
             if not (set_path and clip_val and param_val and env_data):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -246,11 +219,11 @@ class SetInspectorHandler(BaseHandler):
             try:
                 breakpoints = json.loads(env_data)
             except Exception:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("Invalid envelope data", pad_grid=pad_grid)
             result = save_envelope(set_path, track_idx, clip_idx, int(param_val), breakpoints)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_info = list_clips(set_path)
             clip_grid = self.generate_clip_grid(clip_info.get("clips", []), selected=clip_val)
@@ -275,7 +248,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             ro_state = is_read_only(set_path)
             return {
                 "pad_grid": pad_grid,
@@ -317,7 +290,7 @@ class SetInspectorHandler(BaseHandler):
                 and loop_start_val is not None
                 and loop_end_val is not None
             ):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -333,7 +306,7 @@ class SetInspectorHandler(BaseHandler):
                 loop_start = float(loop_start_val)
                 loop_end = float(loop_end_val)
             except Exception:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("Invalid clip data", pad_grid=pad_grid)
             from core.set_inspector_handler import save_clip
 
@@ -348,7 +321,7 @@ class SetInspectorHandler(BaseHandler):
                 loop_end,
             )
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_info = list_clips(set_path)
             clip_grid = self.generate_clip_grid(clip_info.get("clips", []), selected=clip_val)
@@ -368,7 +341,7 @@ class SetInspectorHandler(BaseHandler):
             )
             env_opts = '<option value="">No Envelope</option>' + env_opts
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             ro_state = is_read_only(set_path)
             return {
                 "pad_grid": pad_grid,
@@ -397,7 +370,7 @@ class SetInspectorHandler(BaseHandler):
             set_path = form.getvalue("set_path")
             ro_val = form.getvalue("make_read_only")
             if not set_path or ro_val not in ("true", "false"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -407,15 +380,15 @@ class SetInspectorHandler(BaseHandler):
                 selected_idx = int(entry.get("mset_id"))
             perm_result = set_read_only(set_path, ro_val == "true")
             if not perm_result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(perm_result.get("message"), pad_grid=pad_grid)
             result = list_clips(set_path)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_grid = self.generate_clip_grid(result.get("clips", []))
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {
@@ -440,7 +413,7 @@ class SetInspectorHandler(BaseHandler):
             set_path = form.getvalue("set_path")
             backup_name = form.getvalue("backup_file")
             if not set_path or not backup_name:
-                pad_grid = self.generate_pad_grid(used, color_map, name_map)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map)
                 return self.format_error_response("Missing parameters", pad_grid=pad_grid)
             entry = next(
                 (m for m in msets if os.path.join(MSETS_DIRECTORY, m["uuid"], m["mset_name"], "Song.abl") == set_path),
@@ -449,15 +422,15 @@ class SetInspectorHandler(BaseHandler):
             if entry:
                 selected_idx = int(entry.get("mset_id"))
             if not restore_backup(set_path, backup_name):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response("Backup not found", pad_grid=pad_grid)
             result = list_clips(set_path)
             if not result.get("success"):
-                pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+                pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
                 return self.format_error_response(result.get("message"), pad_grid=pad_grid)
             clip_grid = self.generate_clip_grid(result.get("clips", []))
             set_name = os.path.basename(os.path.dirname(set_path))
-            pad_grid = self.generate_pad_grid(used, color_map, name_map, selected_idx)
+            pad_grid = self.generate_pad_grid(used, color_map, name_map, bpm_map, selected_idx)
             backups = list_backups(set_path)
             ro_state = is_read_only(set_path)
             return {

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -364,6 +364,9 @@ class SetManagementHandler(BaseHandler):
             except Exception as e:
                 logger.warning("Failed to clean up set file %s: %s", set_path, e)
 
+            # Refresh library so Move picks up the new set
+            refresh_library()
+
             # Refresh pad list after successful placement
             msets_updated, updated_ids = list_msets(return_free_ids=True)
             updated_free_pads = sorted([pad_id + 1 for pad_id in updated_ids.get("free", [])])

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -175,11 +175,15 @@ class SetManagementHandler(BaseHandler):
                                 break
                         if existing_uuid:
                             existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid, existing_set_name, "Song.abl")
+                            import logging
+                            logging.info(f"Found existing set {existing_set_name} with UUID {existing_uuid}, path: {existing_path}")
                         else:
                             # Fallback - try direct path
                             existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
                             if not existing_path.endswith('.abl'):
                                 existing_path += '.abl'
+                            import logging
+                            logging.warning(f"Could not find UUID for {existing_set_name}, using fallback: {existing_path}")
                         # Use the existing set name for saving
                         final_set_name = existing_set_name
                     else:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -286,8 +286,6 @@ class SetManagementHandler(BaseHandler):
         # Parse pad assignment (only for new set creation)
         pad_selected = form.getvalue('pad_index')
         pad_color = form.getvalue('pad_color')
-        import logging
-        logging.info(f"DEBUG: pad_selected={pad_selected}, pad_color={pad_color}")
         if not pad_selected or not pad_selected.isdigit():
             return self.format_error_response(
                 "Invalid pad selection",

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -74,150 +74,155 @@ class SetManagementHandler(BaseHandler):
             existing_set_options += f'<option value="{name}">{name} ({bpm} BPM)</option>'
 
         if action == 'upload_midi':
-            # Generate set from uploaded MIDI file
+            # Handle multi-file MIDI upload with track assignments
             set_name = form.getvalue('set_name', '')
-            midi_type = form.getvalue('midi_type', 'melodic')
+            set_mode = form.getvalue('set_mode', 'new')
             
-            # For assign-to-track with existing set, we don't need set_name
+            # Validate set name for new sets
             pad_color_for_clip = None
-            if midi_type == 'assigntotrack':
-                set_mode = form.getvalue('set_mode', 'new')
-                if set_mode == 'new':
-                    if not set_name:
-                        return self.format_error_response(
-                            "Please enter a name for the new set",
-                            pad_options=pad_options,
-                            pad_color_options=pad_color_options,
-                            clip_color_options=clip_color_options,
-                            pad_grid=pad_grid,
-                            existing_set_options=existing_set_options,
-                        )
-                    # Get pad color early for new sets (will be used as clip color)
-                    pad_color_str = form.getvalue('pad_color', '1')
-                    pad_color_for_clip = int(pad_color_str) if pad_color_str and pad_color_str.isdigit() else 1
-                # For existing set mode, we'll validate existing_set_name later
-            elif not set_name:
-                # For non-assign-to-track modes, set_name is always required
-                return self.format_error_response(
-                    "Missing required parameter: set_name",
-                    pad_options=pad_options,
-                    pad_color_options=pad_color_options,
-                    clip_color_options=clip_color_options,
-                    pad_grid=pad_grid,
-                    existing_set_options=existing_set_options,
-                )
+            if set_mode == 'new':
+                if not set_name:
+                    return self.format_error_response(
+                        "Please enter a name for the new set",
+                        pad_options=pad_options,
+                        pad_color_options=pad_color_options,
+                        clip_color_options=clip_color_options,
+                        pad_grid=pad_grid,
+                        existing_set_options=existing_set_options,
+                    )
+                # Get pad color early for new sets (will be used as clip color)
+                pad_color_str = form.getvalue('pad_color', '1')
+                pad_color_for_clip = int(pad_color_str) if pad_color_str and pad_color_str.isdigit() else 1
             
-            # Handle file upload
-            if 'midi_file' not in form:
-                return self.format_error_response(
-                    "No MIDI file uploaded",
-                    pad_options=pad_options,
-                    pad_color_options=pad_color_options,
-                    clip_color_options=clip_color_options,
-                    pad_grid=pad_grid,
-                    existing_set_options=existing_set_options,
-                )
-            
-            fileitem = form['midi_file']
-            if not fileitem.filename:
-                return self.format_error_response(
-                    "No MIDI file selected",
-                    pad_options=pad_options,
-                    pad_color_options=pad_color_options,
-                    clip_color_options=clip_color_options,
-                    pad_grid=pad_grid,
-                    existing_set_options=existing_set_options,
-                )
-            
-            # Check file extension
-            filename = fileitem.filename.lower()
-            if not (filename.endswith('.mid') or filename.endswith('.midi')):
-                return self.format_error_response(
-                    "Invalid file type. Please upload a .mid or .midi file",
-                    pad_options=pad_options,
-                    pad_color_options=pad_color_options,
-                    clip_color_options=clip_color_options,
-                    pad_grid=pad_grid,
-                    existing_set_options=existing_set_options,
-                )
-            
-            # Save uploaded file temporarily
-            success, filepath, error_response = self.handle_file_upload(form, 'midi_file')
-            if not success:
-                return self.format_error_response(
-                    error_response.get('message', "Failed to upload MIDI file"),
-                    pad_options=pad_options,
-                    pad_color_options=pad_color_options,
-                    clip_color_options=clip_color_options,
-                    pad_grid=pad_grid,
-                    existing_set_options=existing_set_options,
-                )
-            
-            try:
-                # Get tempo if provided
-                tempo_str = form.getvalue('tempo')
-                tempo = float(tempo_str) if tempo_str and tempo_str.strip() else None
-
-                # Dispatch based on MIDI type
-                midi_type = form.getvalue('midi_type', 'melodic')
-                if midi_type == 'drum':
-                    result = generate_drum_set_from_file(set_name, filepath, tempo)
-                elif midi_type == 'multichannel':
-                    result = generate_multichannel_midi_set(set_name, filepath, tempo)
-                elif midi_type == 'assigntotrack':
-                    # Handle assign to track mode
-                    target_track_str = form.getvalue('target_track', '1')
-                    target_track = int(target_track_str) if target_track_str.isdigit() else 1
-                    set_mode = form.getvalue('set_mode', 'new')
-                    
-                    if set_mode == 'existing':
-                        # Use existing set name from dropdown
-                        existing_set_name = form.getvalue('existing_set_name', '')
-                        if not existing_set_name:
-                            return self.format_error_response(
-                                "Please select an existing set",
-                                pad_options=pad_options,
-                                pad_color_options=pad_color_options,
-                                clip_color_options=clip_color_options,
-                                pad_grid=pad_grid,
-                                existing_set_options=existing_set_options,
-                            )
-                        # Find the set's UUID to construct correct path
-                        existing_uuid = None
-                        for m in msets:
-                            if m["mset_name"] == existing_set_name:
-                                existing_uuid = m["uuid"]
-                                break
-                        if existing_uuid:
-                            existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid, existing_set_name, "Song.abl")
-                        else:
-                            # Fallback - try direct path
-                            existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
-                            if not existing_path.endswith('.abl'):
-                                existing_path += '.abl'
-                        # Use the existing set name for saving
-                        final_set_name = existing_set_name
-                    else:
-                        # Create new set - name already validated above
-                        existing_path = None
-                        final_set_name = set_name
-                    
-                    # Get clip color - use selected clip color for existing sets, pad color for new sets
-                    clip_color = None
-                    if set_mode == 'existing':
-                        clip_color_str = form.getvalue('clip_color', '1')
-                        clip_color = int(clip_color_str) if clip_color_str.isdigit() else 1
-                    else:
-                        # For new sets, use the pad color as clip color
-                        clip_color = pad_color_for_clip
-                    
-                    result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo, clip_color)
+            # Validate existing set selection for existing mode
+            existing_path = None
+            final_set_name = set_name
+            if set_mode == 'existing':
+                existing_set_name = form.getvalue('existing_set_name', '')
+                if not existing_set_name:
+                    return self.format_error_response(
+                        "Please select an existing set",
+                        pad_options=pad_options,
+                        pad_color_options=pad_color_options,
+                        clip_color_options=clip_color_options,
+                        pad_grid=pad_grid,
+                        existing_set_options=existing_set_options,
+                    )
+                # Find the set's UUID to construct correct path
+                existing_uuid = None
+                for m in msets:
+                    if m["mset_name"] == existing_set_name:
+                        existing_uuid = m["uuid"]
+                        break
+                if existing_uuid:
+                    existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid, existing_set_name, "Song.abl")
                 else:
-                    result = generate_midi_set_from_file(set_name, filepath, tempo)
-
+                    # Fallback - try direct path
+                    existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
+                    if not existing_path.endswith('.abl'):
+                        existing_path += '.abl'
+                final_set_name = existing_set_name
+            
+            # Handle file uploads - support multiple files
+            file_list = []
+            if 'midi_files' in form:
+                # Handle multiple files
+                files = form.getlist('midi_files') if hasattr(form, 'getlist') else [form['midi_files']]
+                for i, fileitem in enumerate(files):
+                    if fileitem.filename:
+                        file_list.append((i, fileitem))
+            
+            if not file_list:
+                return self.format_error_response(
+                    "No MIDI files uploaded",
+                    pad_options=pad_options,
+                    pad_color_options=pad_color_options,
+                    clip_color_options=clip_color_options,
+                    pad_grid=pad_grid,
+                    existing_set_options=existing_set_options,
+                )
+            
+            # Get clip color for existing sets (new sets use pad_color_for_clip per file)
+            clip_color = None
+            if set_mode == 'existing':
+                clip_color_str = form.getvalue('clip_color', '1')
+                clip_color = int(clip_color_str) if clip_color_str.isdigit() else 1
+            
+            # Get tempo if provided
+            tempo_str = form.getvalue('tempo')
+            tempo = float(tempo_str) if tempo_str and tempo_str.strip() else None
+            
+            # Process each file with its track assignment
+            temp_files = []
+            results = []
+            try:
+                for i, fileitem in file_list:
+                    # Get track assignment for this file
+                    track_str = form.getvalue(f'track_{i}', '1')
+                    target_track = int(track_str) if track_str.isdigit() else 1
+                    
+                    # Save uploaded file temporarily
+                    success, filepath, error_response = self.save_uploaded_file(fileitem)
+                    if not success:
+                        results.append({'success': False, 'message': f"File {fileitem.filename}: {error_response.get('message', 'Upload failed')}"})
+                        continue
+                    
+                    temp_files.append(filepath)
+                    
+                    # Determine clip color for this file
+                    file_clip_color = clip_color if set_mode == 'existing' else pad_color_for_clip
+                    
+                    # Process the MIDI file
+                    result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo, file_clip_color)
+                    result['filename'] = fileitem.filename
+                    result['track'] = target_track
+                    results.append(result)
+                    
+                    # For subsequent files, use the updated existing_path (set was created/modified)
+                    if existing_path is None and result.get('success'):
+                        # First file created the set, update path for subsequent files
+                        output_dir = "/data/UserData/UserLibrary/Sets"
+                        existing_path = os.path.join(output_dir, final_set_name)
+                        if not existing_path.endswith('.abl'):
+                            existing_path += '.abl'
+                
+                # Aggregate results
+                success_count = sum(1 for r in results if r.get('success'))
+                failure_count = len(results) - success_count
+                
+                if failure_count == 0:
+                    # All succeeded
+                    if len(results) == 1:
+                        result = results[0]
+                    else:
+                        # Build summary message
+                        track_summary = []
+                        for r in results:
+                            track_summary.append(f"{r['filename']} → Track {r['track']}")
+                        result = {
+                            'success': True,
+                            'message': f"Successfully imported {success_count} file(s): " + ", ".join(track_summary)
+                        }
+                elif success_count == 0:
+                    # All failed
+                    errors = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results]
+                    result = {
+                        'success': False,
+                        'message': "All imports failed: " + "; ".join(errors)
+                    }
+                else:
+                    # Mixed results
+                    success_files = [r['filename'] for r in results if r.get('success')]
+                    failed_files = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results if not r.get('success')]
+                    result = {
+                        'success': True,  # Partial success
+                        'message': f"Partial success: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})"
+                    }
+            
             finally:
-                # Clean up uploaded file
-                self.cleanup_upload(filepath)
+                # Clean up all temporary files
+                for filepath in temp_files:
+                    self.cleanup_upload(filepath)
 
         else:
             return self.format_error_response(
@@ -240,16 +245,14 @@ class SetManagementHandler(BaseHandler):
             )
 
         # Check if this is "add to existing set" mode - skip restore/bundle
-        is_add_to_existing = (
-            midi_type == 'assigntotrack' and
-            form.getvalue('set_mode', 'new') == 'existing'
-        )
+        is_add_to_existing = set_mode == 'existing'
 
         if is_add_to_existing:
             # For existing set mode, file is already saved - just return success
             # The set stays on its original pad
+            existing_set_name = form.getvalue('existing_set_name', '')
             return self.format_success_response(
-                f"MIDI assigned to {form.getvalue('target_track', '1')} in existing set '{form.getvalue('existing_set_name', '')}'",
+                f"{result.get('message', 'MIDI imported')} in existing set '{existing_set_name}'",
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
                 clip_color_options=clip_color_options,

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -3,6 +3,7 @@ import os
 import zipfile
 import tempfile
 import shutil
+import subprocess
 import logging
 from core.set_management_handler import (
     create_set, generate_midi_set_from_file, generate_drum_set_from_file,
@@ -102,6 +103,7 @@ class SetManagementHandler(BaseHandler):
             
             # Validate existing set selection for existing mode
             existing_path = None
+            existing_uuid = None
             final_set_name = set_name
             if set_mode == 'existing':
                 existing_set_name = form.getvalue('existing_set_name', '')
@@ -115,7 +117,6 @@ class SetManagementHandler(BaseHandler):
                         existing_set_options=existing_set_options,
                     )
                 # Find the set's UUID to construct correct path
-                existing_uuid = None
                 for m in msets:
                     if m["mset_name"] == existing_set_name:
                         existing_uuid = m["uuid"]
@@ -296,7 +297,14 @@ class SetManagementHandler(BaseHandler):
         is_add_to_existing = set_mode == 'existing'
 
         if is_add_to_existing:
-            # For existing set mode, file is already saved - refresh library so Move picks up the change
+            # For existing set mode, file is already saved
+            # Set was-externally-modified so Move reloads the Song.abl
+            if existing_uuid:
+                uuid_dir = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid)
+                try:
+                    subprocess.run(["setfattr", "-n", "user.was-externally-modified", "-v", "true", uuid_dir], check=True)
+                except Exception as e:
+                    logger.warning("Failed to set was-externally-modified: %s", e)
             refresh_library()
             existing_set_name = form.getvalue('existing_set_name', '')
             return self.format_success_response(
@@ -348,15 +356,6 @@ class SetManagementHandler(BaseHandler):
         with tempfile.TemporaryDirectory() as tmpdir:
             song_abl_path = os.path.join(tmpdir, 'Song.abl')
             shutil.copy(set_path, song_abl_path)
-            # Debug: verify clips in the file being bundled
-            try:
-                import json as _json
-                with open(song_abl_path, 'r') as _f:
-                    _data = _json.load(_f)
-                _clip_count = sum(1 for t in _data.get('tracks', []) for s in t.get('clipSlots', []) if s.get('clip') is not None)
-                logger.info("Bundling: set_path=%s, clips_in_file=%d", set_path, _clip_count)
-            except Exception as _e:
-                logger.warning("Bundling: could not verify clips: %s", _e)
             # Name bundle based on set name without .abl extension
             base_path, _ = os.path.splitext(set_path)
             bundle_path = base_path + '.ablbundle'
@@ -364,7 +363,6 @@ class SetManagementHandler(BaseHandler):
                 zf.write(song_abl_path, 'Song.abl')
             # Restore to device
             restore_result = restore_ablbundle(bundle_path, pad_selected_int, pad_color_int)
-            logger.info("Restore result: success=%s, message=%s", restore_result.get('success'), restore_result.get('message'))
             os.remove(bundle_path)
 
         if restore_result.get('success'):

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -79,17 +79,22 @@ class SetManagementHandler(BaseHandler):
             midi_type = form.getvalue('midi_type', 'melodic')
             
             # For assign-to-track with existing set, we don't need set_name
+            pad_color_for_clip = None
             if midi_type == 'assigntotrack':
                 set_mode = form.getvalue('set_mode', 'new')
-                if set_mode == 'new' and not set_name:
-                    return self.format_error_response(
-                        "Please enter a name for the new set",
-                        pad_options=pad_options,
-                        pad_color_options=pad_color_options,
-                        clip_color_options=clip_color_options,
-                        pad_grid=pad_grid,
-                        existing_set_options=existing_set_options,
-                    )
+                if set_mode == 'new':
+                    if not set_name:
+                        return self.format_error_response(
+                            "Please enter a name for the new set",
+                            pad_options=pad_options,
+                            pad_color_options=pad_color_options,
+                            clip_color_options=clip_color_options,
+                            pad_grid=pad_grid,
+                            existing_set_options=existing_set_options,
+                        )
+                    # Get pad color early for new sets (will be used as clip color)
+                    pad_color_str = form.getvalue('pad_color', '1')
+                    pad_color_for_clip = int(pad_color_str) if pad_color_str and pad_color_str.isdigit() else 1
                 # For existing set mode, we'll validate existing_set_name later
             elif not set_name:
                 # For non-assign-to-track modes, set_name is always required
@@ -197,11 +202,14 @@ class SetManagementHandler(BaseHandler):
                         existing_path = None
                         final_set_name = set_name
                     
-                    # Get clip color for existing set mode
+                    # Get clip color - use selected clip color for existing sets, pad color for new sets
                     clip_color = None
                     if set_mode == 'existing':
                         clip_color_str = form.getvalue('clip_color', '1')
                         clip_color = int(clip_color_str) if clip_color_str.isdigit() else 1
+                    else:
+                        # For new sets, use the pad color as clip color
+                        clip_color = pad_color_for_clip
                     
                     result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo, clip_color)
                 else:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -184,7 +184,13 @@ class SetManagementHandler(BaseHandler):
                         existing_path = None
                         final_set_name = set_name
                     
-                    result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo)
+                    # Get clip color for existing set mode
+                    clip_color = None
+                    if set_mode == 'existing':
+                        clip_color_str = form.getvalue('clip_color', '1')
+                        clip_color = int(clip_color_str) if clip_color_str.isdigit() else 1
+                    
+                    result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo, clip_color)
                 else:
                     result = generate_midi_set_from_file(set_name, filepath, tempo)
 

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -348,6 +348,15 @@ class SetManagementHandler(BaseHandler):
         with tempfile.TemporaryDirectory() as tmpdir:
             song_abl_path = os.path.join(tmpdir, 'Song.abl')
             shutil.copy(set_path, song_abl_path)
+            # Debug: verify clips in the file being bundled
+            try:
+                import json as _json
+                with open(song_abl_path, 'r') as _f:
+                    _data = _json.load(_f)
+                _clip_count = sum(1 for t in _data.get('tracks', []) for s in t.get('clipSlots', []) if s.get('clip') is not None)
+                logger.info("Bundling: set_path=%s, clips_in_file=%d", set_path, _clip_count)
+            except Exception as _e:
+                logger.warning("Bundling: could not verify clips: %s", _e)
             # Name bundle based on set name without .abl extension
             base_path, _ = os.path.splitext(set_path)
             bundle_path = base_path + '.ablbundle'
@@ -355,6 +364,7 @@ class SetManagementHandler(BaseHandler):
                 zf.write(song_abl_path, 'Song.abl')
             # Restore to device
             restore_result = restore_ablbundle(bundle_path, pad_selected_int, pad_color_int)
+            logger.info("Restore result: success=%s, message=%s", restore_result.get('success'), restore_result.get('message'))
             os.remove(bundle_path)
 
         if restore_result.get('success'):

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -10,7 +10,7 @@ from core.set_management_handler import (
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
-from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS, rgb_string
+from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
 import json
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,9 @@ class SetManagementHandler(BaseHandler):
         pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + pad_options
         pad_color_options = self.generate_color_options()
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+        name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
         return {
             'pad_options': pad_options,
             'pad_color_options': pad_color_options,
@@ -48,7 +50,9 @@ class SetManagementHandler(BaseHandler):
         pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in free_pads)
         pad_color_options = self.generate_color_options()
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+        name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+        bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+        pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
 
         if action == 'upload_midi':
             # Generate set from uploaded MIDI file
@@ -186,32 +190,16 @@ class SetManagementHandler(BaseHandler):
             updated_pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in updated_free_pads)
             updated_pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + updated_pad_options
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets_updated if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(updated_ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets_updated}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets_updated if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(updated_ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
             return self.format_success_response(restore_result['message'], pad_options=updated_pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid)
         else:
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
-            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map)
+            name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
+            bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
+            pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
             return self.format_error_response(restore_result.get('message'), pad_options=pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid)
-
-    def generate_pad_grid(self, used_ids, color_map):
-        """Return HTML for a 32-pad grid showing occupied pads with colors."""
-        cells = []
-        # Pad numbering starts with 1 on the bottom-left
-        for row in range(4):
-            for col in range(8):
-                idx = (3 - row) * 8 + col
-                num = idx + 1
-                occupied = idx in used_ids
-                status = 'occupied' if occupied else 'free'
-                disabled = 'disabled' if occupied else ''
-                color_id = color_map.get(idx)
-                style = f' style="background-color: {rgb_string(color_id)}"' if color_id else ''
-                label_text = "" if not occupied else ""
-                cells.append(
-                    f'<input type="radio" id="pad_{num}" name="pad_index" value="{num}" {disabled}>'
-                    f'<label for="pad_{num}" class="pad-cell {status}"{style}>{label_text}</label>'
-                )
-        return '<div class="pad-grid">' + ''.join(cells) + '</div>'
 
     def generate_color_options(self, input_name="pad_color", pad_input_name="pad_index"):
         """Return HTML for the custom color dropdown with pad preview."""

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -78,6 +78,11 @@ class SetManagementHandler(BaseHandler):
             # Handle multi-file MIDI upload with track assignments
             set_name = form.getvalue('set_name', '')
             set_mode = form.getvalue('set_mode', 'new')
+            midi_type = form.getvalue('midi_type', 'melodic')
+            
+            # Drum mode always creates a new set
+            if midi_type == 'drum':
+                set_mode = 'new'
             
             # Validate set name for new sets
             pad_color_for_clip = None
@@ -155,85 +160,103 @@ class SetManagementHandler(BaseHandler):
             tempo_str = form.getvalue('tempo')
             tempo = float(tempo_str) if tempo_str and tempo_str.strip() else None
             
-            # Process each file with its track assignment
-            temp_files = []
-            results = []
-            try:
-                for i, fileitem in file_list:
-                    # Get track assignment for this file
-                    track_str = form.getvalue(f'track_{i}', '1')
-                    target_track = int(track_str) if track_str.isdigit() else 1
-                    
-                    # Save uploaded file temporarily
+            # Drum import: single file, 808 pad mapping
+            if midi_type == 'drum':
+                temp_files = []
+                try:
+                    i, fileitem = file_list[0]
                     success, filepath, error_response = self.save_uploaded_file(fileitem)
                     if not success:
-                        results.append({'success': False, 'message': f"File {fileitem.filename}: {error_response.get('message', 'Upload failed')}"})
-                        continue
-                    
-                    temp_files.append(filepath)
-                    
-                    # Determine clip color for this file
-                    file_clip_color = clip_color if set_mode == 'existing' else pad_color_for_clip
-                    
-                    # Process the MIDI file
-                    result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo, file_clip_color)
-                    result['filename'] = fileitem.filename
-                    result['track'] = target_track
-                    results.append(result)
-                    
-                    # For subsequent files, use the updated existing_path (set was created/modified)
-                    if existing_path is None and result.get('success'):
-                        # First file created the set, update path for subsequent files
-                        output_dir = "/data/UserData/UserLibrary/Sets"
-                        existing_path = os.path.join(output_dir, final_set_name)
-                        if not existing_path.endswith('.abl'):
-                            existing_path += '.abl'
-                
-                # Aggregate results
-                success_count = sum(1 for r in results if r.get('success'))
-                failure_count = len(results) - success_count
-                
-                if failure_count == 0:
-                    # All succeeded
-                    if len(results) == 1:
-                        result = results[0]
+                        result = {'success': False, 'message': f"Upload failed: {error_response.get('message', 'Unknown error')}"}
                     else:
-                        # Build summary message
-                        track_summary = []
-                        for r in results:
-                            track_summary.append(f"{r['filename']} → Track {r['track']}")
-                        result = {
-                            'success': True,
-                            'message': f"Successfully imported {success_count} file(s): " + ", ".join(track_summary),
-                            'path': results[0].get('path')  # Include path from first result for new set bundling
-                        }
-                elif success_count == 0:
-                    # All failed
-                    errors = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results]
-                    result = {
-                        'success': False,
-                        'message': "All imports failed: " + "; ".join(errors)
-                    }
-                else:
-                    # Mixed results
-                    success_files = [r['filename'] for r in results if r.get('success')]
-                    failed_files = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results if not r.get('success')]
-                    # Find path from first successful result
-                    first_success_path = None
-                    for r in results:
-                        if r.get('success') and r.get('path'):
-                            first_success_path = r.get('path')
-                            break
-                    result = {
-                        'success': True,  # Partial success
-                        'message': f"Partial success: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})",
-                        'path': first_success_path  # Include path if any succeeded (for new set bundling)
-                    }
+                        temp_files.append(filepath)
+                        result = generate_drum_set_from_file(set_name, filepath, tempo=tempo)
+                        result['filename'] = fileitem.filename
+                finally:
+                    for fp in temp_files:
+                        self.cleanup_upload(fp)
             
-            finally:
-                # Clean up all temporary files
-                for filepath in temp_files:
-                    self.cleanup_upload(filepath)
+            # Melodic import: multi-file, per-track assignment
+            else:
+                # Process each file with its track assignment
+                temp_files = []
+                results = []
+                try:
+                    for i, fileitem in file_list:
+                        # Get track assignment for this file
+                        track_str = form.getvalue(f'track_{i}', '1')
+                        target_track = int(track_str) if track_str.isdigit() else 1
+                        
+                        # Save uploaded file temporarily
+                        success, filepath, error_response = self.save_uploaded_file(fileitem)
+                        if not success:
+                            results.append({'success': False, 'message': f"File {fileitem.filename}: {error_response.get('message', 'Upload failed')}"})
+                            continue
+                        
+                        temp_files.append(filepath)
+                        
+                        # Determine clip color for this file
+                        file_clip_color = clip_color if set_mode == 'existing' else pad_color_for_clip
+                        
+                        # Process the MIDI file
+                        result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo, file_clip_color)
+                        result['filename'] = fileitem.filename
+                        result['track'] = target_track
+                        results.append(result)
+                        
+                        # For subsequent files, use the updated existing_path (set was created/modified)
+                        if existing_path is None and result.get('success'):
+                            # First file created the set, update path for subsequent files
+                            output_dir = "/data/UserData/UserLibrary/Sets"
+                            existing_path = os.path.join(output_dir, final_set_name)
+                            if not existing_path.endswith('.abl'):
+                                existing_path += '.abl'
+                    
+                    # Aggregate results
+                    success_count = sum(1 for r in results if r.get('success'))
+                    failure_count = len(results) - success_count
+                    
+                    if failure_count == 0:
+                        # All succeeded
+                        if len(results) == 1:
+                            result = results[0]
+                        else:
+                            # Build summary message
+                            track_summary = []
+                            for r in results:
+                                track_summary.append(f"{r['filename']} → Track {r['track']}")
+                            result = {
+                                'success': True,
+                                'message': f"Successfully imported {success_count} file(s): " + ", ".join(track_summary),
+                                'path': results[0].get('path')  # Include path from first result for new set bundling
+                            }
+                    elif success_count == 0:
+                        # All failed
+                        errors = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results]
+                        result = {
+                            'success': False,
+                            'message': "All imports failed: " + "; ".join(errors)
+                        }
+                    else:
+                        # Mixed results
+                        success_files = [r['filename'] for r in results if r.get('success')]
+                        failed_files = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results if not r.get('success')]
+                        # Find path from first successful result
+                        first_success_path = None
+                        for r in results:
+                            if r.get('success') and r.get('path'):
+                                first_success_path = r.get('path')
+                                break
+                        result = {
+                            'success': True,  # Partial success
+                            'message': f"Partial success: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})",
+                            'path': first_success_path  # Include path if any succeeded (for new set bundling)
+                        }
+                
+                finally:
+                    # Clean up all temporary files
+                    for filepath in temp_files:
+                        self.cleanup_upload(filepath)
 
         else:
             return self.format_error_response(

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -126,10 +126,12 @@ class SetManagementHandler(BaseHandler):
             # Handle file uploads - support multiple files
             file_list = []
             if 'midi_files' in form:
-                # Handle multiple files
-                files = form.getlist('midi_files') if hasattr(form, 'getlist') else [form['midi_files']]
+                # Handle multiple files - form['midi_files'] is now a list of FileField objects
+                files = form['midi_files']
+                if not isinstance(files, list):
+                    files = [files]
                 for i, fileitem in enumerate(files):
-                    if fileitem.filename:
+                    if hasattr(fileitem, 'filename') and fileitem.filename:
                         file_list.append((i, fileitem))
             
             if not file_list:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -38,7 +38,7 @@ class SetManagementHandler(BaseHandler):
             existing_set_options += f'<option value="{name}">{name} ({bpm} BPM)</option>'
         
         # Debug info
-        debug_msg = f"Found {len(msets)} sets for dropdown"
+        debug_msg = f"Found {len(msets)} sets, options length: {len(existing_set_options)} chars"
         
         return {
             'pad_options': pad_options,

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -203,7 +203,24 @@ class SetManagementHandler(BaseHandler):
                 existing_set_options=existing_set_options,
             )
 
-        # Parse pad assignment
+        # Check if this is "add to existing set" mode - skip restore/bundle
+        is_add_to_existing = (
+            midi_type == 'assigntotrack' and
+            form.getvalue('set_mode', 'new') == 'existing'
+        )
+
+        if is_add_to_existing:
+            # For existing set mode, file is already saved - just return success
+            # The set stays on its original pad
+            return self.format_success_response(
+                f"MIDI assigned to {form.getvalue('target_track', '1')} in existing set '{form.getvalue('existing_set_name', '')}'",
+                pad_options=pad_options,
+                pad_color_options=pad_color_options,
+                pad_grid=pad_grid,
+                existing_set_options=existing_set_options
+            )
+
+        # Parse pad assignment (only for new set creation)
         pad_selected = form.getvalue('pad_index')
         pad_color = form.getvalue('pad_color')
         if not pad_selected or not pad_selected.isdigit():
@@ -246,7 +263,7 @@ class SetManagementHandler(BaseHandler):
             # Restore to device
             restore_result = restore_ablbundle(bundle_path, pad_selected_int, pad_color_int)
             os.remove(bundle_path)
-        
+
         if restore_result.get('success'):
             # Clean up the original .abl file after successful placement
             try:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -123,10 +123,14 @@ class SetManagementHandler(BaseHandler):
                 if existing_uuid:
                     existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid, existing_set_name, "Song.abl")
                 else:
-                    # Fallback - try direct path
-                    existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
-                    if not existing_path.endswith('.abl'):
-                        existing_path += '.abl'
+                    return self.format_error_response(
+                        f"Could not find set '{existing_set_name}' in the library. It may have been renamed or removed.",
+                        pad_options=pad_options,
+                        pad_color_options=pad_color_options,
+                        clip_color_options=clip_color_options,
+                        pad_grid=pad_grid,
+                        existing_set_options=existing_set_options,
+                    )
                 final_set_name = existing_set_name
             
             # Handle file uploads - support multiple files
@@ -248,7 +252,7 @@ class SetManagementHandler(BaseHandler):
                             'message': "All imports failed: " + "; ".join(errors)
                         }
                     else:
-                        # Mixed results
+                        # Mixed results - report as error so user sees red banner
                         success_files = [r['filename'] for r in results if r.get('success')]
                         failed_files = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results if not r.get('success')]
                         # Find path from first successful result
@@ -258,9 +262,9 @@ class SetManagementHandler(BaseHandler):
                                 first_success_path = r.get('path')
                                 break
                         result = {
-                            'success': True,  # Partial success
-                            'message': f"Partial success: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})",
-                            'path': first_success_path  # Include path if any succeeded (for new set bundling)
+                            'success': False,
+                            'message': f"Partial failure: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})",
+                            'path': first_success_path
                         }
                 
                 finally:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -27,12 +27,8 @@ class SetManagementHandler(BaseHandler):
         pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in free_pads)
         pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + pad_options
         pad_color_options = self.generate_color_options()
-        # Simple option-based color dropdown for clip color
-        clip_color_options = ''.join(
-            f'<option value="{i}">{PAD_COLOR_LABELS[i]}</option>' 
-            for i in sorted(PAD_COLORS)
-        )
-        clip_color_options = '<option value="" disabled selected>-- Select Color --</option>' + clip_color_options
+        # Generate color dropdown with swatches for clip color (same visual style as pad color)
+        clip_color_options = self.generate_color_options(input_name="clip_color")
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
         bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
@@ -65,12 +61,8 @@ class SetManagementHandler(BaseHandler):
         pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in free_pads)
         pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + pad_options
         pad_color_options = self.generate_color_options()
-        # Simple option-based color dropdown for clip color
-        clip_color_options = ''.join(
-            f'<option value="{i}">{PAD_COLOR_LABELS[i]}</option>' 
-            for i in sorted(PAD_COLORS)
-        )
-        clip_color_options = '<option value="" disabled selected>-- Select Color --</option>' + clip_color_options
+        # Generate color dropdown with swatches for clip color
+        clip_color_options = self.generate_color_options(input_name="clip_color")
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
         bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -27,6 +27,12 @@ class SetManagementHandler(BaseHandler):
         pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in free_pads)
         pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + pad_options
         pad_color_options = self.generate_color_options()
+        # Simple option-based color dropdown for clip color
+        clip_color_options = ''.join(
+            f'<option value="{i}">{PAD_COLOR_LABELS[i]}</option>' 
+            for i in sorted(PAD_COLORS)
+        )
+        clip_color_options = '<option value="" disabled selected>-- Select Color --</option>' + clip_color_options
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
         bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
@@ -40,6 +46,7 @@ class SetManagementHandler(BaseHandler):
         return {
             'pad_options': pad_options,
             'pad_color_options': pad_color_options,
+            'clip_color_options': clip_color_options,
             'pad_grid': pad_grid,
             'existing_set_options': existing_set_options,
             'message': 'Upload a MIDI file to generate a set',
@@ -56,7 +63,14 @@ class SetManagementHandler(BaseHandler):
         msets, ids = list_msets(return_free_ids=True)
         free_pads = sorted([pad_id + 1 for pad_id in ids.get("free", [])])
         pad_options = ''.join(f'<option value="{pad}">{pad}</option>' for pad in free_pads)
+        pad_options = '<option value="" disabled selected>-- Select Pad --</option>' + pad_options
         pad_color_options = self.generate_color_options()
+        # Simple option-based color dropdown for clip color
+        clip_color_options = ''.join(
+            f'<option value="{i}">{PAD_COLOR_LABELS[i]}</option>' 
+            for i in sorted(PAD_COLORS)
+        )
+        clip_color_options = '<option value="" disabled selected>-- Select Color --</option>' + clip_color_options
         color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
         bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
@@ -80,6 +94,7 @@ class SetManagementHandler(BaseHandler):
                         "Please enter a name for the new set",
                         pad_options=pad_options,
                         pad_color_options=pad_color_options,
+                        clip_color_options=clip_color_options,
                         pad_grid=pad_grid,
                         existing_set_options=existing_set_options,
                     )
@@ -90,6 +105,7 @@ class SetManagementHandler(BaseHandler):
                     "Missing required parameter: set_name",
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
+                    clip_color_options=clip_color_options,
                     pad_grid=pad_grid,
                     existing_set_options=existing_set_options,
                 )
@@ -100,6 +116,7 @@ class SetManagementHandler(BaseHandler):
                     "No MIDI file uploaded",
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
+                    clip_color_options=clip_color_options,
                     pad_grid=pad_grid,
                     existing_set_options=existing_set_options,
                 )
@@ -110,6 +127,7 @@ class SetManagementHandler(BaseHandler):
                     "No MIDI file selected",
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
+                    clip_color_options=clip_color_options,
                     pad_grid=pad_grid,
                     existing_set_options=existing_set_options,
                 )
@@ -121,6 +139,7 @@ class SetManagementHandler(BaseHandler):
                     "Invalid file type. Please upload a .mid or .midi file",
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
+                    clip_color_options=clip_color_options,
                     pad_grid=pad_grid,
                     existing_set_options=existing_set_options,
                 )
@@ -132,6 +151,7 @@ class SetManagementHandler(BaseHandler):
                     error_response.get('message', "Failed to upload MIDI file"),
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
+                    clip_color_options=clip_color_options,
                     pad_grid=pad_grid,
                     existing_set_options=existing_set_options,
                 )
@@ -161,6 +181,7 @@ class SetManagementHandler(BaseHandler):
                                 "Please select an existing set",
                                 pad_options=pad_options,
                                 pad_color_options=pad_color_options,
+                                clip_color_options=clip_color_options,
                                 pad_grid=pad_grid,
                                 existing_set_options=existing_set_options,
                             )
@@ -203,6 +224,7 @@ class SetManagementHandler(BaseHandler):
                 f"Unknown action: {action}",
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
                 pad_grid=pad_grid,
             )
 
@@ -212,6 +234,7 @@ class SetManagementHandler(BaseHandler):
                 result.get('message', 'Operation failed'),
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
                 pad_grid=pad_grid,
                 existing_set_options=existing_set_options,
             )
@@ -229,6 +252,7 @@ class SetManagementHandler(BaseHandler):
                 f"MIDI assigned to {form.getvalue('target_track', '1')} in existing set '{form.getvalue('existing_set_name', '')}'",
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
                 pad_grid=pad_grid,
                 existing_set_options=existing_set_options
             )
@@ -243,6 +267,7 @@ class SetManagementHandler(BaseHandler):
                 "Invalid pad selection",
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
                 pad_grid=pad_grid,
                 existing_set_options=existing_set_options,
             )
@@ -251,6 +276,7 @@ class SetManagementHandler(BaseHandler):
                 "Invalid pad color",
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
                 pad_grid=pad_grid,
                 existing_set_options=existing_set_options,
             )
@@ -263,6 +289,7 @@ class SetManagementHandler(BaseHandler):
                 "Internal error: missing set path",
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
                 pad_grid=pad_grid,
                 existing_set_options=existing_set_options,
             )
@@ -295,13 +322,13 @@ class SetManagementHandler(BaseHandler):
             name_map = {int(m["mset_id"]): m["mset_name"] for m in msets_updated}
             bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets_updated if m.get("bpm")}
             pad_grid = self.generate_pad_grid(updated_ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
-            return self.format_success_response(restore_result['message'], pad_options=updated_pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid, existing_set_options=existing_set_options)
+            return self.format_success_response(restore_result['message'], pad_options=updated_pad_options, pad_color_options=pad_color_options, clip_color_options=clip_color_options, pad_grid=pad_grid, existing_set_options=existing_set_options)
         else:
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
             name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
             bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
             pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
-            return self.format_error_response(restore_result.get('message'), pad_options=pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid, existing_set_options=existing_set_options)
+            return self.format_error_response(restore_result.get('message'), pad_options=pad_options, pad_color_options=pad_color_options, clip_color_options=clip_color_options, pad_grid=pad_grid, existing_set_options=existing_set_options)
 
     def generate_color_options(self, input_name="pad_color", pad_input_name="pad_index"):
         """Return HTML for the custom color dropdown with pad preview."""

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -6,7 +6,8 @@ import shutil
 import logging
 from core.set_management_handler import (
     create_set, generate_midi_set_from_file, generate_drum_set_from_file,
-    generate_c_major_chord_example, generate_multichannel_midi_set
+    generate_c_major_chord_example, generate_multichannel_midi_set,
+    assign_midi_to_track
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
@@ -30,11 +31,21 @@ class SetManagementHandler(BaseHandler):
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
         bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
         pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
+        # Get existing sets for dropdown
+        existing_sets = [(m["mset_name"], m.get("bpm", "—")) for m in msets]
+        existing_set_options = '<option value="" disabled selected>-- Select Existing Set --</option>'
+        for name, bpm in sorted(existing_sets):
+            existing_set_options += f'<option value="{name}">{name} ({bpm} BPM)</option>'
+        
+        # Debug info
+        debug_msg = f"Found {len(msets)} sets for dropdown"
+        
         return {
             'pad_options': pad_options,
             'pad_color_options': pad_color_options,
             'pad_grid': pad_grid,
-            'message': 'Upload a MIDI file to generate a set',
+            'existing_set_options': existing_set_options,
+            'message': f'Upload a MIDI file to generate a set ({debug_msg})',
             'message_type': 'info'
         }
 
@@ -53,6 +64,11 @@ class SetManagementHandler(BaseHandler):
         name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
         bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
         pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
+        # Get existing sets for dropdown
+        existing_sets = [(m["mset_name"], m.get("bpm", "—")) for m in msets]
+        existing_set_options = '<option value="" disabled selected>-- Select Existing Set --</option>'
+        for name, bpm in sorted(existing_sets):
+            existing_set_options += f'<option value="{name}">{name} ({bpm} BPM)</option>'
 
         if action == 'upload_midi':
             # Generate set from uploaded MIDI file
@@ -63,6 +79,7 @@ class SetManagementHandler(BaseHandler):
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
                     pad_grid=pad_grid,
+                    existing_set_options=existing_set_options,
                 )
             
             # Handle file upload
@@ -72,6 +89,7 @@ class SetManagementHandler(BaseHandler):
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
                     pad_grid=pad_grid,
+                    existing_set_options=existing_set_options,
                 )
             
             fileitem = form['midi_file']
@@ -81,6 +99,7 @@ class SetManagementHandler(BaseHandler):
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
                     pad_grid=pad_grid,
+                    existing_set_options=existing_set_options,
                 )
             
             # Check file extension
@@ -91,6 +110,7 @@ class SetManagementHandler(BaseHandler):
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
                     pad_grid=pad_grid,
+                    existing_set_options=existing_set_options,
                 )
             
             # Save uploaded file temporarily
@@ -101,6 +121,7 @@ class SetManagementHandler(BaseHandler):
                     pad_options=pad_options,
                     pad_color_options=pad_color_options,
                     pad_grid=pad_grid,
+                    existing_set_options=existing_set_options,
                 )
             
             try:
@@ -114,6 +135,40 @@ class SetManagementHandler(BaseHandler):
                     result = generate_drum_set_from_file(set_name, filepath, tempo)
                 elif midi_type == 'multichannel':
                     result = generate_multichannel_midi_set(set_name, filepath, tempo)
+                elif midi_type == 'assigntotrack':
+                    # Handle assign to track mode
+                    target_track_str = form.getvalue('target_track', '1')
+                    target_track = int(target_track_str) if target_track_str.isdigit() else 1
+                    set_mode = form.getvalue('set_mode', 'new')
+                    
+                    if set_mode == 'existing':
+                        # Use existing set name from dropdown
+                        existing_set_name = form.getvalue('existing_set_name', '')
+                        if not existing_set_name:
+                            return self.format_error_response(
+                                "Please select an existing set",
+                                pad_options=pad_options,
+                                pad_color_options=pad_color_options,
+                                pad_grid=pad_grid,
+                            )
+                        existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
+                        if not existing_path.endswith('.abl'):
+                            existing_path += '.abl'
+                        # Use the existing set name for saving
+                        final_set_name = existing_set_name
+                    else:
+                        # Create new set - validate name
+                        if not set_name:
+                            return self.format_error_response(
+                                "Please enter a name for the new set",
+                                pad_options=pad_options,
+                                pad_color_options=pad_color_options,
+                                pad_grid=pad_grid,
+                            )
+                        existing_path = None
+                        final_set_name = set_name
+                    
+                    result = assign_midi_to_track(final_set_name, filepath, target_track, existing_path, tempo)
                 else:
                     result = generate_midi_set_from_file(set_name, filepath, tempo)
 
@@ -195,13 +250,13 @@ class SetManagementHandler(BaseHandler):
             name_map = {int(m["mset_id"]): m["mset_name"] for m in msets_updated}
             bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets_updated if m.get("bpm")}
             pad_grid = self.generate_pad_grid(updated_ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
-            return self.format_success_response(restore_result['message'], pad_options=updated_pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid)
+            return self.format_success_response(restore_result['message'], pad_options=updated_pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid, existing_set_options=existing_set_options)
         else:
             color_map = {int(m["mset_id"]): int(m["mset_color"]) for m in msets if str(m["mset_color"]).isdigit()}
             name_map = {int(m["mset_id"]): m["mset_name"] for m in msets}
             bpm_map = {int(m["mset_id"]): str(m["bpm"]) for m in msets if m.get("bpm")}
             pad_grid = self.generate_pad_grid(ids.get("used", set()), color_map, name_map, bpm_map, free_only=True)
-            return self.format_error_response(restore_result.get('message'), pad_options=pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid)
+            return self.format_error_response(restore_result.get('message'), pad_options=pad_options, pad_color_options=pad_color_options, pad_grid=pad_grid, existing_set_options=existing_set_options)
 
     def generate_color_options(self, input_name="pad_color", pad_input_name="pad_index"):
         """Return HTML for the custom color dropdown with pad preview."""

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -72,8 +72,23 @@ class SetManagementHandler(BaseHandler):
 
         if action == 'upload_midi':
             # Generate set from uploaded MIDI file
-            set_name = form.getvalue('set_name')
-            if not set_name:
+            set_name = form.getvalue('set_name', '')
+            midi_type = form.getvalue('midi_type', 'melodic')
+            
+            # For assign-to-track with existing set, we don't need set_name
+            if midi_type == 'assigntotrack':
+                set_mode = form.getvalue('set_mode', 'new')
+                if set_mode == 'new' and not set_name:
+                    return self.format_error_response(
+                        "Please enter a name for the new set",
+                        pad_options=pad_options,
+                        pad_color_options=pad_color_options,
+                        pad_grid=pad_grid,
+                        existing_set_options=existing_set_options,
+                    )
+                # For existing set mode, we'll validate existing_set_name later
+            elif not set_name:
+                # For non-assign-to-track modes, set_name is always required
                 return self.format_error_response(
                     "Missing required parameter: set_name",
                     pad_options=pad_options,
@@ -150,6 +165,7 @@ class SetManagementHandler(BaseHandler):
                                 pad_options=pad_options,
                                 pad_color_options=pad_color_options,
                                 pad_grid=pad_grid,
+                                existing_set_options=existing_set_options,
                             )
                         existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
                         if not existing_path.endswith('.abl'):
@@ -157,14 +173,7 @@ class SetManagementHandler(BaseHandler):
                         # Use the existing set name for saving
                         final_set_name = existing_set_name
                     else:
-                        # Create new set - validate name
-                        if not set_name:
-                            return self.format_error_response(
-                                "Please enter a name for the new set",
-                                pad_options=pad_options,
-                                pad_color_options=pad_color_options,
-                                pad_grid=pad_grid,
-                            )
+                        # Create new set - name already validated above
                         existing_path = None
                         final_set_name = set_name
                     

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -138,6 +138,16 @@ class SetManagementHandler(BaseHandler):
                     files = [files]
                 for i, fileitem in enumerate(files):
                     if hasattr(fileitem, 'filename') and fileitem.filename:
+                        # Server-side extension validation
+                        if not fileitem.filename.lower().endswith(('.mid', '.midi')):
+                            return self.format_error_response(
+                                f"File '{fileitem.filename}' is not a MIDI file. Only .mid and .midi files are accepted.",
+                                pad_options=pad_options,
+                                pad_color_options=pad_color_options,
+                                clip_color_options=clip_color_options,
+                                pad_grid=pad_grid,
+                                existing_set_options=existing_set_options,
+                            )
                         file_list.append((i, fileitem))
             
             if not file_list:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -6,7 +6,7 @@ import shutil
 import logging
 from core.set_management_handler import (
     create_set, generate_midi_set_from_file, generate_drum_set_from_file,
-    generate_c_major_chord_example
+    generate_c_major_chord_example, generate_multichannel_midi_set
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
@@ -112,6 +112,8 @@ class SetManagementHandler(BaseHandler):
                 midi_type = form.getvalue('midi_type', 'melodic')
                 if midi_type == 'drum':
                     result = generate_drum_set_from_file(set_name, filepath, tempo)
+                elif midi_type == 'multichannel':
+                    result = generate_multichannel_midi_set(set_name, filepath, tempo)
                 else:
                     result = generate_midi_set_from_file(set_name, filepath, tempo)
 

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -11,6 +11,7 @@ from core.set_management_handler import (
 )
 from core.list_msets_handler import list_msets
 from core.restore_handler import restore_ablbundle
+from core.refresh_handler import refresh_library
 from core.pad_colors import PAD_COLORS, PAD_COLOR_LABELS
 import json
 
@@ -258,8 +259,8 @@ class SetManagementHandler(BaseHandler):
         is_add_to_existing = set_mode == 'existing'
 
         if is_add_to_existing:
-            # For existing set mode, file is already saved - just return success
-            # The set stays on its original pad
+            # For existing set mode, file is already saved - refresh library so Move picks up the change
+            refresh_library()
             existing_set_name = form.getvalue('existing_set_name', '')
             return self.format_success_response(
                 f"{result.get('message', 'MIDI imported')} in existing set '{existing_set_name}'",

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -191,6 +191,7 @@ class SetManagementHandler(BaseHandler):
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
                 pad_grid=pad_grid,
+                existing_set_options=existing_set_options,
             )
 
         # Parse pad assignment
@@ -202,6 +203,7 @@ class SetManagementHandler(BaseHandler):
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
                 pad_grid=pad_grid,
+                existing_set_options=existing_set_options,
             )
         if not pad_color or not pad_color.isdigit():
             return self.format_error_response(
@@ -209,6 +211,7 @@ class SetManagementHandler(BaseHandler):
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
                 pad_grid=pad_grid,
+                existing_set_options=existing_set_options,
             )
         pad_selected_int = int(pad_selected) - 1
         pad_color_int = int(pad_color)
@@ -220,6 +223,7 @@ class SetManagementHandler(BaseHandler):
                 pad_options=pad_options,
                 pad_color_options=pad_color_options,
                 pad_grid=pad_grid,
+                existing_set_options=existing_set_options,
             )
         # Create temp directory for bundling
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -203,7 +203,8 @@ class SetManagementHandler(BaseHandler):
                             track_summary.append(f"{r['filename']} → Track {r['track']}")
                         result = {
                             'success': True,
-                            'message': f"Successfully imported {success_count} file(s): " + ", ".join(track_summary)
+                            'message': f"Successfully imported {success_count} file(s): " + ", ".join(track_summary),
+                            'path': results[0].get('path')  # Include path from first result for new set bundling
                         }
                 elif success_count == 0:
                     # All failed
@@ -216,9 +217,16 @@ class SetManagementHandler(BaseHandler):
                     # Mixed results
                     success_files = [r['filename'] for r in results if r.get('success')]
                     failed_files = [f"{r['filename']}: {r.get('message', 'Unknown error')}" for r in results if not r.get('success')]
+                    # Find path from first successful result
+                    first_success_path = None
+                    for r in results:
+                        if r.get('success') and r.get('path'):
+                            first_success_path = r.get('path')
+                            break
                     result = {
                         'success': True,  # Partial success
-                        'message': f"Partial success: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})"
+                        'message': f"Partial success: {success_count} succeeded ({', '.join(success_files)}), {failure_count} failed ({'; '.join(failed_files)})",
+                        'path': first_success_path  # Include path if any succeeded (for new set bundling)
                     }
             
             finally:
@@ -262,6 +270,19 @@ class SetManagementHandler(BaseHandler):
                 existing_set_options=existing_set_options
             )
 
+        # For new set creation, check if any files succeeded (path is required)
+        set_path = result.get('path')
+        if not set_path:
+            # All files failed - return the error without trying to bundle
+            return self.format_error_response(
+                result.get('message', 'Failed to create set'),
+                pad_options=pad_options,
+                pad_color_options=pad_color_options,
+                clip_color_options=clip_color_options,
+                pad_grid=pad_grid,
+                existing_set_options=existing_set_options
+            )
+
         # Parse pad assignment (only for new set creation)
         pad_selected = form.getvalue('pad_index')
         pad_color = form.getvalue('pad_color')
@@ -287,17 +308,6 @@ class SetManagementHandler(BaseHandler):
             )
         pad_selected_int = int(pad_selected) - 1
         pad_color_int = int(pad_color)
-        # Prepare bundling of generated set
-        set_path = result.get('path')
-        if not set_path:
-            return self.format_error_response(
-                "Internal error: missing set path",
-                pad_options=pad_options,
-                pad_color_options=pad_color_options,
-                clip_color_options=clip_color_options,
-                pad_grid=pad_grid,
-                existing_set_options=existing_set_options,
-            )
         # Create temp directory for bundling
         with tempfile.TemporaryDirectory() as tmpdir:
             song_abl_path = os.path.join(tmpdir, 'Song.abl')

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -167,9 +167,19 @@ class SetManagementHandler(BaseHandler):
                                 pad_grid=pad_grid,
                                 existing_set_options=existing_set_options,
                             )
-                        existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
-                        if not existing_path.endswith('.abl'):
-                            existing_path += '.abl'
+                        # Find the set's UUID to construct correct path
+                        existing_uuid = None
+                        for m in msets:
+                            if m["mset_name"] == existing_set_name:
+                                existing_uuid = m["uuid"]
+                                break
+                        if existing_uuid:
+                            existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid, existing_set_name, "Song.abl")
+                        else:
+                            # Fallback - try direct path
+                            existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
+                            if not existing_path.endswith('.abl'):
+                                existing_path += '.abl'
                         # Use the existing set name for saving
                         final_set_name = existing_set_name
                     else:

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -230,6 +230,8 @@ class SetManagementHandler(BaseHandler):
         # Parse pad assignment (only for new set creation)
         pad_selected = form.getvalue('pad_index')
         pad_color = form.getvalue('pad_color')
+        import logging
+        logging.info(f"DEBUG: pad_selected={pad_selected}, pad_color={pad_color}")
         if not pad_selected or not pad_selected.isdigit():
             return self.format_error_response(
                 "Invalid pad selection",

--- a/handlers/set_management_handler_class.py
+++ b/handlers/set_management_handler_class.py
@@ -37,15 +37,12 @@ class SetManagementHandler(BaseHandler):
         for name, bpm in sorted(existing_sets):
             existing_set_options += f'<option value="{name}">{name} ({bpm} BPM)</option>'
         
-        # Debug info
-        debug_msg = f"Found {len(msets)} sets, options length: {len(existing_set_options)} chars"
-        
         return {
             'pad_options': pad_options,
             'pad_color_options': pad_color_options,
             'pad_grid': pad_grid,
             'existing_set_options': existing_set_options,
-            'message': f'Upload a MIDI file to generate a set ({debug_msg})',
+            'message': 'Upload a MIDI file to generate a set',
             'message_type': 'info'
         }
 
@@ -175,15 +172,11 @@ class SetManagementHandler(BaseHandler):
                                 break
                         if existing_uuid:
                             existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_uuid, existing_set_name, "Song.abl")
-                            import logging
-                            logging.info(f"Found existing set {existing_set_name} with UUID {existing_uuid}, path: {existing_path}")
                         else:
                             # Fallback - try direct path
                             existing_path = os.path.join("/data/UserData/UserLibrary/Sets", existing_set_name)
                             if not existing_path.endswith('.abl'):
                                 existing_path += '.abl'
-                            import logging
-                            logging.warning(f"Could not find UUID for {existing_set_name}, using fallback: {existing_path}")
                         # Use the existing set name for saving
                         final_set_name = existing_set_name
                     else:

--- a/handlers/update_handler_class.py
+++ b/handlers/update_handler_class.py
@@ -6,7 +6,7 @@ import os
 import time
 import subprocess
 import sys
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 
 import requests
 import importlib.util
@@ -17,7 +17,7 @@ from handlers.base_handler import BaseHandler
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 
 
-def _headers() -> dict | None:
+def _headers() -> Optional[dict]:
     if GITHUB_TOKEN:
         return {"Authorization": f"token {GITHUB_TOKEN}"}
     return None
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 def fetch_commits_since(
     repo: str, branch: str, since_sha: str, limit: int = 50
-) -> Tuple[List[Dict[str, Any]], bool, str | None]:
+) -> Tuple[List[Dict[str, Any]], bool, Optional[str]]:
     """Return commits on ``branch`` after ``since_sha`` limited to ``limit`` commits.
 
     Returns ``(commits, truncated, error_message)`` where ``truncated`` indicates
@@ -56,7 +56,7 @@ def fetch_commits_since(
     url = f"https://api.github.com/repos/{repo}/commits?sha={branch}"
     commits: List[Dict[str, Any]] = []
     truncated = False
-    error_message: str | None = None
+    error_message: Optional[str] = None
     headers = _headers()
     while url and len(commits) < limit:
         try:
@@ -95,7 +95,7 @@ class UpdateHandler(BaseHandler):
     def __init__(self) -> None:
         super().__init__()
         self._last_check = 0.0
-        self._cached_info: Dict[str, Any] | None = None
+        self._cached_info: Optional[Dict[str, Any]] = None
 
     def check_for_update(self) -> Dict[str, Any]:
         now = time.time()
@@ -122,7 +122,7 @@ class UpdateHandler(BaseHandler):
         has_update = last_sha != latest_sha
         commits: List[Dict[str, Any]]
         truncated: bool
-        commit_error: str | None = None
+        commit_error: Optional[str] = None
         if has_update:
             commits, truncated, commit_error = fetch_commits_since(
                 REPO, branch, last_sha, limit=50

--- a/handlers/wavetable_param_editor_handler_class.py
+++ b/handlers/wavetable_param_editor_handler_class.py
@@ -4,6 +4,7 @@ import json
 import logging
 import shutil
 import re
+from typing import Optional
 
 from handlers.base_handler import BaseHandler
 from core.file_browser import generate_dir_html
@@ -929,7 +930,7 @@ class WavetableParamEditorHandler(BaseHandler):
             ordered.extend(items.values())
         return ordered
 
-    def _arrange_lfo_panel(self, items: dict, idx: int | None = None) -> list:
+    def _arrange_lfo_panel(self, items: dict, idx: Optional[int] = None) -> list:
         """Return LFO panel rows with a visualization canvas."""
         ordered = []
         canvas_id = f"lfo{idx}-canvas" if idx else "lfo-canvas"

--- a/last-update.log
+++ b/last-update.log
@@ -1,0 +1,6 @@
+Restart requested 2026-07-18 16:56:55
+Restart requested 2026-07-18 16:58:22
+Restart requested 2026-07-18 17:05:26
+Restart requested 2026-07-18 17:08:00
+Restart requested 2026-07-18 17:09:58
+Restart requested 2026-07-18 22:04:43

--- a/last-update.log
+++ b/last-update.log
@@ -6,3 +6,4 @@ Restart requested 2026-07-18 17:09:58
 Restart requested 2026-07-18 22:04:43
 Restart requested 2026-07-18 22:23:36
 Restart requested 2026-07-18 22:44:16
+Restart requested 2026-07-18 23:03:42

--- a/last-update.log
+++ b/last-update.log
@@ -5,3 +5,4 @@ Restart requested 2026-07-18 17:08:00
 Restart requested 2026-07-18 17:09:58
 Restart requested 2026-07-18 22:04:43
 Restart requested 2026-07-18 22:23:36
+Restart requested 2026-07-18 22:44:16

--- a/last-update.log
+++ b/last-update.log
@@ -4,3 +4,4 @@ Restart requested 2026-07-18 17:05:26
 Restart requested 2026-07-18 17:08:00
 Restart requested 2026-07-18 17:09:58
 Restart requested 2026-07-18 22:04:43
+Restart requested 2026-07-18 22:23:36

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -285,9 +285,10 @@ def overview_api_system():
 @app.route("/overview/api/restore", methods=["POST"])
 def overview_api_restore():
     """Handle set restore from Overview page."""
-    from flask import request
-    # Use the same form wrapper as other handlers
-    form = FieldStorageWrapper(request.form, request.files)
+    form_data = request.form.to_dict()
+    if "ablbundle" in request.files:
+        form_data["ablbundle"] = FileField(request.files["ablbundle"])
+    form = SimpleForm(form_data)
     result = overview_handler.handle_post_restore(form)
     return jsonify(result)
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -515,6 +515,7 @@ def midi_upload():
     pad_options = context.get("pad_options", "")
     pad_color_options = context.get("pad_color_options", "")
     pad_grid = context.get("pad_grid", "")
+    existing_set_options = context.get("existing_set_options", "")
     if request.method == "POST":
         form_data = request.form.to_dict()
         if "midi_file" in request.files:
@@ -527,6 +528,7 @@ def midi_upload():
         pad_options = result.get("pad_options", pad_options)
         pad_color_options = result.get("pad_color_options", pad_color_options)
         pad_grid = result.get("pad_grid", pad_grid)
+        existing_set_options = result.get("existing_set_options", existing_set_options)
     else:
         message = context.get("message")
         message_type = context.get("message_type")
@@ -539,6 +541,7 @@ def midi_upload():
         pad_options=pad_options,
         pad_color_options=pad_color_options,
         pad_grid=pad_grid,
+        existing_set_options=existing_set_options,
         active_tab="midi-upload",
     )
 

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -261,13 +261,24 @@ def warm_up_modules():
 @app.route("/overview")
 def overview():
     """Render the Move Over (view) overview page."""
-    return render_template("overview.html", active_tab="overview")
+    return render_template(
+        "overview.html",
+        active_tab="overview",
+        pad_grid=overview_handler.generate_pad_grid_html(),
+    )
 
 
 @app.route("/overview/api/data")
 def overview_api_data():
     """Return full sets data as JSON."""
     return jsonify(get_sets_data())
+
+
+@app.route("/overview/api/grid")
+def overview_api_grid():
+    restore_mode = request.args.get("restore_mode") == "1"
+    camelot = request.args.get("camelot")
+    return jsonify({"pad_grid": overview_handler.generate_pad_grid_html(restore_mode, camelot)})
 
 
 @app.route("/overview/api/active-slot")

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -282,6 +282,22 @@ def overview_api_system():
     return jsonify(get_system_stats())
 
 
+@app.route("/overview/api/restore", methods=["POST"])
+def overview_api_restore():
+    """Handle set restore from Overview page."""
+    from flask import request
+    # Use the same form wrapper as other handlers
+    form = FieldStorageWrapper(request.form, request.files)
+    result = overview_handler.handle_post_restore(form)
+    return jsonify(result)
+
+
+@app.route("/overview/api/colors")
+def overview_api_colors():
+    """Return pad colors for color picker."""
+    return jsonify(overview_handler.generate_color_options_json())
+
+
 @app.route("/")
 def index():
     return redirect("/overview")
@@ -454,38 +470,8 @@ def lfo_route():
 
 @app.route("/restore", methods=["GET", "POST"])
 def restore():
-    message = None
-    success = False
-    message_type = None
-    options_html = ""
-    color_options = ""
-    pad_grid = ""
-    if request.method == "POST":
-        form_data = request.form.to_dict()
-        if "ablbundle" in request.files:
-            form_data["ablbundle"] = FileField(request.files["ablbundle"])
-        form = SimpleForm(form_data)
-        result = restore_handler.handle_post(form)
-        message = result.get("message")
-        message_type = result.get("message_type")
-        success = message_type != "error"
-        options_html = result.get("options", options_html)
-        color_options = result.get("color_options", color_options)
-        pad_grid = result.get("pad_grid", pad_grid)
-    context = restore_handler.handle_get()
-    options_html = context.get("options", options_html)
-    color_options = context.get("color_options", color_options)
-    pad_grid = context.get("pad_grid", pad_grid)
-    return render_template(
-        "restore.html",
-        message=message,
-        success=success,
-        message_type=message_type,
-        options_html=options_html,
-        color_options=color_options,
-        pad_grid=pad_grid,
-        active_tab="restore",
-    )
+    """Restore page now redirects to Overview where restore functionality is integrated."""
+    return redirect("/overview")
 
 
 @app.route("/slice", methods=["GET", "POST"])

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -514,6 +514,7 @@ def midi_upload():
     context = set_management_handler.handle_get()
     pad_options = context.get("pad_options", "")
     pad_color_options = context.get("pad_color_options", "")
+    clip_color_options = context.get("clip_color_options", "")
     pad_grid = context.get("pad_grid", "")
     existing_set_options = context.get("existing_set_options", "")
     if request.method == "POST":
@@ -527,6 +528,7 @@ def midi_upload():
         success = message_type != "error"
         pad_options = result.get("pad_options", pad_options)
         pad_color_options = result.get("pad_color_options", pad_color_options)
+        clip_color_options = result.get("clip_color_options", clip_color_options)
         pad_grid = result.get("pad_grid", pad_grid)
         existing_set_options = result.get("existing_set_options", existing_set_options)
     else:
@@ -540,6 +542,7 @@ def midi_upload():
         message_type=message_type,
         pad_options=pad_options,
         pad_color_options=pad_color_options,
+        clip_color_options=clip_color_options,
         pad_grid=pad_grid,
         existing_set_options=existing_set_options,
         active_tab="midi-upload",

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -47,6 +47,8 @@ from handlers.adsr_handler_class import AdsrHandler
 from handlers.cyc_env_handler_class import CycEnvHandler
 from handlers.lfo_handler_class import LfoHandler
 from handlers.set_inspector_handler_class import SetInspectorHandler
+from handlers.overview_handler_class import OverviewHandler
+from core.overview_handler import get_sets_data, get_active_slot, get_system_stats
 from core.refresh_handler import refresh_library
 from core.file_browser import generate_dir_html
 
@@ -137,6 +139,7 @@ adsr_handler = AdsrHandler()
 cyc_env_handler = CycEnvHandler()
 lfo_handler = LfoHandler()
 set_inspector_handler = SetInspectorHandler()
+overview_handler = OverviewHandler()
 
 
 @app.before_request
@@ -255,9 +258,33 @@ def warm_up_modules():
     logger.info("Module warm-up finished in %.3fs", time.perf_counter() - overall_start)
 
 
+@app.route("/overview")
+def overview():
+    """Render the Move Over (view) overview page."""
+    return render_template("overview.html", active_tab="overview")
+
+
+@app.route("/overview/api/data")
+def overview_api_data():
+    """Return full sets data as JSON."""
+    return jsonify(get_sets_data())
+
+
+@app.route("/overview/api/active-slot")
+def overview_api_active_slot():
+    """Return only the current active pad slot."""
+    return jsonify({"current_slot": get_active_slot()})
+
+
+@app.route("/overview/api/system")
+def overview_api_system():
+    """Return CPU load and memory stats."""
+    return jsonify(get_system_stats())
+
+
 @app.route("/")
 def index():
-    return redirect("/restore")
+    return redirect("/overview")
 
 
 @app.route("/browse-dir")

--- a/move-webserver.py
+++ b/move-webserver.py
@@ -519,8 +519,11 @@ def midi_upload():
     existing_set_options = context.get("existing_set_options", "")
     if request.method == "POST":
         form_data = request.form.to_dict()
-        if "midi_file" in request.files:
-            form_data["midi_file"] = FileField(request.files["midi_file"])
+        # Handle multiple MIDI files
+        if "midi_files" in request.files:
+            files = request.files.getlist("midi_files")
+            if files:
+                form_data["midi_files"] = [FileField(f) for f in files]
         form = SimpleForm(form_data)
         result = set_management_handler.handle_post(form)
         message = result.get("message")

--- a/static/style.css
+++ b/static/style.css
@@ -47,6 +47,41 @@
     font-style: italic;
 }
 
+/* Global Dark Mode Theme Variables */
+#app-wrap {
+    /* Light mode (default) */
+    --bg-primary: #ffffff;
+    --bg-secondary: #f5f5f5;
+    --bg-tertiary: #f0f0f0;
+    --border-color: #dddddd;
+    --text-primary: #262626;
+    --text-secondary: #555555;
+    --text-dim: #888888;
+    --accent-color: #ff764d;
+    --link-color: #0000ff;
+    --tab-bg: #e0e0e0;
+    --tab-active-bg: #ffffff;
+    --input-bg: #ffffff;
+    --input-border: #cccccc;
+}
+
+#app-wrap.dark {
+    /* Dark mode - matches Overview page dark theme */
+    --bg-primary: #0a0a0a;
+    --bg-secondary: #111111;
+    --bg-tertiary: #151515;
+    --border-color: #2a2a2a;
+    --text-primary: #e0e0e0;
+    --text-secondary: #888888;
+    --text-dim: #555555;
+    --accent-color: #4dd9d9;
+    --link-color: #4dd9d9;
+    --tab-bg: #1e1e1e;
+    --tab-active-bg: #0a0a0a;
+    --input-bg: #111111;
+    --input-border: #333333;
+}
+
 /* Base styles */
 body {
     font-family: 'Ableton Sans', Arial, sans-serif;
@@ -57,6 +92,17 @@ body {
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+#app-wrap {
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    min-height: 100vh;
+    padding: 1rem;
+}
+
+#app-wrap.dark body {
+    background-color: #0a0a0a;
 }
 
 .text-lg {
@@ -171,6 +217,39 @@ h3 {
     box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 }
 
+/* Dark mode overrides for common elements */
+#app-wrap.dark h1,
+#app-wrap.dark h2,
+#app-wrap.dark h3,
+#app-wrap.dark h4 {
+    color: var(--text-primary);
+}
+
+#app-wrap.dark .tab a {
+    color: var(--text-secondary);
+}
+
+#app-wrap.dark .tab a:hover {
+    color: var(--text-primary);
+}
+
+#app-wrap.dark .tab a.active {
+    color: var(--accent-color);
+}
+
+#app-wrap.dark .tabcontent {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+#app-wrap.dark a {
+    color: var(--link-color);
+}
+
+#app-wrap.dark #footer a {
+    color: var(--link-color);
+}
+
 /* Form elements */
 input[type="text"],
 input[type="number"],
@@ -226,6 +305,28 @@ input[type="submit"] {
 
 .drum-grid button {
     margin-left: 0.5rem;
+}
+
+/* Dark mode for form elements */
+#app-wrap.dark input[type="text"],
+#app-wrap.dark input[type="number"],
+#app-wrap.dark input[type="file"],
+#app-wrap.dark select {
+    background-color: var(--input-bg);
+    border-color: var(--input-border);
+    color: var(--text-primary);
+}
+
+#app-wrap.dark label,
+#app-wrap.dark .slice-even-group label,
+#app-wrap.dark .slice-transient-group label {
+    color: var(--text-secondary);
+}
+
+#app-wrap.dark button,
+#app-wrap.dark input[type="submit"] {
+    background-color: var(--accent-color);
+    color: #000;
 }
 
 button:hover, 
@@ -339,6 +440,35 @@ body.page-melodic-sampler .waveform-container {
 .current-preset {
     font-weight: 500;
     margin-bottom: 1rem;
+}
+
+/* Dark mode for messages and UI elements */
+#app-wrap.dark .success {
+    color: #4dd9d9;
+    background-color: rgba(77, 217, 217, 0.1);
+}
+
+#app-wrap.dark .error {
+    color: #ff6b6b;
+    background-color: rgba(255, 107, 107, 0.1);
+}
+
+#app-wrap.dark .info {
+    color: #4dd9d9;
+    background-color: rgba(77, 217, 217, 0.1);
+}
+
+#app-wrap.dark .file-browser {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+}
+
+#app-wrap.dark .chord-preview {
+    background-color: var(--bg-secondary);
+}
+
+#app-wrap.dark .file-tree .file-entry button {
+    color: var(--link-color);
 }
 
 /* Chord grid styling */
@@ -526,6 +656,27 @@ nav.breadcrumbs form {
     box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
     animation: pad-pulse 2s ease-in-out infinite;
     opacity: 1 !important;
+}
+
+/* Dark mode pad grid overrides */
+#app-wrap.dark .pad-grid {
+    --pg-bg: #0a0a0a;
+    --pg-bg2: #111111;
+    --pg-border: #2a2a2a;
+    --pg-text: #e0e0e0;
+    --pg-text-dim: #555555;
+    --pg-text-mid: #888888;
+    --pg-pad-empty: #151515;
+    --pg-pad-occupied-bg: var(--pg-bg2);
+}
+
+#app-wrap.dark .pad-cell.free:hover {
+    border-color: #4dd9d9;
+}
+
+#app-wrap.dark .pad-cell.active {
+    border-color: #ff764d !important;
+    box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
 }
 
 @keyframes pad-pulse {

--- a/static/style.css
+++ b/static/style.css
@@ -460,33 +460,103 @@ nav.breadcrumbs form {
     margin-bottom: 1rem;
 }
 
-/* Pad grid for set management */
+/* Pad grid for set management - matches Overview page styling */
 .pad-grid {
     display: grid;
     grid-template-columns: repeat(8, 1fr);
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-    max-width: 600px;
+    gap: 0.35rem;
+    margin-bottom: 1.5rem;
+    max-width: 1100px;
+    /* CSS variables for theming (mirrors Overview page) */
+    --pg-bg: #ffffff;
+    --pg-bg2: #f5f5f5;
+    --pg-border: #dddddd;
+    --pg-text: #262626;
+    --pg-text-dim: #888888;
+    --pg-text-mid: #555555;
+    --pg-pad-empty: #f0f0f0;
+    --pg-pad-occupied-bg: var(--pg-bg2);
 }
 
 .pad-cell {
-    box-shadow: inset 0 0 0 2px transparent;
+    background: var(--pg-pad-empty);
+    color: var(--pg-text);
     border-radius: 4px;
-    padding: 0.5rem;
+    padding: 0.35rem 0.25rem;
     text-align: center;
-    font-weight: 600;
+    font-size: 0.8rem;
+    font-weight: 500;
     box-sizing: border-box;
-    aspect-ratio: 4 / 3; 
+    aspect-ratio: 4/3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid transparent;
+    overflow: hidden;
 }
 
 .pad-cell.free {
     cursor: pointer;
-    background: #f0f0f0;
+}
+
+.pad-cell.free:hover {
+    border-color: #0000ff;
 }
 
 .pad-cell.occupied {
-    cursor: default;
-    background: #ffeef0;
+    cursor: pointer;
+    /* Semi-transparent background to match Overview page (alpha 0.2) */
+    background: var(--pg-pad-occupied-bg);
+}
+
+/* Disabled pads (non-selectable) - reduced opacity like Overview */
+.pad-grid input[type="radio"]:disabled + label {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Occupied pads that are disabled (on restore/midi pages) */
+.pad-grid input[type="radio"]:disabled + label.occupied {
+    opacity: 0.6;
+}
+
+.pad-cell.active {
+    border-color: #ff764d !important;
+    box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
+    animation: pad-pulse 2s ease-in-out infinite;
+    opacity: 1 !important;
+}
+
+@keyframes pad-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(255, 118, 77, 0.3); }
+    50% { box-shadow: 0 0 0 5px rgba(255, 118, 77, 0.5); }
+}
+
+.pad-cell .pad-num {
+    color: var(--pg-text-dim);
+    font-size: 0.7rem;
+    line-height: 1;
+}
+
+.pad-cell .pad-name {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    width: 100%;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    line-clamp: 4;
+}
+
+.pad-cell .pad-bpm {
+    color: var(--pg-text-mid);
+    font-size: 0.7rem;
+}
+
+.pad-cell.free .pad-num {
+    color: #aaa;
 }
 
 .pad-grid input[type="radio"] {
@@ -494,8 +564,8 @@ nav.breadcrumbs form {
 }
 
 .pad-grid input[type="radio"]:checked + label {
-    box-shadow: inset 0 0 0 2px #333;
-    background: #d0e8ff;
+    border-color: #ff764d;
+    box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);
 }
 
 .pad-grid label {

--- a/static/style.css
+++ b/static/style.css
@@ -714,6 +714,11 @@ nav.breadcrumbs form {
     display: none;
 }
 
+.pad-grid.view-only label {
+    cursor: default;
+    pointer-events: none;
+}
+
 .pad-grid input[type="radio"]:checked + label {
     border-color: #ff764d;
     box-shadow: 0 0 0 3px rgba(255, 118, 77, 0.5);

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -9,6 +9,7 @@
 <body class="page-{{ active_tab }}">
     <h1 id="header">Move - Extended</h1>
     <nav class="tab">
+        <a href="{{ host_prefix }}/overview" class="{% if active_tab == 'overview' %}active{% endif %}">Overview</a>
         <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
         <a href="{{ host_prefix }}/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice</a>
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -14,7 +14,6 @@
     </div>
     <nav class="tab">
         <a href="{{ host_prefix }}/overview" class="{% if active_tab == 'overview' %}active{% endif %}">Overview</a>
-        <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
         <a href="{{ host_prefix }}/slice" class="{% if active_tab == 'slice' %}active{% endif %}">Slice</a>
         <a href="{{ host_prefix }}/chord" class="{% if active_tab == 'chord' %}active{% endif %}">Chords</a>
         <a href="{{ host_prefix }}/drum-rack-inspector" class="{% if active_tab == 'drum-rack-inspector' %}active{% endif %}">Drums</a>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -7,7 +7,11 @@
     <link rel="stylesheet" href="{{ host_prefix }}/static/style.css">
 </head>
 <body class="page-{{ active_tab }}">
-    <h1 id="header">Move - Extended</h1>
+    <div id="app-wrap">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+        <h1 id="header">Move - Extended</h1>
+        <button id="theme-toggle" onclick="toggleTheme()" style="font-size:0.8rem;padding:0.3rem 0.8rem;margin:0;">🌙 Dark</button>
+    </div>
     <nav class="tab">
         <a href="{{ host_prefix }}/overview" class="{% if active_tab == 'overview' %}active{% endif %}">Overview</a>
         <a href="{{ host_prefix }}/restore" class="{% if active_tab == 'restore' %}active{% endif %}">Restore</a>
@@ -33,6 +37,7 @@
         <a href="http://github.com/charlesvestal/extending-move/">GitHub</a> |
         <a href="https://discord.gg/GHWaZCC9bQ">Discord</a>
     </footer>
+    </div>
     <script>
     // Shared pad grid styling - matches Overview page behavior
     (function() {
@@ -65,6 +70,48 @@
             }
         });
     })();
+    </script>
+    <script>
+    // Global theme toggle
+    function toggleTheme() {
+        const wrap = document.getElementById('app-wrap');
+        const btn = document.getElementById('theme-toggle');
+        const isDark = wrap.classList.toggle('dark');
+        btn.textContent = isDark ? '☀️ Light' : '🌙 Dark';
+        localStorage.setItem('move-theme', isDark ? 'dark' : 'light');
+        // Update pad grid opacity for dark mode
+        updatePadGridForTheme(isDark);
+    }
+    
+    function updatePadGridForTheme(isDark) {
+        document.querySelectorAll('.pad-grid .pad-cell').forEach(cell => {
+            const bg = cell.style.backgroundColor;
+            if (bg && bg.includes('rgba')) {
+                // In dark mode, use 0.08 opacity, in light mode use 0.2
+                const newAlpha = isDark ? '0.08' : '0.2';
+                cell.style.backgroundColor = bg.replace(/rgba\((\d+),\s*(\d+),\s*(\d+),\s*[\d.]+\)/, `rgba($1, $2, $3, ${newAlpha})`);
+            }
+        });
+    }
+    
+    (function() {
+        // Restore theme preference on page load
+        if (localStorage.getItem('move-theme') === 'dark') {
+            document.getElementById('app-wrap').classList.add('dark');
+            document.getElementById('theme-toggle').textContent = '☀️ Light';
+        }
+    })();
+    
+    // Initialize pad grid opacity after DOM is ready
+    document.addEventListener('DOMContentLoaded', function() {
+        const isDark = document.getElementById('app-wrap').classList.contains('dark');
+        if (isDark && typeof updatePadGridForTheme === 'function') {
+            // Small delay to ensure pad grid is rendered
+            setTimeout(function() {
+                updatePadGridForTheme(true);
+            }, 0);
+        }
+    });
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates_jinja/base.html
+++ b/templates_jinja/base.html
@@ -33,6 +33,39 @@
         <a href="http://github.com/charlesvestal/extending-move/">GitHub</a> |
         <a href="https://discord.gg/GHWaZCC9bQ">Discord</a>
     </footer>
+    <script>
+    // Shared pad grid styling - matches Overview page behavior
+    (function() {
+        function updatePadOpacity() {
+            // Reset all pad backgrounds to 0.2 opacity
+            document.querySelectorAll('.pad-grid .pad-cell').forEach(cell => {
+                const bg = cell.style.backgroundColor;
+                if (bg && bg.includes('rgba')) {
+                    cell.style.backgroundColor = bg.replace(/rgba\((\d+),\s*(\d+),\s*(\d+),\s*[\d.]+\)/, 'rgba($1, $2, $3, 0.2)');
+                }
+            });
+            // Increase opacity to 0.4 for selected pad
+            const checked = document.querySelector('.pad-grid input[type="radio"]:checked');
+            if (checked) {
+                const label = document.querySelector('label[for="' + checked.id + '"]');
+                if (label) {
+                    const bg = label.style.backgroundColor;
+                    if (bg && bg.includes('rgba')) {
+                        label.style.backgroundColor = bg.replace(/rgba\((\d+),\s*(\d+),\s*(\d+),\s*[\d.]+\)/, 'rgba($1, $2, $3, 0.4)');
+                    }
+                    label.classList.add('active');
+                }
+            }
+        }
+        document.addEventListener('DOMContentLoaded', function() {
+            const padGrid = document.querySelector('.pad-grid');
+            if (padGrid) {
+                updatePadOpacity();
+                padGrid.addEventListener('change', updatePadOpacity);
+            }
+        });
+    })();
+    </script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -15,7 +15,9 @@
                 <select name="midi_type" id="midi_type" required>
                     <option value="melodic" selected>Melodic MIDI</option>
                     <option value="drum">Drum MIDI (808)</option>
+                    <option value="multichannel">Multi-Channel (≤4 channels)</option>
                 </select>
+                <small>Melodic: Single track. Drum: Maps to 16 pads. Multi-Channel: Each MIDI channel becomes a separate track (max 4).</small>
             </div>
             <div class="form-group">
                 <label for="midi_file">MIDI File:</label>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -38,10 +38,21 @@
                 </select>
                 <small>Required when adding to existing set</small>
             </div>
+            <div class="form-group" id="midi-type-group">
+                <label>MIDI Type:</label>
+                <div>
+                    <input type="radio" name="midi_type" id="midi_type_melodic" value="melodic" checked onchange="updateMidiTypeFields()">
+                    <label for="midi_type_melodic" style="display:inline;font-weight:normal;">Melodic (multi-file, per-track)</label>
+                </div>
+                <div>
+                    <input type="radio" name="midi_type" id="midi_type_drum" value="drum" onchange="updateMidiTypeFields()">
+                    <label for="midi_type_drum" style="display:inline;font-weight:normal;">Drum (808 pad mapping, single file)</label>
+                </div>
+            </div>
             <div class="form-group">
                 <label for="midi_files">MIDI File(s):</label>
                 <input type="file" name="midi_files" id="midi_files" accept=".mid,.midi" multiple required onchange="handleFileSelect()" />
-                <small>Supported formats: .mid, .midi. Select multiple files to assign to different tracks.</small>
+                <small id="midi-files-hint">Supported formats: .mid, .midi. Select multiple files to assign to different tracks.</small>
             </div>
             <div id="file-track-assignments" style="margin-bottom:1rem;">
                 <!-- Dynamic track assignments will appear here -->
@@ -102,7 +113,30 @@ function handleFileSelect() {
     container.innerHTML = html;
 }
 
+function updateMidiTypeFields() {
+    const isDrum = document.getElementById('midi_type_drum').checked;
+    const fileInput = document.getElementById('midi_files');
+    const filesHint = document.getElementById('midi-files-hint');
+    const trackAssignments = document.getElementById('file-track-assignments');
+    const setModeGroup = document.getElementById('set-mode-group');
+
+    if (isDrum) {
+        fileInput.removeAttribute('multiple');
+        filesHint.textContent = 'Supported formats: .mid, .midi. Single file for drum pad mapping.';
+        trackAssignments.innerHTML = '';
+        // Force new set mode for drum import
+        document.getElementById('set_mode_new').checked = true;
+        setModeGroup.style.display = 'none';
+        updateSetModeFields();
+    } else {
+        fileInput.setAttribute('multiple', '');
+        filesHint.textContent = 'Supported formats: .mid, .midi. Select multiple files to assign to different tracks.';
+        setModeGroup.style.display = 'block';
+    }
+}
+
 function updateSetModeFields() {
+    const isDrum = document.getElementById('midi_type_drum').checked;
     const isNew = document.getElementById('set_mode_new').checked;
     const newSetGroup = document.getElementById('new-set-name-group');
     const existingSetGroup = document.getElementById('existing-set-select-group');
@@ -112,7 +146,7 @@ function updateSetModeFields() {
     const setNameInput = document.getElementById('set_name');
     const existingSetSelect = document.getElementById('existing_set_name');
     
-    if (isNew) {
+    if (isNew || isDrum) {
         newSetGroup.style.display = 'block';
         existingSetGroup.style.display = 'none';
         clipColorGroup.style.display = 'none';
@@ -133,6 +167,7 @@ function updateSetModeFields() {
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', function() {
+    updateMidiTypeFields();
     updateSetModeFields();
 });
 </script>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -49,15 +49,7 @@
             <div class="form-group" id="clip-color-group" style="display:none;">
                 <label for="clip_color">Clip Color:</label>
                 <select name="clip_color" id="clip_color">
-                    <option value="1">Pink</option>
-                    <option value="2">Red</option>
-                    <option value="3">Orange</option>
-                    <option value="4">Yellow</option>
-                    <option value="5">Green</option>
-                    <option value="6">Teal</option>
-                    <option value="7">Blue</option>
-                    <option value="8">Purple</option>
-                    <option value="9">Gray</option>
+                    {{ pad_color_options | safe }}
                 </select>
                 <small>Color for the new clip when adding to existing set</small>
             </div>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -63,7 +63,7 @@
                 <input type="file" name="midi_file" id="midi_file" accept=".mid,.midi" required />
                 <small>Supported formats: .mid, .midi</small>
             </div>
-            <div class="form-group">
+            <div class="form-group" id="tempo-group">
                 <label for="tempo">Tempo (BPM):</label>
                 <input type="number" name="tempo" id="tempo" min="20" max="300" placeholder="Auto-detect from MIDI" />
                 <small>Leave blank to use tempo from MIDI file (or default 120 BPM)</small>
@@ -114,6 +114,7 @@ function updateSetModeFields() {
     const existingSetGroup = document.getElementById('existing-set-select-group');
     const clipColorGroup = document.getElementById('clip-color-group');
     const newSetExtras = document.getElementById('new-set-extras');
+    const tempoGroup = document.getElementById('tempo-group');
     const setNameInput = document.getElementById('set_name');
     const existingSetSelect = document.getElementById('existing_set_name');
     
@@ -122,6 +123,7 @@ function updateSetModeFields() {
         existingSetGroup.style.display = 'none';
         clipColorGroup.style.display = 'none';
         newSetExtras.style.display = 'block';
+        tempoGroup.style.display = 'block';
         setNameInput.required = true;
         existingSetSelect.required = false;
     } else {
@@ -129,6 +131,7 @@ function updateSetModeFields() {
         existingSetGroup.style.display = 'block';
         clipColorGroup.style.display = 'block';
         newSetExtras.style.display = 'none';
+        tempoGroup.style.display = 'none';
         setNameInput.required = false;
         existingSetSelect.required = true;
     }

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -49,7 +49,7 @@
             <div class="form-group" id="clip-color-group" style="display:none;">
                 <label for="clip_color">Clip Color:</label>
                 <select name="clip_color" id="clip_color">
-                    {{ pad_color_options | safe }}
+                    {{ clip_color_options | safe }}
                 </select>
                 <small>Color for the new clip when adding to existing set</small>
             </div>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -12,21 +12,51 @@
             <input type="hidden" name="action" value="upload_midi" />
             <div class="form-group">
                 <label for="midi_type">MIDI Type:</label>
-                <select name="midi_type" id="midi_type" required>
+                <select name="midi_type" id="midi_type" required onchange="updateTrackOptions()">
                     <option value="melodic" selected>Melodic MIDI</option>
                     <option value="drum">Drum MIDI (808)</option>
                     <option value="multichannel">Multi-Channel (≤4 channels)</option>
+                    <option value="assigntotrack">Assign to Track (1-4)</option>
                 </select>
-                <small>Melodic: Single track. Drum: Maps to 16 pads. Multi-Channel: Each MIDI channel becomes a separate track (max 4).</small>
+                <small>Melodic/Drum: Single track. Multi-Channel: Each MIDI channel becomes separate track. Assign to Track: Place on specific track slot.</small>
+            </div>
+            <div class="form-group" id="track-select-group" style="display:none;">
+                <label for="target_track">Target Track:</label>
+                <select name="target_track" id="target_track">
+                    <option value="1" selected>Track 1</option>
+                    <option value="2">Track 2</option>
+                    <option value="3">Track 3</option>
+                    <option value="4">Track 4</option>
+                </select>
+                <small>Select which track slot to place this MIDI on</small>
+            </div>
+            <div class="form-group" id="set-mode-group" style="display:none;">
+                <label>Set Mode:</label>
+                <div>
+                    <input type="radio" name="set_mode" id="set_mode_new" value="new" checked onchange="updateSetModeFields()">
+                    <label for="set_mode_new" style="display:inline;font-weight:normal;">Create New Set</label>
+                </div>
+                <div>
+                    <input type="radio" name="set_mode" id="set_mode_existing" value="existing" onchange="updateSetModeFields()">
+                    <label for="set_mode_existing" style="display:inline;font-weight:normal;">Add to Existing Set</label>
+                </div>
+            </div>
+            <div class="form-group" id="new-set-name-group" style="display:none;">
+                <label for="set_name">New Set Name:</label>
+                <input type="text" name="set_name" id="set_name" placeholder="My MIDI Set" />
+                <small>Required when creating a new set</small>
+            </div>
+            <div class="form-group" id="existing-set-select-group" style="display:none;">
+                <label for="existing_set_name">Select Existing Set:</label>
+                <select name="existing_set_name" id="existing_set_name">
+                    {{ existing_set_options | safe }}
+                </select>
+                <small>Required when adding to existing set</small>
             </div>
             <div class="form-group">
                 <label for="midi_file">MIDI File:</label>
                 <input type="file" name="midi_file" id="midi_file" accept=".mid,.midi" required />
                 <small>Supported formats: .mid, .midi</small>
-            </div>
-            <div class="form-group">
-                <label for="set_name">Set Name:</label>
-                <input type="text" name="set_name" id="set_name" placeholder="My MIDI Set" required />
             </div>
             <div class="form-group">
                 <label for="tempo">Tempo (BPM):</label>
@@ -45,4 +75,44 @@
         </form>
     </div>
 </div>
+<script>
+function updateTrackOptions() {
+    const midiType = document.getElementById('midi_type').value;
+    const trackGroup = document.getElementById('track-select-group');
+    const setModeGroup = document.getElementById('set-mode-group');
+    
+    if (midiType === 'assigntotrack') {
+        trackGroup.style.display = 'block';
+        setModeGroup.style.display = 'block';
+        updateSetModeFields();
+    } else {
+        trackGroup.style.display = 'none';
+        setModeGroup.style.display = 'none';
+        document.getElementById('new-set-name-group').style.display = 'none';
+        document.getElementById('existing-set-select-group').style.display = 'none';
+        // Re-enable set_name for non-assign-to-track modes
+        document.getElementById('set_name').required = true;
+    }
+}
+
+function updateSetModeFields() {
+    const isNew = document.getElementById('set_mode_new').checked;
+    const newSetGroup = document.getElementById('new-set-name-group');
+    const existingSetGroup = document.getElementById('existing-set-select-group');
+    const setNameInput = document.getElementById('set_name');
+    const existingSetSelect = document.getElementById('existing_set_name');
+    
+    if (isNew) {
+        newSetGroup.style.display = 'block';
+        existingSetGroup.style.display = 'none';
+        setNameInput.required = true;
+        existingSetSelect.required = false;
+    } else {
+        newSetGroup.style.display = 'none';
+        existingSetGroup.style.display = 'block';
+        setNameInput.required = false;
+        existingSetSelect.required = true;
+    }
+}
+</script>
 {% endblock %}

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -49,10 +49,9 @@
             <div class="form-group" id="existing-set-select-group" style="display:none;">
                 <label for="existing_set_name">Select Existing Set:</label>
                 <select name="existing_set_name" id="existing_set_name">
-                    <option value="">-- DEBUG: Options below --</option>
                     {{ existing_set_options | safe }}
                 </select>
-                <small>Required when adding to existing set. Raw: {{ existing_set_options[:100] | safe }}...</small>
+                <small>Required when adding to existing set</small>
             </div>
             <div class="form-group">
                 <label for="midi_file">MIDI File:</label>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -49,9 +49,10 @@
             <div class="form-group" id="existing-set-select-group" style="display:none;">
                 <label for="existing_set_name">Select Existing Set:</label>
                 <select name="existing_set_name" id="existing_set_name">
+                    <option value="">-- DEBUG: Options below --</option>
                     {{ existing_set_options | safe }}
                 </select>
-                <small>Required when adding to existing set</small>
+                <small>Required when adding to existing set. Raw: {{ existing_set_options[:100] | safe }}...</small>
             </div>
             <div class="form-group">
                 <label for="midi_file">MIDI File:</label>

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -7,30 +7,10 @@
 <div  >
     <div  >
         <h3>Upload MIDI File</h3>
-        <p>Upload a MIDI file to generate an Ableton Live set with the notes from the file.</p>
+        <p>Upload one or more MIDI files and assign each to a track slot (1-4). Multiple files can target the same track - they'll fill empty clip slots.</p>
         <form method="post" action="{{ host_prefix }}/midi-upload" enctype="multipart/form-data">
             <input type="hidden" name="action" value="upload_midi" />
-            <div class="form-group">
-                <label for="midi_type">MIDI Type:</label>
-                <select name="midi_type" id="midi_type" required onchange="updateTrackOptions()">
-                    <option value="melodic" selected>Melodic MIDI</option>
-                    <option value="drum">Drum MIDI (808)</option>
-                    <option value="multichannel">Multi-Channel (≤4 channels)</option>
-                    <option value="assigntotrack">Assign to Track (1-4)</option>
-                </select>
-                <small>Melodic/Drum: Single track. Multi-Channel: Each MIDI channel becomes separate track. Assign to Track: Place on specific track slot.</small>
-            </div>
-            <div class="form-group" id="track-select-group" style="display:none;">
-                <label for="target_track">Target Track:</label>
-                <select name="target_track" id="target_track">
-                    <option value="1" selected>Track 1</option>
-                    <option value="2">Track 2</option>
-                    <option value="3">Track 3</option>
-                    <option value="4">Track 4</option>
-                </select>
-                <small>Select which track slot to place this MIDI on</small>
-            </div>
-            <div class="form-group" id="set-mode-group" style="display:none;">
+            <div class="form-group" id="set-mode-group">
                 <label>Set Mode:</label>
                 <div>
                     <input type="radio" name="set_mode" id="set_mode_new" value="new" checked onchange="updateSetModeFields()">
@@ -59,9 +39,12 @@
                 <small>Required when adding to existing set</small>
             </div>
             <div class="form-group">
-                <label for="midi_file">MIDI File:</label>
-                <input type="file" name="midi_file" id="midi_file" accept=".mid,.midi" required />
-                <small>Supported formats: .mid, .midi</small>
+                <label for="midi_files">MIDI File(s):</label>
+                <input type="file" name="midi_files" id="midi_files" accept=".mid,.midi" multiple required onchange="handleFileSelect()" />
+                <small>Supported formats: .mid, .midi. Select multiple files to assign to different tracks.</small>
+            </div>
+            <div id="file-track-assignments" style="margin-bottom:1rem;">
+                <!-- Dynamic track assignments will appear here -->
             </div>
             <div class="form-group" id="tempo-group">
                 <label for="tempo">Tempo (BPM):</label>
@@ -83,29 +66,40 @@
     </div>
 </div>
 <script>
-function updateTrackOptions() {
-    const midiType = document.getElementById('midi_type').value;
-    const trackGroup = document.getElementById('track-select-group');
-    const setModeGroup = document.getElementById('set-mode-group');
-    const newSetGroup = document.getElementById('new-set-name-group');
-    const newSetExtras = document.getElementById('new-set-extras');
-    const clipColorGroup = document.getElementById('clip-color-group');
+let selectedFiles = [];
+
+function handleFileSelect() {
+    const fileInput = document.getElementById('midi_files');
+    const container = document.getElementById('file-track-assignments');
+    selectedFiles = Array.from(fileInput.files);
     
-    if (midiType === 'assigntotrack') {
-        trackGroup.style.display = 'block';
-        setModeGroup.style.display = 'block';
-        updateSetModeFields();
-    } else {
-        trackGroup.style.display = 'none';
-        setModeGroup.style.display = 'none';
-        // For non-assign-to-track, always show set name and pad selection
-        newSetGroup.style.display = 'block';
-        newSetExtras.style.display = 'block';
-        document.getElementById('set_name').required = true;
-        document.getElementById('existing-set-select-group').style.display = 'none';
-        document.getElementById('existing_set_name').required = false;
-        clipColorGroup.style.display = 'none';
+    if (selectedFiles.length === 0) {
+        container.innerHTML = '';
+        return;
     }
+    
+    // Build track assignment UI for each file
+    let html = '<div style="border:1px solid #ccc; padding:0.5rem; border-radius:4px;">';
+    html += '<strong>Track Assignments:</strong>';
+    html += '<div style="margin-top:0.5rem;">';
+    
+    selectedFiles.forEach((file, index) => {
+        html += '<div style="display:flex; align-items:center; margin-bottom:0.5rem; gap:0.5rem;">';
+        html += '<span style="flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">' + file.name + '</span>';
+        html += '<select name="track_' + index + '" style="width:auto;">';
+        html += '<option value="1" selected>Track 1</option>';
+        html += '<option value="2">Track 2</option>';
+        html += '<option value="3">Track 3</option>';
+        html += '<option value="4">Track 4</option>';
+        html += '</select>';
+        html += '</div>';
+    });
+    
+    html += '</div>';
+    html += '<small>Assign each file to a track slot. Multiple files can use the same track.</small>';
+    html += '</div>';
+    
+    container.innerHTML = html;
 }
 
 function updateSetModeFields() {
@@ -139,7 +133,7 @@ function updateSetModeFields() {
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', function() {
-    updateTrackOptions();
+    updateSetModeFields();
 });
 </script>
 {% endblock %}

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -70,15 +70,17 @@
                 <input type="number" name="tempo" id="tempo" min="20" max="300" placeholder="Auto-detect from MIDI" />
                 <small>Leave blank to use tempo from MIDI file (or default 120 BPM)</small>
             </div>
-           <div class="form-group">
-                <label for="pad_color_dropdown">Pad Color:</label>
-                {{ pad_color_options | safe }}
+            <div id="new-set-extras">
+                <div class="form-group">
+                    <label for="pad_color_dropdown">Pad Color:</label>
+                    {{ pad_color_options | safe }}
+                </div>
+                <div class="form-group">
+                    <label>Select Pad:</label>
+                    {{ pad_grid | safe }}
+                </div>
             </div>
-            <div class="form-group">
-                <label>Select Pad:</label>
-                {{ pad_grid | safe }}
-            </div>
-            <button type="submit" >Generate Set from MIDI</button>
+            <button type="submit">Generate Set from MIDI</button>
         </form>
     </div>
 </div>
@@ -88,6 +90,7 @@ function updateTrackOptions() {
     const trackGroup = document.getElementById('track-select-group');
     const setModeGroup = document.getElementById('set-mode-group');
     const newSetGroup = document.getElementById('new-set-name-group');
+    const newSetExtras = document.getElementById('new-set-extras');
     const clipColorGroup = document.getElementById('clip-color-group');
     
     if (midiType === 'assigntotrack') {
@@ -97,8 +100,9 @@ function updateTrackOptions() {
     } else {
         trackGroup.style.display = 'none';
         setModeGroup.style.display = 'none';
-        // For non-assign-to-track, always show set name and hide others
+        // For non-assign-to-track, always show set name and pad selection
         newSetGroup.style.display = 'block';
+        newSetExtras.style.display = 'block';
         document.getElementById('set_name').required = true;
         document.getElementById('existing-set-select-group').style.display = 'none';
         document.getElementById('existing_set_name').required = false;
@@ -111,6 +115,7 @@ function updateSetModeFields() {
     const newSetGroup = document.getElementById('new-set-name-group');
     const existingSetGroup = document.getElementById('existing-set-select-group');
     const clipColorGroup = document.getElementById('clip-color-group');
+    const newSetExtras = document.getElementById('new-set-extras');
     const setNameInput = document.getElementById('set_name');
     const existingSetSelect = document.getElementById('existing_set_name');
     
@@ -118,12 +123,14 @@ function updateSetModeFields() {
         newSetGroup.style.display = 'block';
         existingSetGroup.style.display = 'none';
         clipColorGroup.style.display = 'none';
+        newSetExtras.style.display = 'block';
         setNameInput.required = true;
         existingSetSelect.required = false;
     } else {
         newSetGroup.style.display = 'none';
         existingSetGroup.style.display = 'block';
         clipColorGroup.style.display = 'block';
+        newSetExtras.style.display = 'none';
         setNameInput.required = false;
         existingSetSelect.required = true;
     }

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -48,9 +48,7 @@
             </div>
             <div class="form-group" id="clip-color-group" style="display:none;">
                 <label for="clip_color">Clip Color:</label>
-                <select name="clip_color" id="clip_color">
-                    {{ clip_color_options | safe }}
-                </select>
+                {{ clip_color_options | safe }}
                 <small>Color for the new clip when adding to existing set</small>
             </div>
             <div class="form-group" id="existing-set-select-group" style="display:none;">

--- a/templates_jinja/midi_upload.html
+++ b/templates_jinja/midi_upload.html
@@ -41,10 +41,25 @@
                     <label for="set_mode_existing" style="display:inline;font-weight:normal;">Add to Existing Set</label>
                 </div>
             </div>
-            <div class="form-group" id="new-set-name-group" style="display:none;">
+            <div class="form-group" id="new-set-name-group">
                 <label for="set_name">New Set Name:</label>
-                <input type="text" name="set_name" id="set_name" placeholder="My MIDI Set" />
+                <input type="text" name="set_name" id="set_name" placeholder="My MIDI Set" required />
                 <small>Required when creating a new set</small>
+            </div>
+            <div class="form-group" id="clip-color-group" style="display:none;">
+                <label for="clip_color">Clip Color:</label>
+                <select name="clip_color" id="clip_color">
+                    <option value="1">Pink</option>
+                    <option value="2">Red</option>
+                    <option value="3">Orange</option>
+                    <option value="4">Yellow</option>
+                    <option value="5">Green</option>
+                    <option value="6">Teal</option>
+                    <option value="7">Blue</option>
+                    <option value="8">Purple</option>
+                    <option value="9">Gray</option>
+                </select>
+                <small>Color for the new clip when adding to existing set</small>
             </div>
             <div class="form-group" id="existing-set-select-group" style="display:none;">
                 <label for="existing_set_name">Select Existing Set:</label>
@@ -80,6 +95,8 @@ function updateTrackOptions() {
     const midiType = document.getElementById('midi_type').value;
     const trackGroup = document.getElementById('track-select-group');
     const setModeGroup = document.getElementById('set-mode-group');
+    const newSetGroup = document.getElementById('new-set-name-group');
+    const clipColorGroup = document.getElementById('clip-color-group');
     
     if (midiType === 'assigntotrack') {
         trackGroup.style.display = 'block';
@@ -88,10 +105,12 @@ function updateTrackOptions() {
     } else {
         trackGroup.style.display = 'none';
         setModeGroup.style.display = 'none';
-        document.getElementById('new-set-name-group').style.display = 'none';
-        document.getElementById('existing-set-select-group').style.display = 'none';
-        // Re-enable set_name for non-assign-to-track modes
+        // For non-assign-to-track, always show set name and hide others
+        newSetGroup.style.display = 'block';
         document.getElementById('set_name').required = true;
+        document.getElementById('existing-set-select-group').style.display = 'none';
+        document.getElementById('existing_set_name').required = false;
+        clipColorGroup.style.display = 'none';
     }
 }
 
@@ -99,20 +118,28 @@ function updateSetModeFields() {
     const isNew = document.getElementById('set_mode_new').checked;
     const newSetGroup = document.getElementById('new-set-name-group');
     const existingSetGroup = document.getElementById('existing-set-select-group');
+    const clipColorGroup = document.getElementById('clip-color-group');
     const setNameInput = document.getElementById('set_name');
     const existingSetSelect = document.getElementById('existing_set_name');
     
     if (isNew) {
         newSetGroup.style.display = 'block';
         existingSetGroup.style.display = 'none';
+        clipColorGroup.style.display = 'none';
         setNameInput.required = true;
         existingSetSelect.required = false;
     } else {
         newSetGroup.style.display = 'none';
         existingSetGroup.style.display = 'block';
+        clipColorGroup.style.display = 'block';
         setNameInput.required = false;
         existingSetSelect.required = true;
     }
 }
+
+// Initialize on page load
+document.addEventListener('DOMContentLoaded', function() {
+    updateTrackOptions();
+});
 </script>
 {% endblock %}

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -2,10 +2,7 @@
 
 {% block content %}
 <div id="overview-wrap">
-<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
-    <h2 style="margin-bottom:0;">Move Over (view)</h2>
-    <button id="theme-toggle" onclick="toggleTheme()" style="font-size:0.8rem;padding:0.3rem 0.8rem;margin:0;">🌙 Dark</button>
-</div>
+<h2 style="margin-bottom:0;">Move Over (view)</h2>
 <div class="overview-stats">
     <div class="overview-stat-box">
         <div class="overview-stat-label">STORAGE: <span id="disk-text">—</span></div>
@@ -63,7 +60,9 @@
         --ov-pad-empty:  #f0f0f0;
         --ov-bar-track:  #e0e0e0;
     }
-    #overview-wrap.dark {
+    /* Overview uses global dark mode - override variables for dark theme */
+    #app-wrap.dark #overview-wrap {
+        font-family: monospace;
         --ov-bg:         #0a0a0a;
         --ov-bg2:        #111111;
         --ov-border:     #2a2a2a;
@@ -72,33 +71,22 @@
         --ov-text-mid:   #888888;
         --ov-pad-empty:  #151515;
         --ov-bar-track:  #1e1e1e;
-        --ov-accent:     #4dd9d9;
-        font-family: monospace;
-        background: #0a0a0a;
-        padding: 1rem;
-        border-radius: 4px;
-        margin: -2rem;
     }
-    #overview-wrap.dark h2 {
-        color: #4dd9d9;
-        font-family: monospace;
-    }
-    #overview-wrap.dark .overview-filter-btn.active {
+    #app-wrap.dark #overview-wrap .overview-filter-btn.active {
         background: rgba(77,217,217,0.15);
         border-color: #4dd9d9;
         color: #4dd9d9;
     }
-    #overview-wrap.dark .overview-filter-btn {
+    #app-wrap.dark #overview-wrap .overview-filter-btn {
         border-color: #333;
         color: #aaa;
         font-family: monospace;
     }
-    #overview-wrap.dark .overview-table th,
-    #overview-wrap.dark .overview-table td {
-        color: var(--ov-text);
+    #app-wrap.dark #overview-wrap .overview-table th,
+    #app-wrap.dark #overview-wrap .overview-table td {
         font-family: monospace;
     }
-    #overview-wrap.dark .camelot-badge {
+    #app-wrap.dark #overview-wrap .camelot-badge {
         font-family: monospace;
     }
     .overview-stats {
@@ -326,7 +314,7 @@
                 cell.className = 'overview-pad-cell';
                 const s = bySlot[i];
                 if (s) {
-                    const isDark = document.getElementById('overview-wrap').classList.contains('dark');
+                    const isDark = document.getElementById('app-wrap').classList.contains('dark');
                     const isActive = s.slot == activeSlot;
                     if (s.color_css) cell.style.borderColor = s.color_css;
                     const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
@@ -401,20 +389,7 @@
         } catch (e) {}
     }
 
-    function toggleTheme() {
-        const wrap = document.getElementById('overview-wrap');
-        const btn = document.getElementById('theme-toggle');
-        const isDark = wrap.classList.toggle('dark');
-        btn.textContent = isDark ? '☀️ Light' : '🌙 Dark';
-        localStorage.setItem('overview-theme', isDark ? 'dark' : 'light');
-    }
-
-    (function() {
-        if (localStorage.getItem('overview-theme') === 'dark') {
-            document.getElementById('overview-wrap').classList.add('dark');
-            document.getElementById('theme-toggle').textContent = '☀️ Light';
-        }
-    })();
+    // Overview page now uses global dark mode from base.html
 
     loadData();
     pollSystemStats();

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Move Over (view)</h2>
-
+<div id="overview-wrap">
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+    <h2 style="margin-bottom:0;">Move Over (view)</h2>
+    <button id="theme-toggle" onclick="toggleTheme()" style="font-size:0.8rem;padding:0.3rem 0.8rem;margin:0;">🌙 Dark</button>
+</div>
 <div class="overview-stats">
     <div class="overview-stat-box">
         <div class="overview-stat-label">STORAGE: <span id="disk-text">—</span></div>
@@ -23,7 +26,7 @@
 
     <div style="margin:1rem 0;">
         <label style="display:inline;font-weight:400;margin-right:0.5rem;">Filter by Camelot key:</label>
-        <button class="overview-filter-btn active" onclick="filterByCamelot(null, this)">All</button>
+        <button class="overview-filter-btn active" onclick="filterByCamelot(null, this)">All Keys</button>
         <span id="camelot-filter-btns"></span>
     </div>
 
@@ -45,26 +48,76 @@
         Sets refresh every 30s &nbsp;·&nbsp; Active pad updates every 2s
     </div>
 </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
 <style>
+    #overview-wrap {
+        --ov-bg:         #ffffff;
+        --ov-bg2:        #f5f5f5;
+        --ov-border:     #dddddd;
+        --ov-text:       #262626;
+        --ov-text-dim:   #888888;
+        --ov-text-mid:   #555555;
+        --ov-pad-empty:  #f0f0f0;
+        --ov-bar-track:  #e0e0e0;
+    }
+    #overview-wrap.dark {
+        --ov-bg:         #0a0a0a;
+        --ov-bg2:        #111111;
+        --ov-border:     #2a2a2a;
+        --ov-text:       #e0e0e0;
+        --ov-text-dim:   #555555;
+        --ov-text-mid:   #888888;
+        --ov-pad-empty:  #151515;
+        --ov-bar-track:  #1e1e1e;
+        --ov-accent:     #4dd9d9;
+        font-family: monospace;
+        background: #0a0a0a;
+        padding: 1rem;
+        border-radius: 4px;
+        margin: -2rem;
+    }
+    #overview-wrap.dark h2 {
+        color: #4dd9d9;
+        font-family: monospace;
+    }
+    #overview-wrap.dark .overview-filter-btn.active {
+        background: rgba(77,217,217,0.15);
+        border-color: #4dd9d9;
+        color: #4dd9d9;
+    }
+    #overview-wrap.dark .overview-filter-btn {
+        border-color: #333;
+        color: #aaa;
+        font-family: monospace;
+    }
+    #overview-wrap.dark .overview-table th,
+    #overview-wrap.dark .overview-table td {
+        color: var(--ov-text);
+        font-family: monospace;
+    }
+    #overview-wrap.dark .camelot-badge {
+        font-family: monospace;
+    }
     .overview-stats {
+        color: var(--ov-text);
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 0.75rem;
         margin-bottom: 1.5rem;
     }
     .overview-stat-box {
-        background: #f5f5f5;
-        border: 1px solid #ddd;
+        background: var(--ov-bg2);
+        border: 1px solid var(--ov-border);
         border-radius: 4px;
         padding: 0.75rem 1rem;
         font-size: 0.875rem;
     }
     .overview-stat-label { margin-bottom: 0.4rem; }
     .overview-bar-track {
-        background: #e0e0e0;
+        background: var(--ov-bar-track);
         border-radius: 2px;
         height: 12px;
         overflow: hidden;
@@ -80,46 +133,50 @@
     .overview-pad-grid {
         display: grid;
         grid-template-columns: repeat(8, 1fr);
-        gap: 0.4rem;
+        gap: 0.35rem;
         margin-bottom: 1.5rem;
-        max-width: 640px;
+        max-width: 1100px;
     }
     .overview-pad-cell {
+        background: var(--ov-pad-empty);
+        color: var(--ov-text);
         border-radius: 4px;
-        padding: 0.4rem 0.25rem;
+        padding: 0.35rem 0.25rem;
         text-align: center;
-        font-size: 0.7rem;
+        font-size: 0.8rem;
         font-weight: 500;
         aspect-ratio: 4/3;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        background: #f0f0f0;
         border: 2px solid transparent;
         box-sizing: border-box;
         overflow: hidden;
     }
     .overview-pad-cell.active {
-        border-color: #ff764d;
-        box-shadow: 0 0 0 2px rgba(255,118,77,0.3);
+        border-color: #ff764d !important;
+        box-shadow: 0 0 0 3px rgba(255,118,77,0.5);
         animation: overview-pulse 2s ease-in-out infinite;
     }
     .overview-pad-cell .pad-num {
-        font-size: 0.6rem;
-        color: #888;
+        color: var(--ov-text-dim);
+        font-size: 0.7rem;
         line-height: 1;
     }
     .overview-pad-cell .pad-name {
-        font-size: 0.65rem;
-        word-break: break-word;
+        font-size: 0.75rem;
         line-height: 1.2;
-        max-height: 2.4em;
+        width: 100%;
         overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 4;
+        -webkit-box-orient: vertical;
+        line-clamp: 4;
     }
     .overview-pad-cell .pad-bpm {
-        font-size: 0.6rem;
-        color: #555;
+        color: var(--ov-text-mid);
+        font-size: 0.7rem;
     }
     @keyframes overview-pulse {
         0%, 100% { box-shadow: 0 0 0 2px rgba(255,118,77,0.3); }
@@ -150,27 +207,31 @@
         font-size: 0.875rem;
     }
     .overview-table th {
+        color: var(--ov-text-dim);
+        border-bottom-color: var(--ov-border);
         text-align: left;
         padding: 0.4rem 0.6rem;
-        border-bottom: 2px solid #ddd;
+        border-bottom: 2px solid var(--ov-border);
         font-weight: 500;
-        color: #444;
     }
     .overview-table td {
+        border-bottom-color: var(--ov-border);
         padding: 0.35rem 0.6rem;
-        border-bottom: 1px solid #eee;
+        border-bottom: 1px solid var(--ov-border);
     }
     .overview-table tr.active-row td {
-        background: #fff5f0;
+        background: var(--ov-bg2);
         font-weight: 500;
     }
     .camelot-badge {
+        background: var(--ov-bg2);
+        border-color: var(--ov-border);
+        color: var(--ov-text);
         display: inline-block;
         padding: 0.1rem 0.4rem;
         border-radius: 3px;
         font-size: 0.75rem;
-        background: #f0f0f0;
-        border: 1px solid #ccc;
+        border: 1px solid var(--ov-border);
     }
     .color-dot {
         display: inline-block;
@@ -257,23 +318,35 @@
         grid.innerHTML = '';
         const bySlot = {};
         sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
-        for (let i = 0; i < 32; i++) {
-            const cell = document.createElement('div');
-            cell.className = 'overview-pad-cell';
-            const s = bySlot[i];
-            if (s) {
-                if (s.color_css) cell.style.background = s.color_css + '33';
-                if (s.color_css) cell.style.borderColor = s.color_css;
-                if (s.slot == activeSlot) cell.classList.add('active');
-                cell.innerHTML = `
-                    <div class="pad-num">${i + 1}</div>
-                    <div class="pad-name">${s.name}</div>
-                    ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
-                `;
-            } else {
-                cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+        // Build rows bottom-to-top to match physical Move hardware layout
+        for (let row = 3; row >= 0; row--) {
+            for (let col = 0; col < 8; col++) {
+                const i = row * 8 + col;
+                const cell = document.createElement('div');
+                cell.className = 'overview-pad-cell';
+                const s = bySlot[i];
+                if (s) {
+                    const isDark = document.getElementById('overview-wrap').classList.contains('dark');
+                    const isActive = s.slot == activeSlot;
+                    if (s.color_css) cell.style.borderColor = s.color_css;
+                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
+                    if (isActive) {
+                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
+                    } else if (s.color_css) {
+                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
+                    }
+                    if (isActive) cell.classList.add('active');
+                    cell.title = s.name;
+                    cell.innerHTML = `
+                        <div class="pad-num">${i + 1}</div>
+                        <div class="pad-name">${s.name}</div>
+                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
+                    `;
+                } else {
+                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+                }
+                grid.appendChild(cell);
             }
-            grid.appendChild(cell);
         }
     }
 
@@ -327,6 +400,21 @@
             }
         } catch (e) {}
     }
+
+    function toggleTheme() {
+        const wrap = document.getElementById('overview-wrap');
+        const btn = document.getElementById('theme-toggle');
+        const isDark = wrap.classList.toggle('dark');
+        btn.textContent = isDark ? '☀️ Light' : '🌙 Dark';
+        localStorage.setItem('overview-theme', isDark ? 'dark' : 'light');
+    }
+
+    (function() {
+        if (localStorage.getItem('overview-theme') === 'dark') {
+            document.getElementById('overview-wrap').classList.add('dark');
+            document.getElementById('theme-toggle').textContent = '☀️ Light';
+        }
+    })();
 
     loadData();
     pollSystemStats();

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -415,16 +415,43 @@
         sorted.forEach(s => {
             const tr = document.createElement('tr');
             if (s.slot == activeSlot) tr.className = 'active-row';
-            const dot = s.color_css ? `<span class="color-dot" style="background:${s.color_css}"></span>` : '';
-            const playing = s.slot == activeSlot ? '<span class="now-playing-badge">NOW PLAYING</span>' : '';
-            tr.innerHTML = `
-                <td>${s.slot != null ? s.slot + 1 : '—'}</td>
-                <td>${dot}${s.name}${playing}</td>
-                <td>${s.bpm ?? '—'}</td>
-                <td>${s.key ?? '—'}</td>
-                <td>${s.mode ?? '—'}</td>
-                <td>${s.camelot ? `<span class="camelot-badge">${s.camelot}</span>` : '—'}</td>
-            `;
+
+            const padCell = document.createElement('td');
+            padCell.textContent = s.slot != null ? s.slot + 1 : '—';
+            tr.appendChild(padCell);
+
+            const nameCell = document.createElement('td');
+            if (s.color_css) {
+                const dot = document.createElement('span');
+                dot.className = 'color-dot';
+                dot.style.background = s.color_css;
+                nameCell.appendChild(dot);
+            }
+            nameCell.append(document.createTextNode(s.name ?? '—'));
+            if (s.slot == activeSlot) {
+                const playing = document.createElement('span');
+                playing.className = 'now-playing-badge';
+                playing.textContent = 'NOW PLAYING';
+                nameCell.appendChild(playing);
+            }
+            tr.appendChild(nameCell);
+
+            [s.bpm, s.key, s.mode].forEach(value => {
+                const cell = document.createElement('td');
+                cell.textContent = value ?? '—';
+                tr.appendChild(cell);
+            });
+
+            const camelotCell = document.createElement('td');
+            if (s.camelot) {
+                const badge = document.createElement('span');
+                badge.className = 'camelot-badge';
+                badge.textContent = s.camelot;
+                camelotCell.appendChild(badge);
+            } else {
+                camelotCell.textContent = '—';
+            }
+            tr.appendChild(camelotCell);
             tbody.appendChild(tr);
         });
     }

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -19,6 +19,41 @@
 <div id="overview-error" style="color:#d73a49;margin:1rem 0;"></div>
 
 <div id="overview-content" style="display:none;">
+    <!-- Restore Mode Toggle -->
+    <div style="margin-bottom:1rem;">
+        <button id="restore-mode-btn" class="overview-filter-btn" onclick="toggleRestoreMode()">+ Restore Set</button>
+    </div>
+
+    <!-- Restore Form (shown when in restore mode) -->
+    <div id="restore-form-container" style="display:none;margin-bottom:1.5rem;padding:1rem;background:var(--ov-bg2);border:1px solid var(--ov-border);border-radius:4px;">
+        <div id="restore-message" style="margin-bottom:1rem;"></div>
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-end;">
+            <div>
+                <label for="ablbundle" style="font-size:0.8rem;">Set file (.ablbundle/.abl):</label>
+                <input type="file" id="ablbundle" name="ablbundle" accept=".ablbundle,.abl" style="margin-bottom:0;">
+            </div>
+            <div>
+                <label style="font-size:0.8rem;">Pad Color:</label>
+                <div class="color-dropdown" id="color-dropdown">
+                    <div class="dropdown-toggle" onclick="toggleColorDropdown()">
+                        <span class="color-preview" id="selected-color-preview"></span>
+                        <span id="selected-color-name">Select...</span>
+                        <span class="dropdown-arrow">▼</span>
+                    </div>
+                    <div class="dropdown-menu" id="color-dropdown-menu" style="display:none;"></div>
+                </div>
+                <input type="hidden" id="pad_color" name="pad_color" value="">
+            </div>
+            <div id="target-pad-display" style="font-size:0.9rem;color:var(--ov-text-mid);">
+                Click a <strong>free pad</strong> below
+            </div>
+            <input type="hidden" id="target_pad" name="target_pad" value="">
+            <button id="restore-btn" onclick="submitRestore()" disabled style="margin:0;">Upload & Restore</button>
+            <button type="button" onclick="toggleRestoreMode()" style="margin:0;background:transparent;color:var(--ov-text);">Cancel</button>
+        </div>
+    </div>
+
+    <!-- Main Pad Grid (shared between view and restore modes) -->
     <div class="overview-pad-grid" id="pad-grid"></div>
 
     <div style="margin:1rem 0;">
@@ -240,6 +275,99 @@
         margin-left: 0.4rem;
         vertical-align: middle;
     }
+    /* Color dropdown for restore */
+    .color-dropdown {
+        position: relative;
+        display: inline-block;
+        min-width: 200px;
+    }
+    .dropdown-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem;
+        border: 1px solid var(--ov-border);
+        border-radius: 4px;
+        cursor: pointer;
+        background: var(--ov-bg);
+    }
+    .dropdown-toggle:hover {
+        border-color: #999;
+    }
+    .color-preview {
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        border-radius: 3px;
+        border: 1px solid rgba(0,0,0,0.2);
+    }
+    .dropdown-arrow {
+        margin-left: auto;
+        font-size: 0.7rem;
+    }
+    .dropdown-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: var(--ov-bg);
+        border: 1px solid var(--ov-border);
+        border-radius: 4px;
+        margin-top: 2px;
+        max-height: 300px;
+        overflow-y: auto;
+        z-index: 100;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .dropdown-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem;
+        cursor: pointer;
+    }
+    .dropdown-item:hover {
+        background: var(--ov-bg2);
+    }
+    /* Restore mode - main grid free pads are selectable */
+    #pad-grid.restore-mode .overview-pad-cell.free {
+        cursor: pointer;
+        border: 2px dashed #ccc;
+    }
+    #pad-grid.restore-mode .overview-pad-cell.free:hover {
+        border-color: #0000ff;
+        border-style: solid;
+    }
+    #pad-grid.restore-mode .overview-pad-cell.free.selected {
+        border-color: #0000ff !important;
+        border-style: solid !important;
+        background: rgba(0,0,255,0.15) !important;
+    }
+    #pad-grid.restore-mode .overview-pad-cell.occupied {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free {
+        border-color: #444;
+    }
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free:hover,
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+        border-color: #4dd9d9 !important;
+    }
+    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+        background: rgba(77,217,217,0.2) !important;
+    }
+    /* Restore form button styling */
+    #restore-mode-btn.active {
+        background: #0000ff;
+        border-color: #0000ff;
+        color: white;
+    }
+    #app-wrap.dark #restore-mode-btn.active {
+        background: #4dd9d9;
+        border-color: #4dd9d9;
+        color: #000;
+    }
 </style>
 
 <script>
@@ -301,6 +429,10 @@
         renderTable(sets, activeSlot);
     }
 
+    // Restore mode state
+    let restoreMode = false;
+    let selectedTargetPad = null;
+
     function renderPadGrid(sets, activeSlot) {
         const grid = document.getElementById('pad-grid');
         grid.innerHTML = '';
@@ -311,9 +443,10 @@
             for (let col = 0; col < 8; col++) {
                 const i = row * 8 + col;
                 const cell = document.createElement('div');
-                cell.className = 'overview-pad-cell';
                 const s = bySlot[i];
                 if (s) {
+                    // Occupied pad
+                    cell.className = 'overview-pad-cell occupied';
                     const isDark = document.getElementById('app-wrap').classList.contains('dark');
                     const isActive = s.slot == activeSlot;
                     if (s.color_css) cell.style.borderColor = s.color_css;
@@ -331,6 +464,13 @@
                         ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
                     `;
                 } else {
+                    // Free pad
+                    cell.className = 'overview-pad-cell free';
+                    cell.dataset.padNum = i + 1;
+                    // Add click handler for restore mode
+                    if (restoreMode) {
+                        cell.onclick = () => selectTargetPad(i + 1, cell);
+                    }
                     cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
                 }
                 grid.appendChild(cell);
@@ -391,10 +531,220 @@
 
     // Overview page now uses global dark mode from base.html
 
+    // ==================== RESTORE FUNCTIONALITY ====================
+    let padColors = [];
+    let padColorNames = [];
+
+    async function loadPadColors() {
+        try {
+            const res = await fetch('/overview/api/colors');
+            const data = await res.json();
+            padColors = data.colors;
+            padColorNames = data.names;
+            buildColorDropdown();
+            // Select first color by default
+            if (padColors.length > 0) {
+                selectColor(0);
+            }
+        } catch (e) {
+            console.error('Failed to load pad colors:', e);
+        }
+    }
+
+    function buildColorDropdown() {
+        const menu = document.getElementById('color-dropdown-menu');
+        menu.innerHTML = '';
+        padColors.forEach((color, idx) => {
+            const item = document.createElement('div');
+            item.className = 'dropdown-item';
+            item.onclick = () => selectColor(idx);
+            item.innerHTML = `
+                <span class="color-preview" style="background:rgb(${color[0]},${color[1]},${color[2]})"></span>
+                <span>${padColorNames[idx]}</span>
+            `;
+            menu.appendChild(item);
+        });
+    }
+
+    function toggleColorDropdown() {
+        const menu = document.getElementById('color-dropdown-menu');
+        menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+    }
+
+    function selectColor(idx) {
+        const color = padColors[idx];
+        document.getElementById('selected-color-preview').style.background = `rgb(${color[0]},${color[1]},${color[2]})`;
+        document.getElementById('selected-color-name').textContent = padColorNames[idx];
+        document.getElementById('pad_color').value = idx + 1; // 1-indexed color ID
+        document.getElementById('color-dropdown-menu').style.display = 'none';
+        updateRestoreButton();
+    }
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function(e) {
+        const dropdown = document.getElementById('color-dropdown');
+        if (!dropdown.contains(e.target)) {
+            document.getElementById('color-dropdown-menu').style.display = 'none';
+        }
+    });
+
+    function renderRestoreGrid(sets) {
+        restoreAllSets = sets;
+        const grid = document.getElementById('restore-pad-grid');
+        grid.innerHTML = '';
+        const bySlot = {};
+        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
+
+        // Build rows bottom-to-top to match physical Move hardware layout
+        for (let row = 3; row >= 0; row--) {
+            for (let col = 0; col < 8; col++) {
+                const i = row * 8 + col;
+                const cell = document.createElement('div');
+                const s = bySlot[i];
+                const isDark = document.getElementById('app-wrap').classList.contains('dark');
+
+                if (s) {
+                    // Occupied pad
+                    cell.className = 'overview-pad-cell occupied';
+                    const isActive = s.slot == activeSlot;
+                    if (s.color_css) cell.style.borderColor = s.color_css;
+                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
+                    if (isActive) {
+                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
+                    } else if (s.color_css) {
+                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
+                    }
+                    if (isActive) cell.classList.add('active');
+                    cell.title = s.name;
+                    cell.innerHTML = `
+                        <div class="pad-num">${i + 1}</div>
+                        <div class="pad-name">${s.name}</div>
+                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
+                    `;
+                } else {
+                    // Free pad - selectable in restore mode
+                    cell.className = 'overview-pad-cell free';
+                    cell.dataset.padNum = i + 1;
+                    // Add click handler only in restore mode
+                    if (restoreMode) {
+                        cell.onclick = () => selectTargetPad(i + 1, cell);
+                    }
+                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+                }
+                grid.appendChild(cell);
+            }
+        }
+    }
+
+    function toggleRestoreMode() {
+        restoreMode = !restoreMode;
+        const btn = document.getElementById('restore-mode-btn');
+        const form = document.getElementById('restore-form-container');
+        const grid = document.getElementById('pad-grid');
+
+        if (restoreMode) {
+            btn.textContent = '✕ Cancel Restore';
+            btn.classList.add('active');
+            form.style.display = 'block';
+            grid.classList.add('restore-mode');
+        } else {
+            btn.textContent = '+ Restore Set';
+            btn.classList.remove('active');
+            form.style.display = 'none';
+            grid.classList.remove('restore-mode');
+            // Clear selection
+            selectedTargetPad = null;
+            document.getElementById('target_pad').value = '';
+            document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
+            document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+                c.classList.remove('selected');
+            });
+        }
+        // Re-render grid to add/remove click handlers
+        const filtered = activeCamelot ? allSets.filter(s => s.camelot === activeCamelot) : allSets;
+        render(filtered, currentSlot);
+    }
+
+    function selectTargetPad(padNum, cellElement) {
+        // Deselect previous
+        document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+            c.classList.remove('selected');
+        });
+
+        // Select new
+        selectedTargetPad = padNum;
+        cellElement.classList.add('selected');
+        document.getElementById('target_pad').value = padNum;
+        document.getElementById('target-pad-display').textContent = `Pad ${padNum}`;
+        updateRestoreButton();
+    }
+
+    function updateRestoreButton() {
+        const hasFile = document.getElementById('ablbundle').files.length > 0;
+        const hasColor = document.getElementById('pad_color').value !== '';
+        const hasPad = selectedTargetPad !== null;
+        document.getElementById('restore-btn').disabled = !(hasFile && hasColor && hasPad);
+    }
+
+    async function submitRestore() {
+        const btn = document.getElementById('restore-btn');
+        const msg = document.getElementById('restore-message');
+        btn.disabled = true;
+        btn.textContent = 'Restoring...';
+
+        const formData = new FormData();
+        formData.append('ablbundle', document.getElementById('ablbundle').files[0]);
+        formData.append('pad_color', document.getElementById('pad_color').value);
+        formData.append('target_pad', document.getElementById('target_pad').value);
+
+        try {
+            const res = await fetch('/overview/api/restore', {
+                method: 'POST',
+                body: formData
+            });
+            const result = await res.json();
+
+            if (result.success) {
+                msg.innerHTML = `<p class="success">${result.message}</p>`;
+                // Reset form
+                document.getElementById('ablbundle').value = '';
+                selectedTargetPad = null;
+                document.getElementById('target_pad').value = '';
+                document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
+                document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+                    c.classList.remove('selected');
+                });
+                selectColor(0); // Reset to first color
+                // Exit restore mode after short delay
+                setTimeout(() => {
+                    toggleRestoreMode();
+                    msg.innerHTML = '';
+                }, 2000);
+                // Reload data to show new set
+                await loadData();
+            } else {
+                msg.innerHTML = `<p class="error">${result.message}</p>`;
+            }
+        } catch (e) {
+            msg.innerHTML = `<p class="error">Error: ${e.message}</p>`;
+        } finally {
+            btn.disabled = false;
+            btn.textContent = 'Upload & Restore';
+        }
+    }
+
+    // Event listeners
+    document.getElementById('ablbundle').addEventListener('change', updateRestoreButton);
+
+    // Initialize
+    loadPadColors();
+
+    // ==================== END RESTORE FUNCTIONALITY ====================
+
     loadData();
     pollSystemStats();
     setInterval(loadData, 30000);
-    setInterval(pollActiveSlot, 2000);
-    setInterval(pollSystemStats, 5000);
+    setInterval(pollActiveSlot, 2002);
+    setInterval(pollSystemStats, 5005);
 </script>
 {% endblock %}

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -1,0 +1,337 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Move Over (view)</h2>
+
+<div class="overview-stats">
+    <div class="overview-stat-box">
+        <div class="overview-stat-label">STORAGE: <span id="disk-text">—</span></div>
+        <div class="overview-bar-track"><div class="overview-bar-fill" id="disk-fill" style="width:0%"></div></div>
+    </div>
+    <div class="overview-stat-box">
+        <div class="overview-stat-label">MEMORY: <span id="mem-text">—</span></div>
+        <div class="overview-bar-track"><div class="overview-bar-fill overview-bar-mem" id="mem-fill" style="width:0%"></div></div>
+        <div class="overview-stat-label" style="margin-top:6px;">LOAD: <span id="load-text">—</span></div>
+    </div>
+</div>
+
+<div id="overview-loading" style="color:#888;margin:1rem 0;">Loading sets…</div>
+<div id="overview-error" style="color:#d73a49;margin:1rem 0;"></div>
+
+<div id="overview-content" style="display:none;">
+    <div class="overview-pad-grid" id="pad-grid"></div>
+
+    <div style="margin:1rem 0;">
+        <label style="display:inline;font-weight:400;margin-right:0.5rem;">Filter by Camelot key:</label>
+        <button class="overview-filter-btn active" onclick="filterByCamelot(null, this)">All</button>
+        <span id="camelot-filter-btns"></span>
+    </div>
+
+    <table class="overview-table" id="sets-table">
+        <thead>
+            <tr>
+                <th>Pad</th>
+                <th>Name</th>
+                <th>BPM</th>
+                <th>Key</th>
+                <th>Mode</th>
+                <th>Camelot</th>
+            </tr>
+        </thead>
+        <tbody id="sets-tbody"></tbody>
+    </table>
+
+    <div style="color:#888;font-size:0.75rem;margin-top:0.75rem;">
+        Sets refresh every 30s &nbsp;·&nbsp; Active pad updates every 2s
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<style>
+    .overview-stats {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+    }
+    .overview-stat-box {
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+    }
+    .overview-stat-label { margin-bottom: 0.4rem; }
+    .overview-bar-track {
+        background: #e0e0e0;
+        border-radius: 2px;
+        height: 12px;
+        overflow: hidden;
+    }
+    .overview-bar-fill {
+        height: 100%;
+        background: #0000ff;
+        border-radius: 2px;
+        transition: width 0.4s;
+    }
+    .overview-bar-mem { background: #8b5cf6; }
+
+    .overview-pad-grid {
+        display: grid;
+        grid-template-columns: repeat(8, 1fr);
+        gap: 0.4rem;
+        margin-bottom: 1.5rem;
+        max-width: 640px;
+    }
+    .overview-pad-cell {
+        border-radius: 4px;
+        padding: 0.4rem 0.25rem;
+        text-align: center;
+        font-size: 0.7rem;
+        font-weight: 500;
+        aspect-ratio: 4/3;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: #f0f0f0;
+        border: 2px solid transparent;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+    .overview-pad-cell.active {
+        border-color: #ff764d;
+        box-shadow: 0 0 0 2px rgba(255,118,77,0.3);
+        animation: overview-pulse 2s ease-in-out infinite;
+    }
+    .overview-pad-cell .pad-num {
+        font-size: 0.6rem;
+        color: #888;
+        line-height: 1;
+    }
+    .overview-pad-cell .pad-name {
+        font-size: 0.65rem;
+        word-break: break-word;
+        line-height: 1.2;
+        max-height: 2.4em;
+        overflow: hidden;
+    }
+    .overview-pad-cell .pad-bpm {
+        font-size: 0.6rem;
+        color: #555;
+    }
+    @keyframes overview-pulse {
+        0%, 100% { box-shadow: 0 0 0 2px rgba(255,118,77,0.3); }
+        50%       { box-shadow: 0 0 0 5px rgba(255,118,77,0.5); }
+    }
+
+    .overview-filter-btn {
+        background: transparent;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        padding: 0.2rem 0.6rem;
+        font-size: 0.8rem;
+        color: #444;
+        cursor: pointer;
+        margin-right: 0.25rem;
+        margin-bottom: 0.25rem;
+        font-family: 'Ableton Sans', Arial, sans-serif;
+    }
+    .overview-filter-btn.active {
+        background: #0000ff;
+        border-color: #0000ff;
+        color: white;
+    }
+
+    .overview-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.875rem;
+    }
+    .overview-table th {
+        text-align: left;
+        padding: 0.4rem 0.6rem;
+        border-bottom: 2px solid #ddd;
+        font-weight: 500;
+        color: #444;
+    }
+    .overview-table td {
+        padding: 0.35rem 0.6rem;
+        border-bottom: 1px solid #eee;
+    }
+    .overview-table tr.active-row td {
+        background: #fff5f0;
+        font-weight: 500;
+    }
+    .camelot-badge {
+        display: inline-block;
+        padding: 0.1rem 0.4rem;
+        border-radius: 3px;
+        font-size: 0.75rem;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+    }
+    .color-dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        margin-right: 0.3rem;
+        vertical-align: middle;
+        border: 1px solid rgba(0,0,0,0.15);
+    }
+    .now-playing-badge {
+        display: inline-block;
+        background: #ff764d;
+        color: white;
+        font-size: 0.65rem;
+        padding: 0.1rem 0.35rem;
+        border-radius: 2px;
+        margin-left: 0.4rem;
+        vertical-align: middle;
+    }
+</style>
+
+<script>
+    let allSets = [];
+    let currentSlot = null;
+    let activeCamelot = null;
+
+    async function loadData() {
+        try {
+            const res = await fetch('/overview/api/data');
+            const d = await res.json();
+            if (d.error) {
+                document.getElementById('overview-error').textContent = 'Error: ' + d.error;
+                return;
+            }
+            allSets = d.sets || [];
+            currentSlot = d.current_slot;
+            document.getElementById('overview-loading').style.display = 'none';
+            document.getElementById('overview-content').style.display = '';
+
+            if (d.disk) {
+                document.getElementById('disk-text').textContent =
+                    `${d.disk.used_gb} GB / ${d.disk.total_gb} GB — ${d.disk.percent_used}%`;
+                const df = document.getElementById('disk-fill');
+                df.style.width = d.disk.percent_used + '%';
+                df.style.background = d.disk.percent_used > 80 ? '#d73a49' : '#0000ff';
+            }
+
+            buildCamelotFilters(allSets);
+            render(allSets, currentSlot);
+        } catch (e) {
+            document.getElementById('overview-error').textContent = 'Failed to load data.';
+        }
+    }
+
+    function buildCamelotFilters(sets) {
+        const codes = [...new Set(sets.map(s => s.camelot).filter(Boolean))].sort();
+        const container = document.getElementById('camelot-filter-btns');
+        container.innerHTML = '';
+        codes.forEach(code => {
+            const btn = document.createElement('button');
+            btn.className = 'overview-filter-btn';
+            btn.textContent = code;
+            btn.onclick = () => filterByCamelot(code, btn);
+            container.appendChild(btn);
+        });
+    }
+
+    function filterByCamelot(code, btn) {
+        activeCamelot = code;
+        document.querySelectorAll('.overview-filter-btn').forEach(b => b.classList.remove('active'));
+        if (btn) btn.classList.add('active');
+        const filtered = code ? allSets.filter(s => s.camelot === code) : allSets;
+        render(filtered, currentSlot);
+    }
+
+    function render(sets, activeSlot) {
+        renderPadGrid(sets, activeSlot);
+        renderTable(sets, activeSlot);
+    }
+
+    function renderPadGrid(sets, activeSlot) {
+        const grid = document.getElementById('pad-grid');
+        grid.innerHTML = '';
+        const bySlot = {};
+        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
+        for (let i = 0; i < 32; i++) {
+            const cell = document.createElement('div');
+            cell.className = 'overview-pad-cell';
+            const s = bySlot[i];
+            if (s) {
+                if (s.color_css) cell.style.background = s.color_css + '33';
+                if (s.color_css) cell.style.borderColor = s.color_css;
+                if (s.slot == activeSlot) cell.classList.add('active');
+                cell.innerHTML = `
+                    <div class="pad-num">${i + 1}</div>
+                    <div class="pad-name">${s.name}</div>
+                    ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
+                `;
+            } else {
+                cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
+            }
+            grid.appendChild(cell);
+        }
+    }
+
+    function renderTable(sets, activeSlot) {
+        const tbody = document.getElementById('sets-tbody');
+        tbody.innerHTML = '';
+        const sorted = [...sets].sort((a, b) => (a.slot ?? 999) - (b.slot ?? 999));
+        sorted.forEach(s => {
+            const tr = document.createElement('tr');
+            if (s.slot == activeSlot) tr.className = 'active-row';
+            const dot = s.color_css ? `<span class="color-dot" style="background:${s.color_css}"></span>` : '';
+            const playing = s.slot == activeSlot ? '<span class="now-playing-badge">NOW PLAYING</span>' : '';
+            tr.innerHTML = `
+                <td>${s.slot != null ? s.slot + 1 : '—'}</td>
+                <td>${dot}${s.name}${playing}</td>
+                <td>${s.bpm ?? '—'}</td>
+                <td>${s.key ?? '—'}</td>
+                <td>${s.mode ?? '—'}</td>
+                <td>${s.camelot ? `<span class="camelot-badge">${s.camelot}</span>` : '—'}</td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    async function pollActiveSlot() {
+        try {
+            const res = await fetch('/overview/api/active-slot');
+            const d = await res.json();
+            if (d.current_slot != null && d.current_slot !== currentSlot) {
+                currentSlot = d.current_slot;
+                const filtered = activeCamelot ? allSets.filter(s => s.camelot === activeCamelot) : allSets;
+                render(filtered, currentSlot);
+            }
+        } catch (e) {}
+    }
+
+    async function pollSystemStats() {
+        try {
+            const res = await fetch('/overview/api/system');
+            const d = await res.json();
+            if (d.mem_pct != null) {
+                document.getElementById('mem-text').textContent =
+                    `${d.mem_used_mb} MB / ${d.mem_total_mb} MB — ${d.mem_pct}%`;
+                const mf = document.getElementById('mem-fill');
+                mf.style.width = d.mem_pct + '%';
+                mf.style.background = d.mem_pct > 80 ? '#d73a49' : '#8b5cf6';
+            }
+            if (d.load_1 != null) {
+                document.getElementById('load-text').textContent =
+                    `${d.load_1.toFixed(2)} / ${d.load_5.toFixed(2)} / ${d.load_15.toFixed(2)} (1m/5m/15m)`;
+            }
+        } catch (e) {}
+    }
+
+    loadData();
+    pollSystemStats();
+    setInterval(loadData, 30000);
+    setInterval(pollActiveSlot, 2000);
+    setInterval(pollSystemStats, 5000);
+</script>
+{% endblock %}

--- a/templates_jinja/overview.html
+++ b/templates_jinja/overview.html
@@ -54,7 +54,7 @@
     </div>
 
     <!-- Main Pad Grid (shared between view and restore modes) -->
-    <div class="overview-pad-grid" id="pad-grid"></div>
+    <div id="pad-grid">{{ pad_grid|safe }}</div>
 
     <div style="margin:1rem 0;">
         <label style="display:inline;font-weight:400;margin-right:0.5rem;">Filter by Camelot key:</label>
@@ -152,59 +152,6 @@
         transition: width 0.4s;
     }
     .overview-bar-mem { background: #8b5cf6; }
-
-    .overview-pad-grid {
-        display: grid;
-        grid-template-columns: repeat(8, 1fr);
-        gap: 0.35rem;
-        margin-bottom: 1.5rem;
-        max-width: 1100px;
-    }
-    .overview-pad-cell {
-        background: var(--ov-pad-empty);
-        color: var(--ov-text);
-        border-radius: 4px;
-        padding: 0.35rem 0.25rem;
-        text-align: center;
-        font-size: 0.8rem;
-        font-weight: 500;
-        aspect-ratio: 4/3;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        border: 2px solid transparent;
-        box-sizing: border-box;
-        overflow: hidden;
-    }
-    .overview-pad-cell.active {
-        border-color: #ff764d !important;
-        box-shadow: 0 0 0 3px rgba(255,118,77,0.5);
-        animation: overview-pulse 2s ease-in-out infinite;
-    }
-    .overview-pad-cell .pad-num {
-        color: var(--ov-text-dim);
-        font-size: 0.7rem;
-        line-height: 1;
-    }
-    .overview-pad-cell .pad-name {
-        font-size: 0.75rem;
-        line-height: 1.2;
-        width: 100%;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 4;
-        -webkit-box-orient: vertical;
-        line-clamp: 4;
-    }
-    .overview-pad-cell .pad-bpm {
-        color: var(--ov-text-mid);
-        font-size: 0.7rem;
-    }
-    @keyframes overview-pulse {
-        0%, 100% { box-shadow: 0 0 0 2px rgba(255,118,77,0.3); }
-        50%       { box-shadow: 0 0 0 5px rgba(255,118,77,0.5); }
-    }
 
     .overview-filter-btn {
         background: transparent;
@@ -330,31 +277,31 @@
         background: var(--ov-bg2);
     }
     /* Restore mode - main grid free pads are selectable */
-    #pad-grid.restore-mode .overview-pad-cell.free {
+    #pad-grid.restore-mode .pad-cell.free {
         cursor: pointer;
         border: 2px dashed #ccc;
     }
-    #pad-grid.restore-mode .overview-pad-cell.free:hover {
+    #pad-grid.restore-mode .pad-cell.free:hover {
         border-color: #0000ff;
         border-style: solid;
     }
-    #pad-grid.restore-mode .overview-pad-cell.free.selected {
+    #pad-grid.restore-mode .pad-cell.free.selected {
         border-color: #0000ff !important;
         border-style: solid !important;
         background: rgba(0,0,255,0.15) !important;
     }
-    #pad-grid.restore-mode .overview-pad-cell.occupied {
+    #pad-grid.restore-mode .pad-cell.occupied {
         opacity: 0.4;
         cursor: not-allowed;
     }
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free {
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free {
         border-color: #444;
     }
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free:hover,
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free:hover,
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free.selected {
         border-color: #4dd9d9 !important;
     }
-    #app-wrap.dark #pad-grid.restore-mode .overview-pad-cell.free.selected {
+    #app-wrap.dark #pad-grid.restore-mode .pad-cell.free.selected {
         background: rgba(77,217,217,0.2) !important;
     }
     /* Restore form button styling */
@@ -425,7 +372,7 @@
     }
 
     function render(sets, activeSlot) {
-        renderPadGrid(sets, activeSlot);
+        refreshPadGrid();
         renderTable(sets, activeSlot);
     }
 
@@ -433,47 +380,30 @@
     let restoreMode = false;
     let selectedTargetPad = null;
 
-    function renderPadGrid(sets, activeSlot) {
+    async function refreshPadGrid() {
+        const params = new URLSearchParams();
+        if (restoreMode) {
+            params.set('restore_mode', '1');
+        } else if (activeCamelot) {
+            params.set('camelot', activeCamelot);
+        }
+        const res = await fetch(`/overview/api/grid?${params}`);
+        const data = await res.json();
         const grid = document.getElementById('pad-grid');
-        grid.innerHTML = '';
-        const bySlot = {};
-        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
-        // Build rows bottom-to-top to match physical Move hardware layout
-        for (let row = 3; row >= 0; row--) {
-            for (let col = 0; col < 8; col++) {
-                const i = row * 8 + col;
-                const cell = document.createElement('div');
-                const s = bySlot[i];
-                if (s) {
-                    // Occupied pad
-                    cell.className = 'overview-pad-cell occupied';
-                    const isDark = document.getElementById('app-wrap').classList.contains('dark');
-                    const isActive = s.slot == activeSlot;
-                    if (s.color_css) cell.style.borderColor = s.color_css;
-                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
-                    if (isActive) {
-                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
-                    } else if (s.color_css) {
-                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
-                    }
-                    if (isActive) cell.classList.add('active');
-                    cell.title = s.name;
-                    cell.innerHTML = `
-                        <div class="pad-num">${i + 1}</div>
-                        <div class="pad-name">${s.name}</div>
-                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
-                    `;
-                } else {
-                    // Free pad
-                    cell.className = 'overview-pad-cell free';
-                    cell.dataset.padNum = i + 1;
-                    // Add click handler for restore mode
-                    if (restoreMode) {
-                        cell.onclick = () => selectTargetPad(i + 1, cell);
-                    }
-                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
-                }
-                grid.appendChild(cell);
+        grid.innerHTML = data.pad_grid;
+        grid.classList.toggle('restore-mode', restoreMode);
+
+        if (!restoreMode) return;
+
+        grid.querySelectorAll('input[name="overview_pad"]:not(:disabled)').forEach(input => {
+            input.addEventListener('change', () => selectTargetPad(Number(input.value)));
+        });
+
+        if (selectedTargetPad !== null) {
+            const input = document.getElementById(`pad_${selectedTargetPad}`);
+            if (input) {
+                input.checked = true;
+                input.nextElementSibling.classList.add('selected');
             }
         }
     }
@@ -588,92 +518,36 @@
         }
     });
 
-    function renderRestoreGrid(sets) {
-        restoreAllSets = sets;
-        const grid = document.getElementById('restore-pad-grid');
-        grid.innerHTML = '';
-        const bySlot = {};
-        sets.forEach(s => { if (s.slot != null) bySlot[s.slot] = s; });
-
-        // Build rows bottom-to-top to match physical Move hardware layout
-        for (let row = 3; row >= 0; row--) {
-            for (let col = 0; col < 8; col++) {
-                const i = row * 8 + col;
-                const cell = document.createElement('div');
-                const s = bySlot[i];
-                const isDark = document.getElementById('app-wrap').classList.contains('dark');
-
-                if (s) {
-                    // Occupied pad
-                    cell.className = 'overview-pad-cell occupied';
-                    const isActive = s.slot == activeSlot;
-                    if (s.color_css) cell.style.borderColor = s.color_css;
-                    const toRgba = (css, alpha) => css ? css.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`) : null;
-                    if (isActive) {
-                        cell.style.background = toRgba(s.color_css, 0.4) || (isDark ? 'rgba(255,180,0,0.4)' : 'rgba(255,180,0,0.4)');
-                    } else if (s.color_css) {
-                        cell.style.background = toRgba(s.color_css, isDark ? 0.08 : 0.2);
-                    }
-                    if (isActive) cell.classList.add('active');
-                    cell.title = s.name;
-                    cell.innerHTML = `
-                        <div class="pad-num">${i + 1}</div>
-                        <div class="pad-name">${s.name}</div>
-                        ${s.bpm ? `<div class="pad-bpm">${s.bpm} BPM</div>` : ''}
-                    `;
-                } else {
-                    // Free pad - selectable in restore mode
-                    cell.className = 'overview-pad-cell free';
-                    cell.dataset.padNum = i + 1;
-                    // Add click handler only in restore mode
-                    if (restoreMode) {
-                        cell.onclick = () => selectTargetPad(i + 1, cell);
-                    }
-                    cell.innerHTML = `<div class="pad-num">${i + 1}</div>`;
-                }
-                grid.appendChild(cell);
-            }
-        }
-    }
-
-    function toggleRestoreMode() {
+    async function toggleRestoreMode() {
         restoreMode = !restoreMode;
         const btn = document.getElementById('restore-mode-btn');
         const form = document.getElementById('restore-form-container');
-        const grid = document.getElementById('pad-grid');
 
         if (restoreMode) {
             btn.textContent = '✕ Cancel Restore';
             btn.classList.add('active');
             form.style.display = 'block';
-            grid.classList.add('restore-mode');
         } else {
             btn.textContent = '+ Restore Set';
             btn.classList.remove('active');
             form.style.display = 'none';
-            grid.classList.remove('restore-mode');
-            // Clear selection
             selectedTargetPad = null;
             document.getElementById('target_pad').value = '';
             document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
-            document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
-                c.classList.remove('selected');
-            });
         }
-        // Re-render grid to add/remove click handlers
-        const filtered = activeCamelot ? allSets.filter(s => s.camelot === activeCamelot) : allSets;
-        render(filtered, currentSlot);
+
+        await refreshPadGrid();
     }
 
-    function selectTargetPad(padNum, cellElement) {
-        // Deselect previous
-        document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
-            c.classList.remove('selected');
+    function selectTargetPad(padNum) {
+        document.querySelectorAll('#pad-grid .pad-cell.free').forEach(cell => {
+            cell.classList.remove('selected');
         });
 
-        // Select new
         selectedTargetPad = padNum;
-        cellElement.classList.add('selected');
+        const input = document.getElementById(`pad_${padNum}`);
+        input.checked = true;
+        input.nextElementSibling.classList.add('selected');
         document.getElementById('target_pad').value = padNum;
         document.getElementById('target-pad-display').textContent = `Pad ${padNum}`;
         updateRestoreButton();
@@ -711,7 +585,7 @@
                 selectedTargetPad = null;
                 document.getElementById('target_pad').value = '';
                 document.getElementById('target-pad-display').innerHTML = 'Click a <strong>free pad</strong> below';
-                document.querySelectorAll('#pad-grid .overview-pad-cell.free').forEach(c => {
+                document.querySelectorAll('#pad-grid .pad-cell.free').forEach(c => {
                     c.classList.remove('selected');
                 });
                 selectColor(0); // Reset to first color

--- a/tests/test_base_handler.py
+++ b/tests/test_base_handler.py
@@ -58,6 +58,30 @@ def test_format_responses():
     assert info["message_type"] == "info"
 
 
+def test_save_uploaded_file_unique_temp_names(tmp_path):
+    """Two files with the same basename get different temp paths."""
+    handler = BaseHandler()
+    handler.upload_dir = str(tmp_path)
+
+    f1 = DummyField("clip.mid", b"data1")
+    f2 = DummyField("clip.mid", b"data2")
+
+    ok1, path1, err1 = handler.save_uploaded_file(f1)
+    ok2, path2, err2 = handler.save_uploaded_file(f2)
+
+    assert ok1 and ok2
+    assert err1 is None and err2 is None
+    assert path1 != path2
+    assert path1.endswith(".mid")
+    assert path2.endswith(".mid")
+    with open(path1, "rb") as f:
+        assert f.read() == b"data1"
+    with open(path2, "rb") as f:
+        assert f.read() == b"data2"
+    handler.cleanup_upload(path1)
+    handler.cleanup_upload(path2)
+
+
 def test_format_json_response():
     handler = BaseHandler()
     result = handler.format_json_response({"a": 1}, status=201)

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -101,26 +101,16 @@ def test_lfo_get(client, monkeypatch):
     assert b'id="amount"' in resp.data
     assert b'id="attack"' in resp.data
 
-def test_restore_get(client, monkeypatch):
-    def fake_get():
-        return {'options': '<option value="1">1</option>', 'pad_grid': '<div class="pad-grid"></div>', 'message': ''}
-    monkeypatch.setattr(move_webserver.restore_handler, 'handle_get', fake_get)
+def test_restore_get(client):
     resp = client.get('/restore')
-    assert resp.status_code == 200
-    assert b'class="pad-grid"' in resp.data
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/overview')
 
-def test_restore_post(client, monkeypatch):
-    def fake_handle_post(form):
-        return {'message': 'restored', 'message_type': 'success', 'pad_grid': '<div class="pad-grid"></div>', 'options': ''}
-    monkeypatch.setattr(move_webserver.restore_handler, 'handle_post', fake_handle_post)
-    data = {
-        'action': 'restore_ablbundle',
-        'mset_index': '1',
-        'mset_color': '1'
-    }
-    resp = client.post('/restore', data=data, content_type='multipart/form-data')
-    assert resp.status_code == 200
-    assert b'restored' in resp.data
+
+def test_restore_post(client):
+    resp = client.post('/restore')
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/overview')
 
 
 def test_overview_restore_post(client, monkeypatch):
@@ -486,7 +476,7 @@ def test_refresh_get(client, monkeypatch):
 def test_index_redirect(client):
     resp = client.get('/')
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/restore')
+    assert resp.headers['Location'].endswith('/overview')
 
 
 def test_browse_dir(client, tmp_path):

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -447,6 +447,30 @@ def test_midi_upload_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'ok' in resp.data
 
+
+def test_midi_upload_drum_post(client, monkeypatch):
+    def fake_post(form):
+        assert form.getvalue('midi_type') == 'drum'
+        return {
+            'message': 'drum set created',
+            'message_type': 'success',
+            'pad_options': '<option value="2">2</option>',
+            'pad_color_options': '<option value="1">1</option>',
+            'pad_grid': '<div class="pad-grid"></div>'
+        }
+    monkeypatch.setattr(move_webserver.set_management_handler, 'handle_post', fake_post)
+    f = (io.BytesIO(b'data'), 'drum.mid')
+    data = {
+        'action': 'upload_midi',
+        'midi_type': 'drum',
+        'set_name': 'DrumSet',
+        'pad_color': '1',
+        'midi_file': f
+    }
+    resp = client.post('/midi-upload', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    assert b'drum set created' in resp.data
+
 def test_place_files_post(client, monkeypatch):
     def fake_place(form):
         return {'message': 'placed', 'message_type': 'success'}

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -122,6 +122,34 @@ def test_restore_post(client, monkeypatch):
     assert resp.status_code == 200
     assert b'restored' in resp.data
 
+
+def test_overview_restore_post(client, monkeypatch):
+    def fake_handle_post_restore(form):
+        assert form.getvalue('target_pad') == '8'
+        assert form.getvalue('pad_color') == '4'
+        assert form['ablbundle'].filename == 'test.ablbundle'
+        assert form['ablbundle'].file.read() == b'bundle-data'
+        return {'success': True, 'message': 'restored'}
+
+    monkeypatch.setattr(
+        move_webserver.overview_handler,
+        'handle_post_restore',
+        fake_handle_post_restore,
+    )
+    resp = client.post(
+        '/overview/api/restore',
+        data={
+            'target_pad': '8',
+            'pad_color': '4',
+            'ablbundle': (io.BytesIO(b'bundle-data'), 'test.ablbundle'),
+        },
+        content_type='multipart/form-data',
+    )
+
+    assert resp.status_code == 200
+    assert resp.json == {'success': True, 'message': 'restored'}
+
+
 def test_slice_post(client, monkeypatch):
     def fake_handle_post(form):
         return {'message': 'sliced', 'message_type': 'success'}

--- a/tests/test_list_msets_handler.py
+++ b/tests/test_list_msets_handler.py
@@ -1,9 +1,37 @@
+import os
 import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from core import list_msets_handler as lmh
+
+
+def test_parse_bpm_cache_invalidates_when_song_changes(tmp_path, monkeypatch):
+    song_path = tmp_path / "SetA" / "Song.abl"
+    song_path.parent.mkdir()
+    song_path.write_text('{"tempo": 120}')
+    lmh._BPM_CACHE.clear()
+    calls = 0
+    original_load = lmh.json.load
+
+    def tracking_load(file):
+        nonlocal calls
+        calls += 1
+        return original_load(file)
+
+    monkeypatch.setattr(lmh.json, "load", tracking_load)
+
+    assert lmh._parse_bpm_from_song(str(song_path.parent)) == 120.0
+    assert lmh._parse_bpm_from_song(str(song_path.parent)) == 120.0
+    assert calls == 1
+
+    song_path.write_text('{"tempo": 140}')
+    stat = song_path.stat()
+    os.utime(song_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1))
+
+    assert lmh._parse_bpm_from_song(str(song_path.parent)) == 140.0
+    assert calls == 2
 
 
 def test_list_msets_no_directory(tmp_path, monkeypatch):

--- a/tests/test_overview_handler.py
+++ b/tests/test_overview_handler.py
@@ -35,6 +35,32 @@ def test_generate_pad_grid_html_uses_shared_grid(monkeypatch):
     assert '120.0 BPM' in html
 
 
+def test_generate_pad_grid_html_escapes_set_names(monkeypatch):
+    malicious_name = '<img src=x onerror="alert(1)">'
+    monkeypatch.setattr(
+        overview_module,
+        "get_sets_data",
+        lambda: {
+            "sets": [
+                {
+                    "slot": 5,
+                    "xattr_color": 1,
+                    "color_id": 1,
+                    "name": malicious_name,
+                    "bpm": 120.0,
+                    "camelot": "8B",
+                }
+            ],
+            "current_slot": None,
+        },
+    )
+
+    html = OverviewHandler().generate_pad_grid_html()
+
+    assert malicious_name not in html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
+
+
 def test_generate_pad_grid_html_restore_mode_selects_only_free_pads(monkeypatch):
     monkeypatch.setattr(
         overview_module,

--- a/tests/test_overview_handler.py
+++ b/tests/test_overview_handler.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers.overview_handler_class import OverviewHandler
+import handlers.overview_handler_class as overview_module
+
+
+def test_generate_pad_grid_html_uses_shared_grid(monkeypatch):
+    monkeypatch.setattr(
+        overview_module,
+        "get_sets_data",
+        lambda: {
+            "sets": [
+                {
+                    "slot": 5,
+                    "xattr_color": 3,
+                    "color_id": 4,
+                    "name": "Test Set",
+                    "bpm": 120.0,
+                    "camelot": "8B",
+                }
+            ],
+            "current_slot": 5,
+        },
+    )
+
+    html = OverviewHandler().generate_pad_grid_html()
+
+    assert 'class="pad-grid view-only"' in html
+    assert 'id="pad_6" name="overview_pad" value="6"' in html
+    assert 'class="pad-cell occupied active"' in html
+    assert 'Test Set' in html
+    assert '120.0 BPM' in html
+
+
+def test_generate_pad_grid_html_restore_mode_selects_only_free_pads(monkeypatch):
+    monkeypatch.setattr(
+        overview_module,
+        "get_sets_data",
+        lambda: {
+            "sets": [
+                {
+                    "slot": 5,
+                    "xattr_color": 3,
+                    "color_id": 4,
+                    "name": "Test Set",
+                    "bpm": 120.0,
+                    "camelot": "8B",
+                }
+            ],
+            "current_slot": 5,
+        },
+    )
+
+    html = OverviewHandler().generate_pad_grid_html(restore_mode=True)
+
+    assert 'class="pad-grid"' in html
+    assert 'id="pad_6" name="overview_pad" value="6" disabled' in html
+    assert 'id="pad_7" name="overview_pad" value="7" ' in html

--- a/tests/test_pad_colors.py
+++ b/tests/test_pad_colors.py
@@ -3,9 +3,16 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from core.pad_colors import rgb_string
+from core.pad_colors import move_color_to_ui, rgb_string
 
 
 def test_rgb_string_valid_and_invalid():
     assert rgb_string(1) == "rgb(255, 25, 23)"
     assert rgb_string(999) == ""
+
+
+def test_move_zero_color_aliases_the_first_palette_color():
+    assert move_color_to_ui(0) == 1
+    assert move_color_to_ui(1) == 1
+    assert move_color_to_ui(24) == 24
+    assert move_color_to_ui(None) is None

--- a/tests/test_restore_handler_utils.py
+++ b/tests/test_restore_handler_utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from handlers.restore_handler_class import RestoreHandler
+from handlers.overview_handler_class import OverviewHandler
+import handlers.overview_handler_class as overview_module
 
 
 def test_generate_pad_options_empty():
@@ -21,10 +23,10 @@ def test_generate_pad_options_some():
 
 def test_generate_pad_grid():
     h = RestoreHandler()
-    html = h.generate_pad_grid({0, 31}, {0: 1})
+    html = h.generate_pad_grid({0, 31}, {0: 1}, input_name="mset_index", free_only=True)
     assert html.count('class="pad-cell occupied"') == 2
-    assert 'restore_pad_1" name="mset_index" value="1" disabled' in html
-    assert 'background-color: rgb(' in html
+    assert 'id="pad_1" name="mset_index" value="1" disabled' in html
+    assert 'background-color: rgba(' in html
 
 def test_generate_color_options_custom():
     h = RestoreHandler()
@@ -33,3 +35,33 @@ def test_generate_color_options_custom():
     assert 'name="clr"' in html
     assert 'padName = "pad"' in html
     assert 'color-dropdown' in html
+
+
+def test_overview_restore_message_uses_ui_pad_number(monkeypatch, tmp_path):
+    class Form(dict):
+        def getvalue(self, name, default=None):
+            return self.get(name, default)
+
+    upload_path = tmp_path / "test.abl"
+    upload_path.write_text("{}")
+    handler = OverviewHandler()
+    monkeypatch.setattr(
+        handler,
+        "handle_file_upload",
+        lambda form, field_name: (True, str(upload_path), None),
+    )
+    monkeypatch.setattr(
+        overview_module,
+        "restore_abl",
+        lambda filepath, pad, color: {
+            "success": True,
+            "message": f"Successfully restored test to pad {pad}",
+        },
+    )
+
+    result = handler.handle_post_restore(
+        Form({"target_pad": "6", "pad_color": "1"})
+    )
+
+    assert result["success"]
+    assert result["message"] == "Successfully restored test to pad 6"

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -195,3 +195,20 @@ def test_set_read_only_round_trip(tmp_path):
     for p in (song, sample_file, sample_dir, root, root.parent):
         assert os.stat(p).st_mode & 0o222 != 0
     assert not sih.is_read_only(str(song))
+
+
+def test_get_clip_data_null_clip(tmp_path):
+    """get_clip_data should return a clear error for empty clip slots."""
+    song = tmp_path / "Song.abl"
+    track = {
+        "name": "Track1",
+        "devices": [],
+        "clipSlots": [
+            {"clip": None},
+            {"clip": None},
+        ],
+    }
+    song.write_text(json.dumps({"tracks": [track]}))
+    result = sih.get_clip_data(str(song), 0, 0)
+    assert not result["success"]
+    assert "empty" in result["message"].lower()

--- a/tests/test_set_inspector_handler.py
+++ b/tests/test_set_inspector_handler.py
@@ -39,7 +39,7 @@ def test_generate_pad_grid():
     assert html.count('class="pad-cell occupied"') == 2
     assert html.count('name="pad_index"') == 32
     # Selected pad should have "checked" attribute
-    assert 'inspect_pad_32" name="pad_index" value="32" checked' in html
+    assert 'id="pad_32" name="pad_index" value="32" checked' in html
 
 
 def test_generate_clip_grid():

--- a/tests/test_set_management_handler.py
+++ b/tests/test_set_management_handler.py
@@ -88,7 +88,11 @@ def test_generate_drum_set_from_file(monkeypatch, tmp_path):
 
 MINIMAL_TEMPLATE = {
     "tracks": [
-        {"clipSlots": [{"clip": None}, {"clip": None}]},
+        {"clipSlots": [{"clip": {
+            "isPlaying": True, "name": "", "color": 1, "isEnabled": True,
+            "region": {"start": 0.0, "end": 4.0, "loop": {"start": 0.0, "end": 4.0, "isEnabled": True}},
+            "grooveId": 1, "notes": [], "stepEditorScrollPosition": 0.0, "envelopes": []
+        }}, {"clip": None}]},
         {"clipSlots": [{"clip": None}, {"clip": None}]},
         {"clipSlots": [{"clip": None}, {"clip": None}]},
         {"clipSlots": [{"clip": None}, {"clip": None}]},

--- a/tests/test_set_management_handler.py
+++ b/tests/test_set_management_handler.py
@@ -322,3 +322,53 @@ def test_partial_failure_reports_error(monkeypatch, tmp_path):
     assert "a.mid" in result["message"]
     assert "b.mid" in result["message"]
 
+
+def test_new_set_restore_calls_refresh_library(monkeypatch, tmp_path):
+    """After successful new set restore, refresh_library() should be called."""
+    handler = SetManagementHandler()
+
+    monkeypatch.setattr(
+        "handlers.set_management_handler_class.list_msets",
+        lambda return_free_ids=False: ([], {"used": set(), "free": list(range(32))})
+    )
+
+    monkeypatch.setattr(handler, "save_uploaded_file", lambda f: (True, str(tmp_path / f.filename), None))
+    monkeypatch.setattr(handler, "cleanup_upload", lambda p: None)
+
+    # Mock assign_midi_to_track to succeed
+    monkeypatch.setattr(
+        "handlers.set_management_handler_class.assign_midi_to_track",
+        lambda *a, **kw: {"success": True, "message": "ok", "path": str(tmp_path / "out.abl")}
+    )
+
+    # Create the .abl file so bundling can copy it
+    (tmp_path / "out.abl").write_text("{}")
+
+    # Mock restore_ablbundle to succeed
+    monkeypatch.setattr(
+        "handlers.set_management_handler_class.restore_ablbundle",
+        lambda *a, **kw: {"success": True, "message": "Restored"}
+    )
+
+    # Track refresh_library calls
+    refresh_called = [False]
+    def track_refresh():
+        refresh_called[0] = True
+    monkeypatch.setattr("handlers.set_management_handler_class.refresh_library", track_refresh)
+
+    (tmp_path / "test.mid").write_bytes(b"data")
+
+    form = _FakeForm()
+    form["action"] = "upload_midi"
+    form["midi_type"] = "melodic"
+    form["set_mode"] = "new"
+    form["set_name"] = "TestSet"
+    form["pad_index"] = "1"
+    form["pad_color"] = "1"
+    form["track_0"] = "1"
+    form["midi_files"] = [_FakeFileItem("test.mid")]
+
+    result = handler.handle_post(form)
+    assert result["message_type"] == "success"
+    assert refresh_called[0], "refresh_library() was not called after new set restore"
+

--- a/tests/test_set_management_handler.py
+++ b/tests/test_set_management_handler.py
@@ -84,3 +84,130 @@ def test_generate_drum_set_from_file(monkeypatch, tmp_path):
     assert len(data["tracks"][0]["clipSlots"][0]["clip"]["notes"]) == 1
     assert data["tracks"][0]["clipSlots"][0]["clip"]["notes"][0]["noteNumber"] == 36
 
+
+MINIMAL_TEMPLATE = {
+    "tracks": [
+        {"clipSlots": [{"clip": None}, {"clip": None}]},
+        {"clipSlots": [{"clip": None}, {"clip": None}]},
+        {"clipSlots": [{"clip": None}, {"clip": None}]},
+        {"clipSlots": [{"clip": None}, {"clip": None}]},
+    ],
+    "tempo": 120.0
+}
+
+
+def _make_midi(path, ticks_per_beat=480, note=60, duration_ticks=480):
+    mid = mido.MidiFile(ticks_per_beat=ticks_per_beat)
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.Message("note_on", note=note, velocity=80, time=0))
+    track.append(mido.Message("note_off", note=note, velocity=0, time=duration_ticks))
+    mid.save(path)
+
+
+def test_assign_midi_to_track_new_set(monkeypatch, tmp_path):
+    """New set created with correct clip structure."""
+    patch_output(monkeypatch, tmp_path)
+    import copy
+    monkeypatch.setattr(sm, "load_set_template", lambda p: copy.deepcopy(MINIMAL_TEMPLATE))
+
+    midi_path = tmp_path / "a.mid"
+    _make_midi(midi_path)
+
+    result = sm.assign_midi_to_track("MySet", str(midi_path), target_track=1, clip_color=3)
+    assert result["success"], result["message"]
+
+    out = tmp_path / "MySet.abl"
+    with open(out) as f:
+        data = json.load(f)
+
+    clip = data["tracks"][0]["clipSlots"][0]["clip"]
+    assert clip is not None
+    assert clip["isPlaying"] is True
+    assert "color" in clip
+    assert clip["color"] == 3
+    assert len(clip["notes"]) == 1
+    assert clip["notes"][0]["noteNumber"] == 60
+
+
+def test_assign_midi_to_track_clip_length_exact_bar(monkeypatch, tmp_path):
+    """clip_length must not overshoot when max_end_time is exactly on a bar boundary."""
+    patch_output(monkeypatch, tmp_path)
+    import copy
+    monkeypatch.setattr(sm, "load_set_template", lambda p: copy.deepcopy(MINIMAL_TEMPLATE))
+
+    # 480 ticks/beat * 4 beats = 1 bar exactly (4.0 beats)
+    midi_path = tmp_path / "exact.mid"
+    _make_midi(midi_path, ticks_per_beat=480, duration_ticks=480 * 4)
+
+    result = sm.assign_midi_to_track("ExactBarSet", str(midi_path), target_track=1, clip_color=1)
+    assert result["success"], result["message"]
+
+    out = tmp_path / "ExactBarSet.abl"
+    with open(out) as f:
+        data = json.load(f)
+
+    clip = data["tracks"][0]["clipSlots"][0]["clip"]
+    region_end = clip["region"]["end"]
+    assert region_end == 4.0, f"Expected 4.0 beats, got {region_end}"
+    assert clip["region"]["loop"]["end"] == region_end
+
+
+def test_assign_midi_to_track_existing_set(monkeypatch, tmp_path):
+    """Adding MIDI to an existing set updates the correct track slot."""
+    patch_output(monkeypatch, tmp_path)
+    import copy
+
+    existing_set_path = tmp_path / "existing.abl"
+    existing_data = copy.deepcopy(MINIMAL_TEMPLATE)
+    with open(existing_set_path, "w") as f:
+        json.dump(existing_data, f)
+
+    midi_path = tmp_path / "b.mid"
+    _make_midi(midi_path, note=48)
+
+    result = sm.assign_midi_to_track(
+        "existing", str(midi_path), target_track=2,
+        existing_set_path=str(existing_set_path), clip_color=5
+    )
+    assert result["success"], result["message"]
+
+    with open(existing_set_path) as f:
+        data = json.load(f)
+
+    clip = data["tracks"][1]["clipSlots"][0]["clip"]
+    assert clip is not None
+    assert clip["notes"][0]["noteNumber"] == 48
+    assert clip["color"] == 5
+    assert data["tempo"] == 120.0
+
+
+def test_assign_midi_to_track_default_color(monkeypatch, tmp_path):
+    """clip color defaults to 1 when clip_color is None."""
+    patch_output(monkeypatch, tmp_path)
+    import copy
+    monkeypatch.setattr(sm, "load_set_template", lambda p: copy.deepcopy(MINIMAL_TEMPLATE))
+
+    midi_path = tmp_path / "c.mid"
+    _make_midi(midi_path)
+
+    result = sm.assign_midi_to_track("DefaultColorSet", str(midi_path), target_track=1, clip_color=None)
+    assert result["success"], result["message"]
+
+    out = tmp_path / "DefaultColorSet.abl"
+    with open(out) as f:
+        data = json.load(f)
+
+    clip = data["tracks"][0]["clipSlots"][0]["clip"]
+    assert clip["color"] == 1
+
+
+def test_assign_midi_to_track_invalid_track(monkeypatch, tmp_path):
+    """Invalid track number returns failure."""
+    midi_path = tmp_path / "e.mid"
+    _make_midi(midi_path)
+
+    result = sm.assign_midi_to_track("BadTrack", str(midi_path), target_track=5)
+    assert not result["success"]
+    assert "Invalid track number" in result["message"]
+

--- a/tests/test_set_management_handler.py
+++ b/tests/test_set_management_handler.py
@@ -211,3 +211,36 @@ def test_assign_midi_to_track_invalid_track(monkeypatch, tmp_path):
     assert not result["success"]
     assert "Invalid track number" in result["message"]
 
+
+def test_sanitize_set_name_rejects_traversal():
+    """Path traversal attempts in set_name are rejected."""
+    assert sm.sanitize_set_name("../../../etc/passwd") is None
+    assert sm.sanitize_set_name("..") is None
+    assert sm.sanitize_set_name("foo/bar") is None
+    assert sm.sanitize_set_name("foo\\bar") is None
+    assert sm.sanitize_set_name("") is None
+    assert sm.sanitize_set_name(None) is None
+    # Valid names pass through
+    assert sm.sanitize_set_name("My Set") == "My Set"
+    assert sm.sanitize_set_name("Set-123") == "Set-123"
+
+
+def test_assign_midi_to_track_rejects_traversal(monkeypatch, tmp_path):
+    """Path traversal in set_name is rejected before any file operations."""
+    midi_path = tmp_path / "trav.mid"
+    _make_midi(midi_path)
+
+    result = sm.assign_midi_to_track("../../../etc/evil", str(midi_path), target_track=1)
+    assert not result["success"]
+    assert "Invalid set name" in result["message"]
+
+
+def test_generate_drum_set_from_file_rejects_traversal(monkeypatch, tmp_path):
+    """Path traversal in set_name is rejected for drum import."""
+    midi_path = tmp_path / "d.mid"
+    _make_midi(midi_path)
+
+    result = sm.generate_drum_set_from_file("../../evil", str(midi_path), tempo=120.0)
+    assert not result["success"]
+    assert "Invalid set name" in result["message"]
+

--- a/tests/test_set_management_handler.py
+++ b/tests/test_set_management_handler.py
@@ -6,6 +6,7 @@ import mido
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import core.set_management_handler as sm
+from handlers.set_management_handler_class import SetManagementHandler
 
 
 def patch_output(monkeypatch, tmp_path):
@@ -243,4 +244,81 @@ def test_generate_drum_set_from_file_rejects_traversal(monkeypatch, tmp_path):
     result = sm.generate_drum_set_from_file("../../evil", str(midi_path), tempo=120.0)
     assert not result["success"]
     assert "Invalid set name" in result["message"]
+
+
+class _FakeFileItem:
+    def __init__(self, filename, data=b"data"):
+        self.filename = filename
+        self.file = __import__("io").BytesIO(data)
+
+
+class _FakeForm(dict):
+    def getvalue(self, key, default=None):
+        return self.get(key, default)
+
+
+def test_existing_set_uuid_not_found_errors(monkeypatch):
+    """When UUID is not found for an existing set, handler returns a clear error."""
+    handler = SetManagementHandler()
+
+    # Mock list_msets to return sets that don't match the requested name
+    monkeypatch.setattr(
+        "handlers.set_management_handler_class.list_msets",
+        lambda return_free_ids=False: ([], {"used": set(), "free": list(range(32))})
+    )
+
+    form = _FakeForm()
+    form["action"] = "upload_midi"
+    form["midi_type"] = "melodic"
+    form["set_mode"] = "existing"
+    form["existing_set_name"] = "Nonexistent Set"
+    form["midi_files"] = _FakeFileItem("test.mid")
+
+    result = handler.handle_post(form)
+    assert result["message_type"] == "error"
+    assert "Could not find" in result["message"]
+
+
+def test_partial_failure_reports_error(monkeypatch, tmp_path):
+    """When some files in a batch fail, result is success:False with details."""
+    handler = SetManagementHandler()
+
+    monkeypatch.setattr(
+        "handlers.set_management_handler_class.list_msets",
+        lambda return_free_ids=False: ([], {"used": set(), "free": list(range(32))})
+    )
+
+    # Mock save_uploaded_file to return temp paths
+    monkeypatch.setattr(handler, "save_uploaded_file", lambda f: (True, str(tmp_path / f.filename), None))
+    monkeypatch.setattr(handler, "cleanup_upload", lambda p: None)
+
+    # Mock assign_midi_to_track: first call succeeds, second fails
+    call_count = [0]
+    def fake_assign(set_name, midi_path, target_track, existing_path, tempo, clip_color):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return {"success": True, "message": "ok", "path": str(tmp_path / "out.abl")}
+        return {"success": False, "message": "Track 2 has no empty clip slots"}
+
+    monkeypatch.setattr("handlers.set_management_handler_class.assign_midi_to_track", fake_assign)
+
+    # Create temp files so save_uploaded_file's returned paths exist
+    (tmp_path / "a.mid").write_bytes(b"data")
+    (tmp_path / "b.mid").write_bytes(b"data")
+
+    form = _FakeForm()
+    form["action"] = "upload_midi"
+    form["midi_type"] = "melodic"
+    form["set_mode"] = "new"
+    form["set_name"] = "TestSet"
+    form["pad_color"] = "1"
+    form["track_0"] = "1"
+    form["track_1"] = "2"
+    form["midi_files"] = [_FakeFileItem("a.mid"), _FakeFileItem("b.mid")]
+
+    result = handler.handle_post(form)
+    assert result["message_type"] == "error"
+    assert "Partial failure" in result["message"]
+    assert "a.mid" in result["message"]
+    assert "b.mid" in result["message"]
 

--- a/utility-scripts/restart-webserver.sh
+++ b/utility-scripts/restart-webserver.sh
@@ -55,7 +55,7 @@ if [ -f "$PID_FILE" ]; then
   fi
   rm -f "$PID_FILE"
 else
-  pkill -f 'python3 move-webserver.py' || true
+  pkill -f 'python3.*move-webserver.py' || true
 fi
 
 # Clean up any old log file


### PR DESCRIPTION
## Summary
Enhances the MIDI upload workflow to support multiple files with independent track assignments. Users can now build complete multi-track sets by uploading several MIDI files at once, assigning each to tracks 1-4.
 
## Features
- **Multi-file selection**: Upload one or more .mid/.midi files simultaneously
- **Per-file track assignment**: Each file gets its own Track 1-4 dropdown
- **Smart slot filling**: Multiple files targeting the same track fill empty clip slots sequentially
- **Create new or add to existing**: Support for both new set creation and adding clips to existing sets
- **Visual color selection**: Color swatch dropdowns for pad and clip colors
- **BPM preservation**: Maintains existing set tempo when adding clips
 
## Changes
- Replaces single-file upload with multi-file interface
- Removes "MIDI Type" dropdown (no longer needed)
- Dynamic track assignment UI appears after file selection
- New [save_uploaded_file()](cci:1://file:///Users/szydek/GitHub/extending-move/handlers/base_handler.py:166:4-201:109) helper for batch processing
- Path aggregation for multi-file new set creation
 
## Testing
- [x] Single file → new set
- [x] Multiple files → new set (different tracks)
- [x] Multiple files → existing set
- [x] Same track → fills empty clip slots
- [x] Clip colors inherit from pad color for new sets